### PR TITLE
Expose the App-To-App auth delegation functionality directly from the SDK

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
@@ -59,6 +59,7 @@ typedef enum {
     BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued = 20001, // access token is expired and the operation cannot be reenqueued because it cannot be copied
     BOXContentSDKAuthErrorAccessTokenExpiredOperationCouldNotBeCompleted = 20002, // Operation failed because access token is expired and could not be refreshed. Usually due to no internet connection
     BOXContentSDKAuthErrorAccessTokenNonceMismatch = 20003, // Operation failed because nonce returned by server didn't match the one used by app to authorize user.
+    BOXContentSDKAuthErrorNotPossible = 20004, // Operation failed because the specific type of auth is not possible (for example App-To-App auth delegation when the Box app is not installed).
 } BOXContentSDKAuthError;
 
 typedef enum {

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Authentication.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Authentication.h
@@ -31,6 +31,16 @@
 - (void)authenticateInAppWithCompletionBlock:(void (^)(BOXUser *user, NSError *error))completion;
 
 /**
+ *  Authenticate a user. If necessary and possible, this will launch the Box app to allow the user to autmatically
+ *  be authenticated to that account.
+ *  If App-To-App authentication is not possible, an error is returned in the completion block.
+ *  If a user is already authenticated, then a UIViewController will not be presented and the completionBlock will be called.
+ *
+ *  @param completionBlock Called when the authentication has completed.
+ */
+- (void)authenticateAppToAppWithCompletionBlock:(void (^)(BOXUser *user, NSError *error))completion;
+
+/**
  *  Discerns whether a launch URL is associated with Box App-to-App authentication - if it is the return URL that should be used
  *  to complete the user's authentication in the case of authenticating App-to-App using the Box app.
  *


### PR DESCRIPTION
So that third parties could use it explicitly instead of the generic
authentication method which will use whichever functionality is available.
