### PR TITLE
We were vulnerable to the following scenario when refreshing expired tokens:

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
@@ -40,6 +40,7 @@ typedef enum {
     // 5xx errors
     BOXContentSDKAPIErrorInternalServerError = 500,
     BOXContentSDKAPIErrorInsufficientStorage = 507,
+    
     // Access Denied by user
     BOXContentSDKAPIErrorUserDeniedAccess = 997,
     // Cancelation
@@ -60,6 +61,7 @@ typedef enum {
     BOXContentSDKAuthErrorAccessTokenExpiredOperationCouldNotBeCompleted = 20002, // Operation failed because access token is expired and could not be refreshed. Usually due to no internet connection
     BOXContentSDKAuthErrorAccessTokenNonceMismatch = 20003, // Operation failed because nonce returned by server didn't match the one used by app to authorize user.
     BOXContentSDKAuthErrorNotPossible = 20004, // Operation failed because the specific type of auth is not possible (for example App-To-App auth delegation when the Box app is not installed).
+    BOXContentSDKAuthErrorTokenRefreshAlreadyInProgress = 20005, // Returned when duplicate attempts to refresh the same token are detected
 } BOXContentSDKAuthError;
 
 typedef enum {

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -10,6 +10,7 @@
 #import "BOXAPIOAuth2ToJSONOperation.h"
 #import "BOXLog.h"
 #import "BOXContentSDKConstants.h"
+#import "BOXContentSDKErrors.h"
 
 @interface BOXParallelOAuth2Session ()
 
@@ -44,19 +45,44 @@
         {
             // Only attempt to refresh the token if this is the first time this access
             // token has expired
+            
+            // TODO We need to ensure that completion block gets called, but we don't want to trigger duplicate attempts to refresh the same token.
+            // We should have an observer-notifier pattern to hook up this block into the existing refresh operation in progress.
+            // Without that, the best we can do is return this error.
+            if (block) {
+                block(self, [NSError errorWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorTokenRefreshAlreadyInProgress userInfo:nil]);
+            }
             return;
         }
         
-        BOXLog(@"access token expired: %@", expiredAccessToken);
-        BOXLog(@"refreshing tokens");
         if (expiredAccessToken)
         {
             [self.expiredOAuth2Tokens addObject:expiredAccessToken];
         }
         
-        [super performRefreshTokenGrant:expiredAccessToken withCompletionBlock:block];
+        [super performRefreshTokenGrant:expiredAccessToken withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
+            if (error != nil && ![self isInvalidGrantError:error]) {
+                // If there was an error, remove from 'expiredOAuth2Tokens' so that we can try again. For example, if there was a network
+                // error, then we would not want to block ourselves from trying to refresh the tokens again later.
+                // The exception to this is if we get 'invalid_grant' in which case the token is not just expired, but is just dead. In that
+                // case, we don't want to ever try refreshing that again.
+                [self.expiredOAuth2Tokens removeObject:expiredAccessToken];
+            }
+        }];
     }
 }
 
+- (BOOL)isInvalidGrantError:(NSError *)error
+{
+    BOOL isInvalidGrantError = NO;
+    if ([error.domain isEqualToString:BOXContentSDKErrorDomain]) {
+        NSDictionary *errorInfo = [error.userInfo objectForKey:BOXJSONErrorResponseKey];
+        NSString *errorType = [errorInfo objectForKey:BOXAuthURLParameterErrorCodeKey];
+        if ([errorType isEqualToString:BOXAuthTokenRequestErrorInvalidGrant]) {
+            isInvalidGrantError = YES;
+        }
+    }
+    return isInvalidGrantError;
+}
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -113,45 +113,37 @@
     BOOL isMainThread = [NSThread isMainThread];
     BOXAPIMultipartToJSONOperation *uploadOperation = (BOXAPIMultipartToJSONOperation *)self.operation;
     
-    void (^perform)() = ^void() {
-        if (progressBlock) {
-            uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
-                [BOXDispatchHelper callCompletionBlock:^{
-                    progressBlock(bytesSent, totalBytes);
-                } onMainThread:isMainThread];
-            };
-        }
-        if (completionBlock) {
-            uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
-                BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
-                [BOXDispatchHelper callCompletionBlock:^{
-                    completionBlock(file, nil);
-                } onMainThread:isMainThread];
-            };
-            uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
-                [BOXDispatchHelper callCompletionBlock:^{
-                    completionBlock(nil, error);
-                } onMainThread:isMainThread];
-            };
-        }
-        
-        [self performRequest];
-    };
-    
     // Unlike other operation types, BOXAPIMultipartToJSONOperation cannot be gracefully re-enqueued if the access token is expired (and can be refreshed).
     // In order to minimize the risk of a failed request due to an expired access token, more aggressively check if it is expired, and refresh it manually
     // beforehand if necessary.
     if ([self.operation.session.accessTokenExpiration timeIntervalSinceNow] < 300) {
-        [self.operation.session performRefreshTokenGrant:self.operation.session.accessToken withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
-            if (error) {
-                completionBlock(nil, error);
-            } else {
-                perform();
-            }
-        }];
-    } else {
-        perform();
+        // We rely on our operations layer to block the upload request until this is done, because
+        // BOXParallelOAuth2Session cannot reliably call the completion block. (See TODO in [BOXParallelOAuth2Session:performRefreshTokenGrant:withCompletionBlock]
+        [self.operation.session performRefreshTokenGrant:self.operation.session.accessToken withCompletionBlock:nil];
     }
