### PR TITLE
Make a call to the 'revoke' endpoint on logout.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -380,7 +380,6 @@ static BOXContentClient *defaultInstance = nil;
     }
 }
 
-
 + (NSMutableDictionary *)SDKClients
 {
     if (_SDKClients == nil) {

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -251,6 +251,36 @@
     [self.queueManager enqueueOperation:operation];
 }
 
+#pragma mark - Token revoke
+
+- (void)revokeCredentials
+{
+    // Call this before '[super revokeCredentials]' otherwise we would have already lost our accessToken.
+    [self sendRevokeRequest];
+    
+    [super revokeCredentials];
+}
+
+/**
+ *  Send API request to revoke tokens. We don't care about the response to this request.
+ *  This will be called when we're about to wipe the token from keychain+memory, so we could not do anything
+ *  about successes/failures anyway.
+ */
+- (void)sendRevokeRequest
+{
+    // We don't go through any of our regular queues/operations because those get shut down upon logout.
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/oauth2/revoke", BOXAPIBaseURL]]];
+    [request setHTTPMethod:@"POST"];
+    [request setValue:@"application/x-www-form-urlencoded charset=utf-8" forHTTPHeaderField:@"Content-Type"];
+    
+    NSData *postData = [[NSString stringWithFormat:@"client_id=%@&client_secret=%@&token=%@", self.clientID, self.clientSecret, self.accessToken] dataUsingEncoding:NSUTF8StringEncoding];
+    [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)postData.length] forHTTPHeaderField:@"Content-Length"];
+    [request setHTTPBody:postData];
+    
+    NSURLConnection *connection = [[NSURLConnection alloc] initWithRequest:request delegate:nil];
+    [connection start];
+}
+
 #pragma mark Token Helpers
 
 - (void)reassignTokensFromSession:(BOXOAuth2Session *)session


### PR DESCRIPTION
- We cannot guarantee that the call will succeed (e.g. network connectivity) but we still
  make our best attempt at revoking the tokens.
