### PR TITLE
Issue #132: Unexpected type received while creating BOXMetadata

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.m
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.m
@@ -14,18 +14,18 @@
 {
     if (self = [super initWithJSON:JSONData]) {
         self.JSONData = JSONData;
-        
+
+        // NOTE: The set of default metadata keys (those that have '$' at the beginning) can
+        // change over time.
         self.modelID = [NSJSONSerialization box_ensureObjectForKey:BOXAPIMetadataObjectKeyID
                                                       inDictionary:JSONData
                                                    hasExpectedType:[NSString class]
-                                                       nullAllowed:NO
-                                                 suppressNullAsNil:NO];
+                                                       nullAllowed:NO];
         
         self.type = [NSJSONSerialization box_ensureObjectForKey:BOXAPIMetadataObjectKeyType
                                                    inDictionary:JSONData
                                                 hasExpectedType:[NSString class]
-                                                    nullAllowed:NO
-                                              suppressNullAsNil:NO];
+                                                    nullAllowed:NO];
         
         self.scope = [NSJSONSerialization box_ensureObjectForKey:BOXAPIMetadataObjectKeyScope
                                                     inDictionary:JSONData
@@ -43,14 +43,11 @@
                                                       nullAllowed:NO];
         
         // Retrieving all custom metadata information (key/value pairs).
-        NSMutableDictionary *info = [[NSMutableDictionary alloc]init];
+        NSMutableDictionary *info = [[NSMutableDictionary alloc] init];
         for (NSString *key in JSONData) {
-            NSString *value = [NSJSONSerialization box_ensureObjectForKey:key
-                                                             inDictionary:JSONData
-                                                          hasExpectedType:[NSString class]
-                                                              nullAllowed:NO];
             // Only default metadata keys have '$' at the beginning, so the ones that don't are custom metadata keys.
             if ([key characterAtIndex:0] != '$') {
+                NSString *value = [JSONData objectForKey:key];
                 [info setObject:value forKey:key];
             }
         }


### PR DESCRIPTION
Custom metadata information can be of multiple types, not just string.
