### PR TITLE
Improve handling of expired access tokens, especially for upload operations.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -210,7 +210,6 @@
                                  BOXAuthTokenRequestClientSecretKey : self.clientSecret,
                                  };
     
-    __weak BOXOAuth2Session *weakSelf = self;
     BOXAPIOAuth2ToJSONOperation *operation = [[BOXAPIOAuth2ToJSONOperation alloc] initWithURL:self.grantTokensURL
                                                                                    HTTPMethod:BOXAPIHTTPMethodPOST
                                                                                          body:POSTParams
@@ -219,20 +218,20 @@
     
     operation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary)
     {
-        weakSelf.accessToken = [JSONDictionary valueForKey:BOXAuthTokenJSONAccessTokenKey];
-        weakSelf.refreshToken = [JSONDictionary valueForKey:BOXAuthTokenJSONRefreshTokenKey];
+        self.accessToken = [JSONDictionary valueForKey:BOXAuthTokenJSONAccessTokenKey];
+        self.refreshToken = [JSONDictionary valueForKey:BOXAuthTokenJSONRefreshTokenKey];
         
         NSTimeInterval accessTokenExpiresIn = [[JSONDictionary valueForKey:BOXAuthTokenJSONExpiresInKey] integerValue];
         BOXAssert(accessTokenExpiresIn >= 0, @"accessTokenExpiresIn value is negative");
-        weakSelf.accessTokenExpiration = [NSDate dateWithTimeIntervalSinceNow:accessTokenExpiresIn];
+        self.accessTokenExpiration = [NSDate dateWithTimeIntervalSinceNow:accessTokenExpiresIn];
         
-        [weakSelf storeCredentialsToKeychain];
+        [self storeCredentialsToKeychain];
         
         // send success notification
-        [[NSNotificationCenter defaultCenter] postNotificationName:BOXSessionDidRefreshTokensNotification object:weakSelf];
+        [[NSNotificationCenter defaultCenter] postNotificationName:BOXSessionDidRefreshTokensNotification object:self];
         
         if (block) {
-            block(weakSelf, nil);
+            block(self, nil);
         }
     };
     
@@ -241,11 +240,11 @@
         NSDictionary *errorInfo = [NSDictionary dictionaryWithObject:error
                                                               forKey:BOXAuthenticationErrorKey];
         [[NSNotificationCenter defaultCenter] postNotificationName:BOXSessionDidReceiveRefreshErrorNotification
-                                                            object:weakSelf
+                                                            object:self
                                                           userInfo:errorInfo];
         
         if (block) {
-            block(weakSelf, error);
+            block(self, error);
         }
     };
     

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
@@ -73,4 +73,11 @@
  */
 - (void)prepareAPIRequest;
 
+/**
+  * Whether or not the operation request can be re-enqueued automatically.
+  * In certain cases, the Operations layer can try to re-execute (once) upon failure (e.g. token needed refreshing).
+  * Sub-classes should override to indicate whether they are re-enqueueable or not.
+  */
+- (BOOL)canBeReenqueued;
+
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
@@ -39,10 +39,10 @@
     if (timeUntilTokenExpiry < 60)
     {
         // Do a token refresh. This will become a dependency for the API operation.
-        [self.session performRefreshTokenGrant:self.session.accessToken withCompletionBlock:nil];
+        [self handleExpiredAccessToken];
         
         NSInteger errorCode;
-        if (self.timesReenqueued == 0)
+        if (self.timesReenqueued == 0 && [self canBeReenqueued])
         {
             errorCode = BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued;
             
@@ -53,7 +53,7 @@
         }
         else
         {
-            errorCode = BOXContentSDKAuthErrorAccessTokenExpiredOperationCouldNotBeCompleted;
+            errorCode = BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued;
         }
         
         // Short-circuit this operation.
@@ -85,6 +85,11 @@
     [self.session performRefreshTokenGrant:self.accessToken withCompletionBlock:nil];
 }
 
