### PR TITLE
Add refreshDefaultClientFromKeychain

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -93,6 +93,13 @@
 + (BOXContentClient *)defaultClient;
 
 /**
+ *  Use this to refresh the default client based on the user currently stored in the keychain.
+ *  If there are no users in the keychain, this will log out the default client's current user.
+ *  NOTE: Currently not thread-safe.
+ */
++ (void)refreshDefaultClientFromKeychain;
+
+/**
  *  Get a BOXContentClient for a specific user that has an authenticated session. 
  *  You can obtain a list of users with through the 'users' method.
  *  NOTE: Unless you want to allow your app to manage multiple Box users at one time, it is simpler to use

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -72,6 +72,25 @@ static BOXContentClient *defaultInstance = nil;
     return defaultInstance;
 }
 
++ (void)refreshDefaultClientFromKeychain
+{
+    NSArray *usersFromKeychain = [BOXAbstractSession usersInKeychain];
+    
+    if (usersFromKeychain.count == 0)
+    {
+        [defaultInstance logOut];
+    }
+    else if (usersFromKeychain.count == 1)
+    {
+        BOXUserMini *storedUser = [usersFromKeychain firstObject];
+        [defaultInstance.session restoreCredentialsFromKeychainForUserWithID:storedUser.modelID];
+    }
+    else {
+        [NSException raise:@"You cannot use 'defaultClient' if multiple users have established a session."
+                    format:@"Specify a user through clientForUser:"];
+    }
+}
+
 + (BOXContentClient *)clientForUser:(BOXUserMini *)user
 {
     if (user == nil)


### PR DESCRIPTION
Add a method to reset the default client based on what is currently in the keychain. This is useful, for example, in a multi-process situation where one process logs out or changes the user, and other instances of the default client need to be updated to reflect the change.
