### PR TITLE
Fix EXC_BAD_ACCESS crash in BOXAPIDataOperation caused by removing th…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -170,7 +170,6 @@
     }
     else {
         self.outputStream.delegate = nil;
-        [self.outputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
         [self.outputStream close];
         _outputStream = nil;
     }


### PR DESCRIPTION
…e outputStream from runLoop and then closing.