+- (BOOL)canBeReenqueued
+{
+    return NO;
+}
+
 #pragma mark - NSURLConnectionDataDelegate
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
 {
@@ -92,36 +97,23 @@
 
     BOOL isOAuth2TokenExpired = [self isAccessTokenExpired];
 
-    if (isOAuth2TokenExpired && self.timesReenqueued == 0)
+    if (isOAuth2TokenExpired)
     {
-        BOXLog(@"OAuth2 access token is expired.");
-        self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued userInfo:nil];
-
-        // re-enqueue operation in the same queue referred to by the OAuth2 session
-        // if possible. This is only possible for BOXAPIJSONOperations.
-        // BOXAPIDataOperations and BOXAPIMultipartToJSONOperations contain NSStream
-        // properties that cannot be copied. If an operation cannot be copied, an
-        // NSError indicating so is returned in this operation's failure callback.
-        if ([self isMemberOfClass:[BOXAPIJSONOperation class]])
+        [self handleExpiredAccessToken];
+        
+        // re-enqueue operation in the same queue referred to by the OAuth2 session if possible.
+        if ([self canBeReenqueued] && self.timesReenqueued == 0)
         {
-            BOXLog(@"Re-enqueueing operation that failed to authenticate");
+            self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued userInfo:nil];
+            
             BOXAPIJSONOperation *operationCopy = [self copy];
             operationCopy.timesReenqueued = operationCopy.timesReenqueued + 1;
-            // re-enqueue before adding OAuth2 operation so OAuth2 operation can be
-            // added as a dependency
             [self.session.queueManager enqueueOperation:operationCopy];
         }
         else
         {
             self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued userInfo:nil];
         }
-
-        BOXLog(@"Attempting automatic OAuth2 token refresh");
-        [self handleExpiredAccessToken];
-    }
-    else if (isOAuth2TokenExpired)
-    {
-        self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationCouldNotBeCompleted userInfo:nil];
     }
 }
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -322,4 +322,9 @@
     return operationCopy;
 }
 
+- (BOOL)canBeReenqueued
+{
+    return YES;
+}
+
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
@@ -147,4 +147,9 @@
     }
 }
 
+- (BOOL)canBeReenqueued
+{
+    return YES;
+}
+
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
@@ -668,6 +668,11 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
     }
 }
 
+- (BOOL)canBeReenqueued
+{
+    return NO;
+}
+
 - (void)dealloc
 {
     _outputStream.delegate = nil;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -112,28 +112,46 @@
 {
     BOOL isMainThread = [NSThread isMainThread];
     BOXAPIMultipartToJSONOperation *uploadOperation = (BOXAPIMultipartToJSONOperation *)self.operation;
-    if (progressBlock) {
-        uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
-            [BOXDispatchHelper callCompletionBlock:^{
-                progressBlock(bytesSent, totalBytes);
-            } onMainThread:isMainThread];
-        };
-    }
-    if (completionBlock) {
-        uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
-            BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
-            [BOXDispatchHelper callCompletionBlock:^{
-                completionBlock(file, nil);
-            } onMainThread:isMainThread];
-        };
-        uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
-            [BOXDispatchHelper callCompletionBlock:^{
-                completionBlock(nil, error);
-            } onMainThread:isMainThread];
-        };
-    }
     
-    [self performRequest];
+    void (^perform)() = ^void() {
+        if (progressBlock) {
+            uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
+                [BOXDispatchHelper callCompletionBlock:^{
+                    progressBlock(bytesSent, totalBytes);
+                } onMainThread:isMainThread];
+            };
+        }
+        if (completionBlock) {
+            uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
+                BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
+                [BOXDispatchHelper callCompletionBlock:^{
+                    completionBlock(file, nil);
+                } onMainThread:isMainThread];
+            };
+            uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
+                [BOXDispatchHelper callCompletionBlock:^{
+                    completionBlock(nil, error);
+                } onMainThread:isMainThread];
+            };
+        }
+        
+        [self performRequest];
+    };
+    
+    // Unlike other operation types, BOXAPIMultipartToJSONOperation cannot be gracefully re-enqueued if the access token is expired (and can be refreshed).
+    // In order to minimize the risk of a failed request due to an expired access token, more aggressively check if it is expired, and refresh it manually
+    // beforehand if necessary.
+    if ([self.operation.session.accessTokenExpiration timeIntervalSinceNow] < 300) {
+        [self.operation.session performRefreshTokenGrant:self.operation.session.accessToken withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
+            if (error) {
+                completionBlock(nil, error);
+            } else {
+                perform();
+            }
+        }];
+    } else {
+        perform();
+    }
 }
 
 #pragma mark - Superclass overidden methods


### PR DESCRIPTION
1. Upload operations (BOXAPIMultipartToJSONOperation) cannot be re-enqueued. Currently, we
   are re-enqueing them, which results in a (previously) mysterious 405 response. Added an explicit
   (BOOL)canBeReenqueued method so that it's clearer to see when it's possible to re-enqueue.
2. For BOXFileUploadRequest and BOXFileUploadNewVersionRequest, added a pre-emptive check
   on the access token expiry, and if it is close to expiration, we now manually attempt a token
   refresh. This minimizes the chance that a developer will actually get the error due to our
   inability to re-enqueue (BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued).
3. Un-did some of the changes made in BOXOAuth2Session in https://github.com/box/box-ios-sdk/pull/59/files
   wherein we de-referenced 'self'. This (sometimes) led to us not storing new tokens from the server,
   after doing a refresh. In this case, we really do need to hang on to 'self' until the refresh request completes.
