### PR TITLE
Remove ability to continue to login with servers identity of which can't be verified.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
@@ -35,6 +35,8 @@ typedef enum {
     BOXContentSDKAPIErrorRequestEntityTooLarge = 413,
     BOXContentSDKAPIErrorPreconditionRequired = 428,
     BOXContentSDKAPIErrorTooManyRequests = 429, // rate limit exceeded
+    BOXContentSDKAPIErrorServerCertError = 495, // indicates error when app encounters server with unverified identity.
+
     // 5xx errors
     BOXContentSDKAPIErrorInternalServerError = 500,
     BOXContentSDKAPIErrorInsufficientStorage = 507,


### PR DESCRIPTION
Also introduced new error 495 in similar fashion to NGINX error:
495 Cert Error (Nginx)
Nginx internal code used when SSL client certificate error occurred to
distinguish it from 4XX in a log and an error page redirection.
