### PR TITLE
Add comment request can post a message or a tag message, but not both…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.m
@@ -58,12 +58,10 @@
         NSMutableDictionary *bodyDictionary = [NSMutableDictionary dictionary];
         bodyDictionary[BOXAPIObjectKeyItem] = objectDictionary;
         
-        if (self.message) {
-            bodyDictionary[BOXAPIObjectKeyMessage] = self.message;
-        }
-        
         if (self.taggedMessage) {
             bodyDictionary[BOXAPIObjectKeyTaggedMessage] = self.taggedMessage;
+        } else if (self.message) {
+            bodyDictionary[BOXAPIObjectKeyMessage] = self.message;
         }
         
         operation = [self JSONOperationWithURL:url 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXCommentRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXCommentRequest.h
@@ -7,6 +7,7 @@
 
 @interface BOXCommentRequest : BOXRequest
 
+@property (nonatomic, readwrite, assign) BOOL requestAllItemFields;
 @property (nonatomic, readwrite, strong) NSURL *sharedLinkURL;
 @property (nonatomic, readwrite, strong) NSString *sharedLinkPassword; // Only required if the shared link is password-protected
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXCommentRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXCommentRequest.m
@@ -33,9 +33,15 @@
                            subresource:nil
                                  subID:nil];
     
-    operation = [self JSONOperationWithURL:url 
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    
+    if (self.requestAllItemFields) {
+        parameters[BOXAPIParameterKeyFields] = [self fullCommentFieldsParameterString];
+    }
+    
+    operation = [self JSONOperationWithURL:url
                                 HTTPMethod:BOXAPIHTTPMethodGET 
-                     queryStringParameters:nil 
+                     queryStringParameters:parameters
                             bodyDictionary:nil 
                           JSONSuccessBlock:nil 
                               failureBlock:nil];

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileCommentsRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileCommentsRequest.h
@@ -7,6 +7,7 @@
 
 @interface BOXFileCommentsRequest : BOXRequestWithSharedLinkHeader
 
+@property (nonatomic, readwrite, assign) BOOL requestAllItemFields;
 @property (nonatomic, readwrite, strong) NSURL *sharedLinkURL;
 @property (nonatomic, readwrite, strong) NSString *sharedLinkPassword; // Only required if the shared link is password-protected
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileCommentsRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileCommentsRequest.m
@@ -35,9 +35,15 @@
                            subresource:BOXAPISubresourceComments
                                  subID:nil];
     
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    
+    if (self.requestAllItemFields) {
+        parameters[BOXAPIParameterKeyFields] = [self fullCommentFieldsParameterString];
+    }
+    
     BOXAPIJSONOperation *JSONOperation = [self JSONOperationWithURL:URL
                                                          HTTPMethod:BOXAPIHTTPMethodGET
-                                              queryStringParameters:nil
+                                              queryStringParameters:parameters
                                                      bodyDictionary:nil
                                                    JSONSuccessBlock:nil
                                                        failureBlock:nil];

--- a/BoxContentSDK/BoxContentSDKTests/BOXCommentRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXCommentRequestTests.m
@@ -8,6 +8,8 @@
 
 #import "BOXRequestTestCase.h"
 #import "BOXCommentRequest.h"
+#import "BOXRequest_Private.h"
+#import "NSURL+BOXURLHelper.h"
 #import "BOXComment.h"
 
 @interface BOXCommentRequestTests : BOXRequestTestCase
@@ -49,6 +51,22 @@
     }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+- (void)test_that_request_with_all_fields_has_expected_URLRequest_query_params
+{
+    NSString *commentID = @"987654";
+    
+    BOXCommentRequest *request = [[BOXCommentRequest  alloc] initWithCommentID:commentID];
+    request.requestAllItemFields = YES;
+    NSURLRequest *URLRequest = request.urlRequest;
+    
+    NSString *expectedURLWithoutQueryString = [NSString stringWithFormat:@"%@/%@/comments/%@", BOXAPIBaseURL, BOXAPIVersion, commentID];
+    NSString *actualURLWithoutQueryString = [NSString stringWithFormat:@"%@://%@%@", URLRequest.URL.scheme, URLRequest.URL.host, URLRequest.URL.path];
+    XCTAssertEqualObjects(expectedURLWithoutQueryString, actualURLWithoutQueryString);
+    
+    NSString *expectedFieldsString = [[[BOXRequest alloc] init] fullCommentFieldsParameterString];
+    XCTAssertEqualObjects(expectedFieldsString, [[[URLRequest.URL box_queryDictionary] objectForKey:@"fields"] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileCommentsRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileCommentsRequestTests.m
@@ -8,6 +8,8 @@
 
 #import "BOXRequestTestCase.h"
 #import "BOXFileCommentsRequest.h"
+#import "BOXRequest_Private.h"
+#import "NSURL+BOXURLHelper.h"
 #import "BoxComment.h"
 
 @interface BOXFileCommentsRequest ()
@@ -74,6 +76,22 @@
     }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
+}
+
+- (void)test_that_request_with_all_fields_has_expected_URLRequest_query_params
+{
+    NSString *fileID = @"1234567";
+    
+    BOXFileCommentsRequest *request = [[BOXFileCommentsRequest alloc] initWithFileID:fileID];
+    request.requestAllItemFields = YES;
+    NSURLRequest *URLRequest = request.urlRequest;
+    
+    NSString *expectedURLWithoutQueryString = [NSString stringWithFormat:@"%@/%@/files/%@/comments", BOXAPIBaseURL, BOXAPIVersion, fileID];
+    NSString *actualURLWithoutQueryString = [NSString stringWithFormat:@"%@://%@%@", URLRequest.URL.scheme, URLRequest.URL.host, URLRequest.URL.path];
+    XCTAssertEqualObjects(expectedURLWithoutQueryString, actualURLWithoutQueryString);
+    
+    NSString *expectedFieldsString = [[[BOXRequest alloc] init] fullCommentFieldsParameterString];
+    XCTAssertEqualObjects(expectedFieldsString, [[[URLRequest.URL box_queryDictionary] objectForKey:@"fields"] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
 }
 
 @end


### PR DESCRIPTION
…. Added code to the request evaluate if a tag message exists
