### PR TITLE
Fix shared link storage for folders within a folder

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderPaginatedItemsRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderPaginatedItemsRequest.m
@@ -75,19 +75,9 @@
             for (NSDictionary *itemDictionary in itemDictionaries) {
                 BOXItem *item = [BOXRequest itemWithJSON:itemDictionary];
                 [items addObject:item];
-
-                NSArray *pathFolders = nil;
-
-                if ([item isKindOfClass:[BOXFile class]]) {
-                    pathFolders = [((BOXFile *)item) pathFolders];
-                } else if ([item isKindOfClass:[BOXFile class]]) {
-                    pathFolders = [((BOXFolder *) item) pathFolders];
-                } else if ([item isKindOfClass:[BOXBookmark class]]) {
-                    pathFolders = [((BOXBookmark *) item) pathFolders];
-                }
                 [self.sharedLinkHeadersHelper storeHeadersFromAncestorsIfNecessaryForItemWithID:item.modelID
                                                                                        itemType:item.type
-                                                                                      ancestors:pathFolders];
+                                                                                      ancestors:item.pathFolders];
             }
 
             if ([self.cacheClient respondsToSelector:@selector(cacheFolderPaginatedItemsRequest:withItems:limit:offset:error:)]) {


### PR DESCRIPTION
Changed class check for folders to BOXFolder instead of BOXFile.
