### PR TITLE
Remove BOXFolder.items property.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Models/BOXFolder.h
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXFolder.h
@@ -39,11 +39,6 @@
 @property (nonatomic, readwrite, strong) NSString *folderUploadEmailAddress;
 
 /**
- *  Child items of the folder. If set, the array contains BOXFolderMini, BOXFileMini and BOXBookmarkMini objects.
- */
-@property (nonatomic, readwrite, strong) NSArray *items;
-
-/**
  *  Whether this folder will be synced by the Box sync clients or not.
  *  Can be synced, not_synced, or partially_synced.
  *  Warning: By default, the Box API does not return this value, and it will be nil.

--- a/BoxContentSDK/BoxContentSDK/Models/BOXFolder.m
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXFolder.m
@@ -52,27 +52,6 @@
             self.folderUploadEmailAddress = folderUploadEmailDictionary[BOXAPIObjectKeyEmail];
         }
 
-        // Parse ItemCollection
-        NSDictionary *itemCollectionJSON = [NSJSONSerialization box_ensureObjectForKey:BOXAPIObjectKeyItemCollection
-                                                                          inDictionary:JSONResponse
-                                                                       hasExpectedType:[NSDictionary class]
-                                                                           nullAllowed:NO];
-        NSArray *itemsJSONArray = itemCollectionJSON[BOXAPICollectionKeyEntries];
-        NSMutableArray *tempItems = [NSMutableArray array];
-        for (NSDictionary *itemDictionary in itemsJSONArray) {
-            NSString *itemType = [itemDictionary objectForKey:BOXAPIObjectKeyType];
-            if ([itemType isEqualToString:BOXAPIItemTypeFile]) {
-                [tempItems addObject:[[BOXFile alloc] initWithJSON:itemDictionary]];
-            } else if ([itemType isEqualToString:BOXAPIItemTypeFolder]) {
-                [tempItems addObject:[[BOXFolder alloc] initWithJSON:itemDictionary]];
-            } else if ([itemType isEqualToString:BOXAPIItemTypeWebLink]) {
-                [tempItems addObject:[[BOXBookmark alloc] initWithJSON:itemDictionary]];
-            } else {
-                [tempItems addObject:[[BOXItem alloc] initWithJSON:itemDictionary]];
-            }
-        }
-        self.items = [NSArray arrayWithArray:tempItems];
-
         // Parse SyncState.
         self.syncState = [NSJSONSerialization box_ensureObjectForKey:BOXAPIObjectKeySyncState
                                                         inDictionary:JSONResponse

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
@@ -48,12 +48,16 @@
                            subresource:subresource
                                  subID:nil];
 
-    NSDictionary *queryParameters = nil;
+    NSMutableDictionary *queryParameters = [NSMutableDictionary dictionary];
 
     if (self.requestAllFolderFields) {
-        queryParameters = @{BOXAPIParameterKeyFields: [self fullFolderFieldsParameterString]};
+        queryParameters[BOXAPIParameterKeyFields] = [self fullFolderFieldsParameterString];
     }
 
+    // We don't want to request the children through this request. We don't parse it, and it would be a waste
+    // of bandwidth/processing time.
+    queryParameters[@"limit"] = @"0";
+    
     BOXAPIJSONOperation *JSONoperation = [self JSONOperationWithURL:URL
                                                          HTTPMethod:BOXAPIHTTPMethodGET
                                               queryStringParameters:queryParameters

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
@@ -251,7 +251,6 @@
                        BOXAPIObjectKeyAllowedSharedLinkAccessLevels,
                        BOXAPIObjectKeyCollections,
                        BOXAPIObjectKeyFolderUploadEmail,
-                       BOXAPIObjectKeyItemCollection,
                        BOXAPIObjectKeySyncState,
                        BOXAPIObjectKeyHasCollaborations,
                        BOXAPIObjectKeyIsExternallyOwned,

--- a/BoxContentSDK/BoxContentSDKTests/BOXContentSDKTestCase.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXContentSDKTestCase.m
@@ -93,7 +93,6 @@
             BOXFolder *folderB = (BOXFolder *)modelB;
             XCTAssertEqualObjects(folderA.folderUploadEmailAccess, folderB.folderUploadEmailAccess);
             XCTAssertEqualObjects(folderA.folderUploadEmailAddress, folderB.folderUploadEmailAddress);
-            [self assertItemCollection:folderA.items isEquivalentTo:folderB.items];
             XCTAssertEqualObjects(folderA.syncState, folderB.syncState);
             XCTAssertEqual(folderA.hasCollaborations, folderB.hasCollaborations);
             XCTAssertEqual(folderA.canDownload, folderB.canDownload);

--- a/BoxContentSDK/BoxContentSDKTests/BOXFolderRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFolderRequestTests.m
@@ -25,7 +25,7 @@
     BOXFolderRequest *folderRequest = [[BOXFolderRequest alloc] initWithFolderID:folderID];
     NSURLRequest *URLRequest = folderRequest.urlRequest;
 
-    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/folders/%@", BOXAPIBaseURL, BOXAPIVersion, folderID]];
+    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/folders/%@?limit=0", BOXAPIBaseURL, BOXAPIVersion, folderID]];
 
     XCTAssertEqualObjects(expectedURL, URLRequest.URL);
     XCTAssertEqualObjects(@"GET", URLRequest.HTTPMethod);
@@ -37,7 +37,7 @@
     BOXFolderRequest *folderRequest = [[BOXFolderRequest alloc] initWithFolderID:folderID isTrashed:YES];
     NSURLRequest *URLRequest = folderRequest.urlRequest;
     
-    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/folders/%@/trash", BOXAPIBaseURL, BOXAPIVersion, folderID]];
+    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/%@/folders/%@/trash?limit=0", BOXAPIBaseURL, BOXAPIVersion, folderID]];
     
     XCTAssertEqualObjects(expectedURL, URLRequest.URL);
     XCTAssertEqualObjects(@"GET", URLRequest.HTTPMethod);
@@ -75,7 +75,7 @@
     [folderRequest setNotMatchingEtags:notMatchingEtagsToUse];
     NSURLRequest *URLRequest = folderRequest.urlRequest;
     
-    NSString *expectedURL = [NSString stringWithFormat:@"%@/%@/folders/%@", BOXAPIBaseURL, BOXAPIVersion, folderID];
+    NSString *expectedURL = [NSString stringWithFormat:@"%@/%@/folders/%@?limit=0", BOXAPIBaseURL, BOXAPIVersion, folderID];
     NSString *actualURL = [URLRequest.URL absoluteString];
     XCTAssertEqualObjects(expectedURL, actualURL);
     

--- a/BoxContentSDK/BoxContentSDKTests/BOXFolderTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFolderTests.m
@@ -75,18 +75,9 @@
     [self assertModel:parentFolder isEquivalentTo:folder.parentFolder];
     XCTAssertEqualObjects(@"0", folder.parentFolder.modelID);
 
-
     XCTAssertEqualObjects(@"active", folder.status);
     XCTAssertEqualObjects(nil, folder.folderUploadEmailAccess);
     XCTAssertEqualObjects(nil, folder.folderUploadEmailAddress);
-
-    BOXBookmark *item1 = [[BOXBookmark alloc] initWithJSON:@{@"type": @"web_link", @"id": @"6006481", @"sequence_id": @"0", @"etag": @"0", @"name": @"Box Dev", @"url": @"http://developers.box.com"}];
-    BOXBookmark *item2 = [[BOXBookmark alloc] initWithJSON:@{@"type": @"web_link", @"id": @"6006477", @"sequence_id": @"0", @"etag": @"0", @"name": @"Google", @"url": @"http://google.com"}];
-    BOXBookmark *item3 = [[BOXBookmark alloc] initWithJSON:@{@"type": @"web_link", @"id": @"6006479", @"sequence_id": @"0", @"etag": @"0", @"name": @"news.google.com", @"url": @"http://news.google.com"}];
-    NSArray *itemsArray = @[item1, item2, item3];
-    for (NSInteger i = 0; i < itemsArray.count; i++) {
-        [self assertModel:itemsArray[i] isEquivalentTo:folder.items[i]];
-    }
 
     XCTAssertNil(folder.allowedSharedLinkAccessLevels);
     XCTAssertNil(folder.syncState);
@@ -156,8 +147,6 @@
     XCTAssertEqualObjects(@"active", folder.status);
     XCTAssertEqualObjects(@"collaborators", folder.folderUploadEmailAccess);
     XCTAssertEqualObjects(@"bilbo.baggins@gmail.com", folder.folderUploadEmailAddress);
-
-    XCTAssertEqual(6, folder.items.count);
 
     NSArray *accessLevels = @[@"collaborators", @"open"];
     XCTAssertEqualObjects(accessLevels, folder.allowedSharedLinkAccessLevels);

--- a/BoxContentSDK/BoxContentSDKTests/BOXRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXRequestTests.m
@@ -64,7 +64,7 @@
 
 - (void)test_that_full_fields_string_for_folders_is_correct
 {
-    NSString *expectedFieldsString = @"type,id,sequence_id,etag,name,description,size,path_collection,created_at,modified_at,trashed_at,purged_at,content_created_at,content_modified_at,created_by,modified_by,owned_by,shared_link,parent,item_status,permissions,lock,extension,is_package,allowed_shared_link_access_levels,collections,folder_upload_email,item_collection,sync_state,has_collaborations,is_externally_owned,can_non_owners_invite,allowed_invitee_roles";
+    NSString *expectedFieldsString = @"type,id,sequence_id,etag,name,description,size,path_collection,created_at,modified_at,trashed_at,purged_at,content_created_at,content_modified_at,created_by,modified_by,owned_by,shared_link,parent,item_status,permissions,lock,extension,is_package,allowed_shared_link_access_levels,collections,folder_upload_email,sync_state,has_collaborations,is_externally_owned,can_non_owners_invite,allowed_invitee_roles";
     NSString *actualFieldsString = [[[BOXRequest alloc] init] fullFolderFieldsParameterString];
     XCTAssertEqualObjects(expectedFieldsString, actualFieldsString);
 }
@@ -78,7 +78,7 @@
 
 - (void)test_that_full_fields_string_for_items_is_correct
 {
-    NSString *expectedFieldsString = @"type,id,sequence_id,etag,name,description,size,path_collection,created_at,modified_at,trashed_at,purged_at,content_created_at,content_modified_at,created_by,modified_by,owned_by,shared_link,parent,item_status,permissions,lock,extension,is_package,allowed_shared_link_access_levels,collections,folder_upload_email,item_collection,sync_state,has_collaborations,is_externally_owned,can_non_owners_invite,allowed_invitee_roles,sha1,version_number,comment_count,url";
+    NSString *expectedFieldsString = @"type,id,sequence_id,etag,name,description,size,path_collection,created_at,modified_at,trashed_at,purged_at,content_created_at,content_modified_at,created_by,modified_by,owned_by,shared_link,parent,item_status,permissions,lock,extension,is_package,allowed_shared_link_access_levels,collections,folder_upload_email,sync_state,has_collaborations,is_externally_owned,can_non_owners_invite,allowed_invitee_roles,sha1,version_number,comment_count,url";
     NSString *actualFieldsString = [[[BOXRequest alloc] init] fullItemFieldsParameterString];
     XCTAssertEqualObjects(expectedFieldsString, actualFieldsString);
 }


### PR DESCRIPTION
- Developers should be using BOXFolderItemsRequest to obtain children of a folder.
- BOXFolder.items only contains the first 100 items and there was no way for developers
  to request items beyond that in BOXFolderRequest. So it was a dangerous property to expose
  because developers might not realize they're not getting all the items in a folder.
