### PR TITLE
IOS-9038: Authentication flow redirects to Box web experience within auth view

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -13,6 +13,7 @@
 
 // API URLs
 extern NSString *const BOXAPIBaseURL;
+extern NSString *const BOXAPIAuthBaseURL;
 extern NSString *const BOXAPIUploadBaseURL;
 
 // API Versions

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
@@ -10,6 +10,7 @@
 
 // API URLs
 NSString *const BOXAPIBaseURL = @"https://api.box.com";
+NSString *const BOXAPIAuthBaseURL = @"https://app.box.com/api";
 NSString *const BOXAPIUploadBaseURL = @"https://upload.box.com/api";
 
 // API Versions

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -27,9 +27,14 @@
 @property (nonatomic, readonly, strong) BOXAbstractSession *session;
 
 /**
- *  The base URL for all API operations including Authentication.
+ *  The base URL for all API operations except for Authentication and Upload.
  */
 @property (nonatomic, readwrite, strong) NSString *APIBaseURL;
+
+/**
+ *  The base URL for all API Authentication operations.
+ */
+@property (nonatomic, readwrite, strong) NSString *APIAuthBaseURL;
 
 /**
  *  The client's queue manager. All API calls are scheduled by this queue manager.

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -146,6 +146,7 @@ static BOXContentClient *defaultInstance = nil;
     if (self = [super init])
     {
         [self setAPIBaseURL:BOXAPIBaseURL];
+        [self setAPIAuthBaseURL:BOXAPIAuthBaseURL];
         
         // the circular reference between the queue manager and the session is necessary
         // because sessions enqueue API operations to fetch access tokens and the queue
@@ -154,7 +155,8 @@ static BOXContentClient *defaultInstance = nil;
 
         _OAuth2Session = [[BOXParallelOAuth2Session alloc] initWithClientID:staticClientID
                                                                      secret:staticClientSecret
-                                                                 APIBaseURL:BOXAPIBaseURL
+                                                                 APIBaseURL:_APIBaseURL
+                                                             APIAuthBaseURL:_APIAuthBaseURL
                                                                queueManager:_queueManager];
         _queueManager.session = self.session;
         
@@ -271,7 +273,15 @@ static BOXContentClient *defaultInstance = nil;
 - (void)setAPIBaseURL:(NSString *)APIBaseURL
 {
     _APIBaseURL = APIBaseURL;
-    self.session.APIBaseURLString = APIBaseURL;
+    self.session.APIBaseURLString = _APIBaseURL;
+}
+
+- (void)setAPIAuthBaseURL:(NSString *)APIAuthBaseURL
+{
+    _APIAuthBaseURL = APIAuthBaseURL;
+    if ([self.session isKindOfClass:[BOXOAuth2Session class]]) {
+        ((BOXOAuth2Session *)self.session).APIAuthBaseURLString = _APIAuthBaseURL;
+    }
 }
 
 // Load the ressources bundle.

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
@@ -56,10 +56,6 @@ extern NSString *const BOXUserIDKey;
 /**
  * The base URL for API requests.
  * @see BOXAPIBaseURL
- *
- * Used for granting authorization with OAuth2 as well.
- * @see grantTokensURL
- * @see authorizeURL
  */
 @property (nonatomic, readwrite, strong) NSString *APIBaseURLString;
 

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -103,14 +103,25 @@
  * @param ID your client ID, also known as API key.
  * @param secret your client secret. DO NOT publish this secret.
  * @param baseURL The base URL String for accessing the Box API.
+ * @param authBaseURL The base URL String for authenticating with the Box API.
  * @param queueManager The queue manager on which to enqueue [BOXAPIOAuth2ToJSONOperations](BOXAPIOAuth2ToJSONOperation).
  *
  * @return A BOXOAuth2Session capable of authorizing a user and signing requests.
  */
-- (instancetype)initWithClientID:(NSString *)ID secret:(NSString *)secret APIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager;
+- (instancetype)initWithClientID:(NSString *)ID
+                          secret:(NSString *)secret
+                      APIBaseURL:(NSString *)baseURL
+                  APIAuthBaseURL:(NSString *)authBaseURL
+                    queueManager:(BOXAPIQueueManager *)queueManager;
 
 #pragma mark - Authorization
 /** @name Authorization */
