### PR TITLE
Set user-agent in requests.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+#define BOX_CONTENT_SDK_IDENTIFIER @"box-content-sdk"
+#define BOX_CONTENT_SDK_VERSION @"1.0.0"
+
 // API URLs
 extern NSString *const BOXAPIBaseURL;
 extern NSString *const BOXAPIUploadBaseURL;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
@@ -64,6 +64,9 @@ typedef void (^BOXFileVersionBlock)(BOXFileVersion *fileVersion, NSError *error)
 
 @property (nonatomic, readonly, strong) NSURLRequest *urlRequest;
 
+@property (nonatomic, readwrite, strong) NSString *SDKIdentifier;
+@property (nonatomic, readwrite, strong) NSString *SDKVersion;
+
 - (void)performRequest;
 - (void)cancel;
 


### PR DESCRIPTION
- Also include a mechanism to allow our child SDKs (Share, Browse, etc.) to
  override the SDK identifier and version.
