### PR TITLE
Resolve threading issue for first time login view controller

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
@@ -204,18 +204,20 @@ typedef void (^BOXAuthCancelBlock)(BOXAuthorizationViewController *authorization
 	{
         __weak BOXAuthorizationViewController *me = self;
         [self.SDKClient.OAuth2Session performAuthorizationCodeGrantWithReceivedURL:request.URL withCompletionBlock:^(BOXOAuth2Session *session, NSError *error) {
-            if (error) {
-                if (self.completionBlock) {
-                    self.completionBlock(me, nil, error);
-                }
-            } else {
-                BOXUserRequest *userRequest = [self.SDKClient currentUserRequest];
-                [userRequest performRequestWithCompletion:^(BOXUser *user, NSError *error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (error) {
                     if (self.completionBlock) {
-                        self.completionBlock(me, user, error);
+                        self.completionBlock(me, nil, error);
                     }
-                }];
-            }
+                } else {
+                    BOXUserRequest *userRequest = [self.SDKClient currentUserRequest];
+                    [userRequest performRequestWithCompletion:^(BOXUser *user, NSError *error) {
+                        if (self.completionBlock) {
+                            self.completionBlock(me, user, error);
+                        }
+                    }];
+                }                
+            });
         }];
 	}
 	else if (self.connectionIsTrusted == NO)


### PR DESCRIPTION
Always dispatch_async completion block of the BOXAuthorizationViewController on the main thread.
Cancellation block is already on the main thread because it is called directly from the button press.
