### PR TITLE
IOS-11233 Crashlytics reporting BOXISO8601DateFormatter race condition

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXAdditions.m
@@ -13,6 +13,7 @@
 
 + (NSDate *)box_dateWithISO8601String:(NSString *)timestamp
 {
+    static NSString *token = @"boxdateformatter";
     static BOXISO8601DateFormatter *dateFormatter;
     static dispatch_once_t pred;
     
@@ -28,7 +29,10 @@
     NSDate *returnDate = nil;
     if (timestamp != nil)
     {
-        returnDate = [dateFormatter dateFromString:timestamp];
+        // Add @synchronized because this is not thread safe
+        @synchronized(token) {
+            returnDate = [dateFormatter dateFromString:timestamp];
+        }
     }
     
     return returnDate;
@@ -36,6 +40,7 @@
 
 - (NSString *)box_ISO8601String
 {
+    static NSString *token = @"boxdateformatter";
     static BOXISO8601DateFormatter *dateFormatter;
     static dispatch_once_t pred;
     dispatch_once(&pred, ^{
@@ -46,7 +51,13 @@
         dateFormatter.defaultTimeZone = [[NSTimeZone alloc] initWithName:@"UTC"];
     });
     
-    return [dateFormatter stringFromDate:self];
+    NSString *dateString;
+    // Add @synchronized because this is not thread safe
+    @synchronized(token) {
+        dateString = [dateFormatter stringFromDate:self];
+    }
+    
+    return dateString;
 }
 
 @end


### PR DESCRIPTION
Apply TOT fix to box_dateWithISO8601String and also to our issue in box_ISO8601String. Crashing when we release the dateformatter being reference by a second thread.
