### PR TITLE
IOS-10522 Device pinning information is not included in API calls oth…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -168,9 +168,9 @@
 @property (nonatomic, readwrite, strong) NSString *redirectURIString;
 
 /**
- * Custom parameters to use in the token grant request. Optional, defaults to nil.
+ * Custom parameters to append to the POST method body. Optional, defaults to nil.
  */
-@property (nonatomic, readwrite, strong) NSDictionary *additionalTokenGrantParameters;
+@property (nonatomic, readwrite, strong) NSDictionary *additionalCustomDictionaryParameters;
 
 /**
  * Returns the randomly generated nonce used to prevent spoofing attack during login

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -106,9 +106,6 @@
                                                                                       BOXAuthTokenRequestClientSecretKey : self.clientSecret,
                                                                                       BOXAuthTokenRequestRedirectURIKey : self.redirectURIString,
                                                                                       }];
-    if (self.additionalTokenGrantParameters.count > 0) {
-        [POSTParams addEntriesFromDictionary:self.additionalTokenGrantParameters];
-    }
     
     BOXAPIOAuth2ToJSONOperation *operation = [[BOXAPIOAuth2ToJSONOperation alloc] initWithURL:[self grantTokensURL]
                                                                                    HTTPMethod:BOXAPIHTTPMethodPOST
@@ -213,10 +210,6 @@
                                                                                       BOXAuthTokenRequestClientIDKey : self.clientID,
                                                                                       BOXAuthTokenRequestClientSecretKey : self.clientSecret,
                                                                                       }];
-    
-    if (self.additionalTokenGrantParameters.count > 0) {
-        [POSTParams addEntriesFromDictionary:self.additionalTokenGrantParameters];
-    }
     
     BOXAPIOAuth2ToJSONOperation *operation = [[BOXAPIOAuth2ToJSONOperation alloc] initWithURL:self.grantTokensURL
                                                                                    HTTPMethod:BOXAPIHTTPMethodPOST

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
@@ -115,7 +115,7 @@ typedef void (^BOXAPIDataFailureBlock)(NSURLRequest *request, NSHTTPURLResponse 
  * @see [BOXAPIJSONOperation encodeBody:]
  * @see [BOXAPIMultipartToJSONOperation encodeBody:]
  */
-@property (nonatomic, readwrite, strong) NSDictionary *body;
+@property (nonatomic, readonly, strong) NSDictionary *body;
 
 /**
  * Key value pairs to be appended to baseRequestURL as part of the query string. Keys and values

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
@@ -97,14 +97,25 @@ static BOOL BoxOperationStateTransitionIsValid(BOXAPIOperationState fromState, B
     self = [super init];
     if (self != nil)
     {
+        
+        // If we are not a POST method, postParams will be nil and we will not add a body.
+        // If we are a POST method, all api calls will append our custom entries to the body prior to encoding.
+        NSMutableDictionary *POSTParams = [body mutableCopy];
+        if ([session isKindOfClass:[BOXOAuth2Session class]]) {
+            BOXOAuth2Session *currentSession = (BOXOAuth2Session *)session;
+            if (currentSession.additionalCustomDictionaryParameters.count > 0) {
+                [POSTParams addEntriesFromDictionary:currentSession.additionalCustomDictionaryParameters];
+            }
+        }
+        
         _baseRequestURL = URL;
-        _body = body;
+        _body = [POSTParams copy];
         _queryStringParameters = queryParams;
         _session = session;
 
         _APIRequest = nil;
         _connection = nil; // delay setting up the connection as long as possible so the authentication credentials remain fresh
-
+        
         NSMutableURLRequest *APIRequest = [NSMutableURLRequest requestWithURL:[self requestURLWithURL:_baseRequestURL queryStringParameters:_queryStringParameters]];
         APIRequest.HTTPMethod = HTTPMethod;
 


### PR DESCRIPTION
…er than auth

We are moving the token support for addition grant parameters into the BOXAPIOperations allowing all POST methods to append to the body for all calls.
