### PR TITLE
IOS-10592 Auth VC - Do not attempt to load UIWebView request until viewDidAppear.

### DIFF
--- a/box-ios-sdk-interfaces.podspec
+++ b/box-ios-sdk-interfaces.podspec
@@ -13,7 +13,7 @@ s.source                = { :git => "https://github.com/box/box-ios-sdk.git", :t
 
 # Platform
 
-s.ios.deployment_target = "7.0"
+s.ios.deployment_target = "8.0"
 
 # File patterns
 

--- a/box-ios-sdk-tests.podspec
+++ b/box-ios-sdk-tests.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   
   # Platform
 
-  s.ios.deployment_target = "7.0"
+  s.ios.deployment_target = "8.0"
 
   # File patterns
 

--- a/box-ios-sdk.podspec
+++ b/box-ios-sdk.podspec
@@ -12,7 +12,7 @@ s.source                = { :git => "https://github.com/box/box-ios-sdk.git", :t
 
 # Platform
 
-s.ios.deployment_target = "7.0"
+s.ios.deployment_target = "8.0"
 
 # File patterns
 


### PR DESCRIPTION
- If we attempt to load the request to soon we risk the VC not being in the view
  heirarchy yet, and so it makes it difficult to load alerts, respond to errors, etc.
- Use a UIAlertController for showing error alert instead of UIAlertView. Fire the
  completion handler with the error so that developers can respond.
- Update deployment target to iOS 8.0 (won't apply until we actually push to CocoaPods).
