### PR TITLE
Introduced a new operation queue in our queue manager to allow more thumbnails to be downloaded in parallel.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
@@ -94,6 +94,13 @@ typedef void (^BOXAPIDataProgressBlock)(long long expectedTotalBytes, unsigned l
  */
 @property (nonatomic, readwrite, strong) BOXAPIDataProgressBlock progressBlock;
 
+
+/**
+ * Describes wether or not the operation is a small download such as a thumbnail retrieval.
+ * If it is, the operation will be run on a specific queue whose max concurrent operation count will be NSOperationQueueDefaultMaxConcurrentOperationCount
+ */
+@property (nonatomic, readwrite, assign) BOOL isSmallDownloadOperation;
+
 /**
  * Call success or failure depending on whether or not an error has occurred during the request.
  * @see successBlock

--- a/BoxContentSDK/BoxContentSDK/QueueManagers/BOXParallelAPIQueueManager.h
+++ b/BoxContentSDK/BoxContentSDK/QueueManagers/BOXParallelAPIQueueManager.h
@@ -48,6 +48,13 @@
  */
 @property (nonatomic, readwrite, strong) NSOperationQueue *uploadsQueue;
 
+/**
+ * The NSOperationQueue on which all small download operations such as thumbnail retrievals
+ * are enqueued. This queue is configured
+ * with `maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount`.
+ */
+@property (nonatomic, readwrite, strong) NSOperationQueue *smallDownloadsQueue;
+
 /** @name Designated initializer */
 
 /**

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileThumbnailRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileThumbnailRequest.m
@@ -67,7 +67,8 @@
                                                        failureBlock:nil];
     dataOperation.fileID = self.fileID;
     dataOperation.outputStream = self.outputStream;
-
+    dataOperation.isSmallDownloadOperation = YES;
+    
     [self addSharedLinkHeaderToRequest:dataOperation.APIRequest];
 
     return dataOperation;

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileDownloadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileDownloadRequestTests.m
@@ -141,6 +141,15 @@
     XCTAssertEqual(1 + numberOfIntermediate202Responses, numberOfOperationsEnqueued);
 }
 
+- (void)test_that_operation_is_not_marked_as_small_download
+{
+    BOXFileDownloadRequest *request = [[BOXFileDownloadRequest alloc] initWithLocalDestination:@"/dummy/path" fileID:@"123"];
+    BOXAPIOperation *operation = [request operation];
+    XCTAssert([operation isKindOfClass:[BOXAPIDataOperation class]]);
+    BOXAPIDataOperation *dataOperation = (BOXAPIDataOperation *)operation;
+    XCTAssert(dataOperation.isSmallDownloadOperation == NO);
+}
+
 #pragma mark - Error Handling
 
 - (void)test_that_invalid_grant_400_error_triggers_logout_notification

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileThumbnailRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileThumbnailRequestTests.m
@@ -98,6 +98,15 @@
     XCTAssertEqual(1 + numberOfIntermediate202Responses, numberOfOperationsEnqueued);
 }
 
+- (void)test_that_operation_is_marked_as_small_download
+{
+    BOXFileThumbnailRequest *request = [[BOXFileThumbnailRequest alloc] initWithFileID:@"123" size:BOXThumbnailSize64];
+    BOXAPIOperation *operation = [request operation];
+    XCTAssert([operation isKindOfClass:[BOXAPIDataOperation class]]);
+    BOXAPIDataOperation *dataOperation = (BOXAPIDataOperation *)operation;
+    XCTAssert(dataOperation.isSmallDownloadOperation);
+}
+
 #pragma mark - Private helper
 
 - (UIImage *)blankImageWithSize:(CGSize)size color:(UIColor *)color


### PR DESCRIPTION
This is fixing the thumbnail download performance issue that we're seeing in Flexo