+
+/**
+ * The base URL for API requests.
+ * @see BOXAPIAuthBaseURL
+ */
+@property (nonatomic, readwrite, strong) NSString *APIAuthBaseURLString;
 
 /**
  * Exchange an authorization code for an access token and a refresh token.

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -34,19 +34,24 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithClientID:(NSString *)ID secret:(NSString *)secret APIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager
+- (instancetype)initWithClientID:(NSString *)ID
+                          secret:(NSString *)secret
+                      APIBaseURL:(NSString *)baseURL
+                  APIAuthBaseURL:(NSString *)authBaseURL
+                    queueManager:(BOXAPIQueueManager *)queueManager
 {
     if ([self initWithAPIBaseURL:baseURL queueManager:queueManager]) {
         _clientID = ID;
         _clientSecret = secret;
         _redirectURIString = [NSString stringWithFormat:@"boxsdk-%@://boxsdkoauth2redirect", _clientID];
+        _APIAuthBaseURLString = authBaseURL;
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didReceiveRevokeSessionNotification:)
                                                      name:BOXSessionWasRevokedNotification
                                                    object:nil];
     }
-    
+
     return self;
 }
 
@@ -174,7 +179,7 @@
     NSString *encodedRedirectURI = [NSString box_stringWithString:self.redirectURIString URLEncoded:YES];
     NSString *authorizeURLString = [NSString stringWithFormat:
                                     @"%@/oauth2/authorize?response_type=code&client_id=%@&state=%@&redirect_uri=%@",
-                                    self.APIBaseURLString, self.clientID, self.nonce, encodedRedirectURI];
+                                    self.APIAuthBaseURLString, self.clientID, self.nonce, encodedRedirectURI];
     return [NSURL URLWithString:authorizeURLString];
 }
 

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -21,9 +21,13 @@
 
 @synthesize expiredOAuth2Tokens = _expiredOAuth2Tokens;
 
-- (id)initWithClientID:(NSString *)ID secret:(NSString *)secret APIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager
+- (id)initWithClientID:(NSString *)ID
+                secret:(NSString *)secret
+            APIBaseURL:(NSString *)baseURL
+        APIAuthBaseURL:(NSString *)authBaseURL
+          queueManager:(BOXAPIQueueManager *)queueManager
 {
-    self = [super initWithClientID:ID secret:secret APIBaseURL:baseURL queueManager:queueManager];
+    self = [super initWithClientID:ID secret:secret APIBaseURL:baseURL APIAuthBaseURL:authBaseURL queueManager:queueManager];
     if (self != nil)
     {
         _expiredOAuth2Tokens = [NSMutableSet set];

--- a/BoxContentSDK/BoxContentSDKTests/BOXRequestTestCase.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXRequestTestCase.m
@@ -37,7 +37,7 @@
     [NSURLProtocol registerClass:[BOXCannedURLProtocol class]];
     
     self.fakeQueueManager = [[BOXParallelAPIQueueManager alloc] init];
-    self.fakeOAuth2Session = [[BOXOAuth2Session alloc] initWithClientID:@"test_client_id" secret:@"test_client_secret" APIBaseURL:BOXAPIBaseURL queueManager:self.fakeQueueManager];
+    self.fakeOAuth2Session = [[BOXOAuth2Session alloc] initWithClientID:@"test_client_id" secret:@"test_client_secret" APIBaseURL:BOXAPIBaseURL APIAuthBaseURL:BOXAPIAuthBaseURL queueManager:self.fakeQueueManager];
     self.fakeOAuth2Session.refreshToken = @"sample_refresh_token";
     self.fakeOAuth2Session.accessToken = @"sample_access_token";
     self.fakeOAuth2Session.accessTokenExpiration = [NSDate distantFuture];


### PR DESCRIPTION
Updated the authentication code to include many fixes and improvements to
SSO and other authentication scenarios made recently.
Updated the base URL used for Box OAuth2 to match the specification in the
developer documentation (https://box-content.readme.io/reference#authorize).
