### PR TITLE
When querying keychain, do not assume that entries are strings before checking for Box keychain entries.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -412,7 +412,12 @@ static NSString *staticKeychainAccessGroup;
         NSArray* keychainEntries = (__bridge_transfer NSArray*)keychainQueryResult;
         for (NSDictionary *dict in keychainEntries)
         {
-            NSString *keychainIdentifier = [dict objectForKey:((__bridge NSString *)kSecAttrGeneric)];
+            NSObject *object = [dict objectForKey:((__bridge id)kSecAttrGeneric)];
+            if (![object isKindOfClass:[NSString class]]) {
+                continue;
+            }
+            
+            NSString *keychainIdentifier = (NSString *) object;
             if ([keychainIdentifier hasPrefix:[self keychainIdentifierPrefix]])
             {
                 NSString *userID = [self userIDFromKeychainIdentifier:keychainIdentifier];


### PR DESCRIPTION
- If there are other entries that are not strings, then we were crashing
  when calling 'hasPrefix'.