+    
+    if (progressBlock) {
+        uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
+            [BOXDispatchHelper callCompletionBlock:^{
+                progressBlock(bytesSent, totalBytes);
+            } onMainThread:isMainThread];
+        };
+    }
+    if (completionBlock) {
+        uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
+            BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
+            [BOXDispatchHelper callCompletionBlock:^{
+                completionBlock(file, nil);
+            } onMainThread:isMainThread];
+        };
+        uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
+            [BOXDispatchHelper callCompletionBlock:^{
+                completionBlock(nil, error);
+            } onMainThread:isMainThread];
+        };
+    }
+    
+    [self performRequest];
 }
 
 #pragma mark - Superclass overidden methods

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
@@ -157,46 +157,38 @@
     BOOL isMainThread = [NSThread isMainThread];
     BOXAPIMultipartToJSONOperation *uploadOperation = (BOXAPIMultipartToJSONOperation *)self.operation;
     
-    void (^perform)() = ^void() {
-        if (progressBlock) {
-            uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
-                [BOXDispatchHelper callCompletionBlock:^{
-                    progressBlock(bytesSent, totalBytes);
-                } onMainThread:isMainThread];
-            };
-        }
-        
-        if (completionBlock) {
-            uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
-                BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
-                [BOXDispatchHelper callCompletionBlock:^{
-                    completionBlock(file, nil);
-                } onMainThread:isMainThread];
-            };
-            uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
-                [BOXDispatchHelper callCompletionBlock:^{
-                    completionBlock(nil, error);
-                } onMainThread:isMainThread];
-            };
-        }
-        
-        [self performRequest];
-    };
-    
     // Unlike other operation types, BOXAPIMultipartToJSONOperation cannot be gracefully re-enqueued if the access token is expired (and can be refreshed).
     // In order to minimize the risk of a failed request due to an expired access token, more aggressively check if it is expired, and refresh it manually
     // beforehand if necessary.
     if ([self.operation.session.accessTokenExpiration timeIntervalSinceNow] < 300) {
-        [self.operation.session performRefreshTokenGrant:self.operation.session.accessToken withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
-            if (error) {
-                completionBlock(nil, error);
-            } else {
-                perform();
-            }
-        }];
-    } else {
-        perform();
+        // We rely on our operations layer to block the upload request until this is done, because
+        // BOXParallelOAuth2Session cannot reliably call the completion block. (See TODO in [BOXParallelOAuth2Session:performRefreshTokenGrant:withCompletionBlock]
+        [self.operation.session performRefreshTokenGrant:self.operation.session.accessToken withCompletionBlock:nil];
     }
+    
+    if (progressBlock) {
+        uploadOperation.progressBlock = ^(unsigned long long totalBytes, unsigned long long bytesSent) {
+            [BOXDispatchHelper callCompletionBlock:^{
+                progressBlock(bytesSent, totalBytes);
+            } onMainThread:isMainThread];
+        };
+    }
+    
+    if (completionBlock) {
+        uploadOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
+            BOXFile *file = [[BOXFile alloc] initWithJSON:JSONDictionary];
+            [BOXDispatchHelper callCompletionBlock:^{
+                completionBlock(file, nil);
+            } onMainThread:isMainThread];
+        };
+        uploadOperation.failure = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSDictionary *JSONDictionary) {
+            [BOXDispatchHelper callCompletionBlock:^{
+                completionBlock(nil, error);
+            } onMainThread:isMainThread];
+        };
+    }
+    
+    [self performRequest];
 }
 
 #pragma mark - Helper Methods


### PR DESCRIPTION
1. Be in airplane mode with an expired token. The first refresh request will fail (expected), but
   will also block all future attempts to refresh the same token.
2. Turn off airplane mode. We won't attempt to refresh the token because we've already blacklisted
   it.

We've unconvered some technical debt:
- 'performRefreshTokenGrant' takes in a completion block but cannot actually handle calling it with
  meaningful data, in a parallel session. We whould either remove the completion block as a parameter
  to that method, or we need to implement the observer-notifier pattern.
