### PR TITLE
Remove reference to internal Podspecs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Quickstart
 ----------
 Step 1: Add to your Podfile
 ```
-source 'https://github.com/box/box-ios-podspecs.git'
 pod 'box-ios-content-sdk'
 ```
 Step 2: Install


### PR DESCRIPTION
We can merge this after successful submission to the global Cocoa Pods directory.

After merging this, remember to update the version tag.
