### PR TITLE
Add random nonce and matching it with state returned with auth code response

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -61,6 +61,7 @@ extern BOXAPIHTTPHeader *const BOXAPIHTTPHeaderBoxAPI;
 
 // OAuth2 constants
 // Authorization code response
+extern NSString *const BOXOAuth2URLParameterAuthorizationStateKey;
 extern NSString *const BOXOAuth2URLParameterAuthorizationCodeKey;
 extern NSString *const BOXOAuth2URLParameterErrorCodeKey;
 extern NSString *const BOXOAuth2URLParameterStateKey;

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
@@ -56,6 +56,7 @@ BOXAPIHTTPHeader *const BOXAPIHTTPHeaderBoxAPI = @"BoxApi";
 
 // OAuth2 constants
 // Authorization code response
+NSString *const BOXOAuth2URLParameterAuthorizationStateKey = @"state";
 NSString *const BOXOAuth2URLParameterAuthorizationCodeKey = @"code";
 NSString *const BOXOAuth2URLParameterErrorCodeKey = @"error";
 NSString *const BOXOAuth2URLParameterStateKey = @"state";

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
@@ -57,7 +57,8 @@ typedef enum {
 typedef enum {
     BOXContentSDKOAuth2ErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued = 20000, // access token is expired. The failed request was reenqueued
     BOXContentSDKOAuth2ErrorAccessTokenExpiredOperationCannotBeReenqueued = 20001, // access token is expired and the operation cannot be reenqueued because it cannot be copied
-    BOXContentSDKOAuth2ErrorAccessTokenExpiredOperationCouldNotBeCompleted = 20002 // Operation failed because access token is expired and could not be refreshed. Usually due to no internet connection
+    BOXContentSDKOAuth2ErrorAccessTokenExpiredOperationCouldNotBeCompleted = 20002, // Operation failed because access token is expired and could not be refreshed. Usually due to no internet connection
+    BOXContentSDKOAuth2ErrorAccessTokenNonceMismatch = 20003, // Operation failed because nonce returned by server didn't match the one used by app to authorize user.
 } BOXContentSDKOAuth2Error;
 
 typedef enum {

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -80,6 +80,11 @@ extern NSString *const BOXOAuth2UserIDKey;
  */
 @property (nonatomic, readwrite, weak) BOXAPIQueueManager *queueManager;
 
+/**
+ * The randomly generated nonce used to prevent spoofing attack during login
+ */
+@property (nonatomic, readwrite, strong) NSString *nonce;
+
 /** @name Service settings */
 
 /**


### PR DESCRIPTION
Nonce check prevents from CSRF attack which otherwise would
technically let malicious user login in non-malicious user
into malicious user's spoofed account.
