### PR TITLE
Fix the framework naming issue that prevents pod install in swift to …

### DIFF
--- a/box-ios-sdk-interfaces.podspec
+++ b/box-ios-sdk-interfaces.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
 # Root specification
 
 s.name                  = "box-ios-sdk-interfaces"
-s.version               = "1.0.8"
+s.version               = "1.1.0"
 s.summary               = "iOS SDK for the Box API."
 s.homepage              = "https://github.com/box/box-ios-sdk"
 s.license               = { :type => "Apache 2.0", :file => "LICENSE" }
@@ -29,4 +29,6 @@ s.ios.frameworks        = "Security", "QuartzCore", "AssetsLibrary"
 s.requires_arc          = true
 s.xcconfig              = { "OTHER_LDFLAGS" => "-ObjC -all_load" }
 s.ios.header_dir        = "BoxContentSDK"
+s.module_name           = "BoxContentSDK"
+
 end

--- a/box-ios-sdk-tests.podspec
+++ b/box-ios-sdk-tests.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "box-ios-sdk-tests"
-  s.version      = "1.0.8"
+  s.version      = "1.1.0"
   s.summary      = "A common testing interface extracted from Content SDK."
   s.license      = { :type => "Apache 2.0", :file => "LICENSE" }
   s.author       = "Box"

--- a/box-ios-sdk.podspec
+++ b/box-ios-sdk.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 # Root specification
 
 s.name                  = "box-ios-sdk"
-s.version               = "1.0.8"
+s.version               = "1.1.0"
 s.summary               = "iOS SDK for the Box API"
 s.homepage              = "https://github.com/box/box-ios-sdk"
 s.license               = { :type => "Apache 2.0", :file => "LICENSE" }
@@ -34,6 +34,7 @@ s.ios.frameworks        = "Security", "QuartzCore", "AssetsLibrary"
 s.requires_arc          = true
 s.xcconfig              = { "OTHER_LDFLAGS" => "-ObjC -all_load" }
 s.ios.header_dir        = "BoxContentSDK"
+s.module_name           = "BoxContentSDK"
 
 # Subspecs
 


### PR DESCRIPTION
…find the source.

Note: When merging, we need to add a tag with version 1.1.0.
Why not 1.0.9? Because after renaming, it's not compatible with 1.0.8 anymore, so we use semantic versioning to indicate that this is incompatible with the past version.
