### PR TITLE
Remove an extra public property from the auth view controller interface

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.h
@@ -31,10 +31,6 @@
  */
 @interface BOXAuthorizationViewController : UIViewController
 
-/**
- * The authorization URL to be used.
- */
-@property (nonatomic, readwrite, strong) NSURL *authorizeURL;
 
 /** @name Initializers */
 

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.m
@@ -39,6 +39,7 @@ typedef void (^BOXAuthCancelBlock)(BOXAuthorizationViewController *authorization
 @property (nonatomic, readwrite, strong) BOXContentClient *SDKClient;
 @property (nonatomic, readwrite, copy) BOXAuthCompletionBlock completionBlock;
 @property (nonatomic, readwrite, copy) BOXAuthCancelBlock cancelBlock;
+@property (nonatomic, readwrite, strong) NSURL *authorizeURL;
 @property (nonatomic, readwrite, strong) NSString *redirectURI;
 @property (nonatomic, readwrite, strong) NSDictionary *headers;
 


### PR DESCRIPTION
Made the authorizeURL property private only.
