### PR TITLE
It should be possible to set 'fields' query string params on file/folder/bookmark update requests.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.h
@@ -19,6 +19,8 @@
 
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
+@property (nonatomic, readwrite, assign) BOOL requestAllBookmarkFields;
+
 - (instancetype)initWithBookmarkID:(NSString *)bookmarkID;
 
 - (void)performRequestWithCompletion:(BOXBookmarkBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.m
@@ -47,6 +47,8 @@
                            subresource:nil
                                  subID:nil];
     
+    // Body
+    
     NSMutableDictionary *bodyDictionary = [[NSMutableDictionary alloc] init];
     
     if (self.URL != nil) {
@@ -97,9 +99,17 @@
         bodyDictionary[BOXAPIObjectKeyParent] = parentID;
     }
     
+    // Query Params
+    
+    NSDictionary *queryParameters = nil;
+    
+    if (self.requestAllBookmarkFields) {
+        queryParameters = @{BOXAPIParameterKeyFields : [self fullBookmarkFieldsParameterString]};
+    }
+    
     BOXAPIJSONOperation *JSONOperation = [self JSONOperationWithURL:URL
                                                          HTTPMethod:BOXAPIHTTPMethodPUT
-                                              queryStringParameters:nil
+                                              queryStringParameters:queryParameters
                                                      bodyDictionary:bodyDictionary
                                                    JSONSuccessBlock:nil
                                                        failureBlock:nil];

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.h
@@ -18,6 +18,8 @@
 
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
+@property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
+
 - (instancetype)initWithFileID:(NSString *)fileID;
 
 - (void)performRequestWithCompletion:(BOXFileBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.m
@@ -46,6 +46,8 @@
                            subresource:nil
                                  subID:nil];
 
+    // Body
+    
     NSMutableDictionary *bodyDictionary = [[NSMutableDictionary alloc] init];
 
     if (self.fileName.length > 0) {
@@ -90,9 +92,17 @@
         bodyDictionary[BOXAPIObjectKeyParent] = parentID;
     }
 
+    // Query Params
+    
+    NSDictionary *queryParameters = nil;
+    
+    if (self.requestAllFileFields) {
+        queryParameters = @{BOXAPIParameterKeyFields: [self fullFileFieldsParameterString]};
+    }
+    
     BOXAPIJSONOperation *JSONoperation = [self JSONOperationWithURL:URL
                                                          HTTPMethod:BOXAPIHTTPMethodPUT
-                                              queryStringParameters:nil
+                                              queryStringParameters:queryParameters
                                                      bodyDictionary:bodyDictionary
                                                    JSONSuccessBlock:nil
                                                        failureBlock:nil];

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.h
@@ -3,10 +3,9 @@
 //  BoxContentSDK
 //
 
-#import "BOXFolderRequest.h"
-#import "BOXSharedLink.h"
+#import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFolderUpdateRequest : BOXFolderRequest
+@interface BOXFolderUpdateRequest : BOXRequestWithSharedLinkHeader
 
 @property (nonatomic, readonly, strong) NSString *folderID;
 @property (nonatomic, readwrite, strong) NSString *folderName;
@@ -26,6 +25,9 @@
 
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
+@property (nonatomic, readwrite, assign) BOOL requestAllFolderFields;
+
 - (instancetype)initWithFolderID:(NSString *)folderID;
+- (void)performRequestWithCompletion:(BOXFolderBlock)completionBlock;
 
 @end

--- a/BoxContentSDK/BoxContentSDKTests/BOXFolderUpdateRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFolderUpdateRequestTests.m
@@ -10,6 +10,7 @@
 #import "BOXFolderUpdateRequest.h"
 #import "BOXRequest_Private.h"
 #import "BOXFolder.h"
+#import "NSURL+BOXURLHelper.h"
 
 @interface BOXFolderUpdateRequestTests : BOXRequestTestCase
 @end
@@ -62,6 +63,7 @@
     NSString *matchingEtag = @"5849054tsefs";
     
     BOXFolderUpdateRequest *request = [[BOXFolderUpdateRequest alloc] initWithFolderID:folderID];
+    request.requestAllFolderFields = YES;
     request.folderName = newName;
     request.folderDescription = newDescription;
     request.parentID = newParentFolderID;
@@ -78,9 +80,14 @@
     NSURLRequest *URLRequest = request.urlRequest;
     
     // URL assertions
-    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/folders/%@", BOXAPIBaseURL, BOXAPIVersion, folderID]];
-    XCTAssertEqualObjects(expectedURL, URLRequest.URL);
     XCTAssertEqualObjects(@"PUT", URLRequest.HTTPMethod);
+    
+    NSString *expectedURLWithoutQueryString = [NSString stringWithFormat:@"%@/%@/folders/%@", BOXAPIBaseURL, BOXAPIVersion, folderID];
+    NSString *actualURLWithoutQueryString = [NSString stringWithFormat:@"%@://%@%@", URLRequest.URL.scheme, URLRequest.URL.host, URLRequest.URL.path];
+    XCTAssertEqualObjects(expectedURLWithoutQueryString, actualURLWithoutQueryString);
+    
+    NSString *expectedFieldsString = [[[BOXRequest alloc] init] fullFolderFieldsParameterString];
+    XCTAssertEqualObjects(expectedFieldsString, [[[URLRequest.URL box_queryDictionary] objectForKey:@"fields"] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
     
     // HTTP body assertions
     NSDictionary *expectedBodyDictionary = @{@"name" : newName,


### PR DESCRIPTION
- Also removed inheritance of BOXFolderUpdateRequest to BOXFolderRequest to be consistent with files and bookmarks.
