### PR TITLE
Cleanup BOXAuthorizationViewController thread and memory management management

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
@@ -206,14 +206,14 @@ typedef void (^BOXAuthCancelBlock)(BOXAuthorizationViewController *authorization
         [self.SDKClient.OAuth2Session performAuthorizationCodeGrantWithReceivedURL:request.URL withCompletionBlock:^(BOXOAuth2Session *session, NSError *error) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error) {
-                    if (self.completionBlock) {
-                        self.completionBlock(me, nil, error);
+                    if (me.completionBlock) {
+                        me.completionBlock(me, nil, error);
                     }
                 } else {
-                    BOXUserRequest *userRequest = [self.SDKClient currentUserRequest];
+                    BOXUserRequest *userRequest = [me.SDKClient currentUserRequest];
                     [userRequest performRequestWithCompletion:^(BOXUser *user, NSError *error) {
-                        if (self.completionBlock) {
-                            self.completionBlock(me, user, error);
+                        if (me.completionBlock) {
+                            me.completionBlock(me, user, error);
                         }
                     }];
                 }                


### PR DESCRIPTION
- first change: dispatch_async completion block always on the main thread
- second change: use __weak reference to self inside a completion block, so that it can be cancelled in flight and avoid retain loop on BOXAuthorizationViewController till completion of the networking operation.
