### PR TITLE
Do cache retrievals synchronously so we can ensure that cache blocks fire before refresh blocks.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Cache/BOXRequestCache.h
+++ b/BoxContentSDK/BoxContentSDK/Cache/BOXRequestCache.h
@@ -29,7 +29,7 @@
  *  @param key        key associated with the request to retrieve.
  *  @param cacheBlock block to be executed when the cached request has been retrieved.
  */
-- (void)fetchCacheForKey:(NSString *)key cacheBlock:(void(^)(NSDictionary *dictionary))cacheBlock;
+- (NSDictionary *)fetchCacheForKey:(NSString *)key;
 
 /**
  *  Removes the cached response for the specified key.

--- a/BoxContentSDK/BoxContentSDK/Cache/BOXRequestCache.m
+++ b/BoxContentSDK/BoxContentSDK/Cache/BOXRequestCache.m
@@ -89,20 +89,14 @@
     return _cachePath;
 }
 
-- (void)fetchCacheForKey:(NSString *)key cacheBlock:(void(^)(NSDictionary *dictionary))cacheBlock
+- (NSDictionary *)fetchCacheForKey:(NSString *)key
 {
-    BOOL isMainThread = [NSThread isMainThread];
-    
-    if (cacheBlock) {
-        PINCacheObjectBlock localCacheBlock = ^void(PINCache *cache, NSString *key, id __nullable object) {
-            if ([object isKindOfClass:[NSDictionary class]]) {
-                [BOXDispatchHelper callCompletionBlock:^{
-                    cacheBlock(object);
-                } onMainThread:isMainThread];
-            }
-        };
-        [self.cache objectForKey:key block:localCacheBlock];
+    NSDictionary *dictionary = nil;
+    id object = [self.cache objectForKey:key];
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        dictionary = (NSDictionary *)object;
     }
+    return dictionary;
 }
 
 - (void)removeCacheForKey:(NSString *)key

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderItemsRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderItemsRequest.m
@@ -81,20 +81,17 @@
 
 - (void)performRequestWithCached:(BOXItemsBlock)cacheBlock refreshed:(BOXItemsBlock)refreshBlock
 {
-    BOXFolderItemsRequest *weakSelf = self;
     NSString *cacheKey = self.requestCacheKey;
     BOXRequestCache *requestCache = self.requestCache;
-    
-    if (cacheBlock) {
-        if (self.requestCache) {
-            void (^localCacheBlock)(NSDictionary *JSONDictionary) = ^void(NSDictionary *JSONDictionary) {
-                NSArray *items = [BOXRequest itemsWithJSON:JSONDictionary];
-                cacheBlock(items, nil);
-            };
-            [requestCache fetchCacheForKey:cacheKey cacheBlock:localCacheBlock];
+    if (cacheBlock && requestCache) {
+        NSDictionary *JSONDictionary = [requestCache fetchCacheForKey:cacheKey];
+        if (JSONDictionary != nil) {
+            NSArray *itemsFromCache = [BOXRequest itemsWithJSON:JSONDictionary];
+            cacheBlock(itemsFromCache, nil);
         }
     }
     
+    BOXFolderItemsRequest *weakSelf = self;
     if (refreshBlock) {
         BOOL isMainThread = [NSThread isMainThread];
         

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
@@ -84,19 +84,17 @@
 
 - (void)performRequestWithCached:(BOXFolderBlock)cacheBlock refreshed:(BOXFolderBlock)refreshBlock
 {
+    if (cacheBlock && self.requestCache) {
+        NSDictionary *JSONDictionary = [self.requestCache fetchCacheForKey:self.requestCacheKey];
+        if (JSONDictionary != nil) {
+            BOXFolder *folder = [[BOXFolder alloc] initWithJSON:JSONDictionary];
+            cacheBlock(folder, nil);
+        }
+    }
+ 
     __weak BOXFolderRequest *weakSelf = self;
     BOOL isMainThread = [NSThread isMainThread];
     BOXAPIJSONOperation *folderOperation = (BOXAPIJSONOperation *)self.operation;
-    
-    if (cacheBlock) {
-        if (self.requestCache) {
-            void (^localCacheBlock)(NSDictionary *JSONDictionary) = ^(NSDictionary *JSONDictionary) {
-                BOXFolder *folder = [[BOXFolder alloc] initWithJSON:JSONDictionary];
-                cacheBlock(folder, nil);
-            };
-            [weakSelf.requestCache fetchCacheForKey:weakSelf.requestCacheKey cacheBlock:localCacheBlock];
-        }
-    }
     
     if (refreshBlock) {
         folderOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {


### PR DESCRIPTION
…

2 reasons to do this:
1. Developers might reasonably expect that cache blocks should always fire before refresh blocks.
2. We are vulnerable to inconsistencies within the SDK itself if we end up writing to the cache
in the refresh block before we've even read from the cache block.
