### PR TITLE
Set ISO8601DateFormatter to en_US_POSIX locale

### DIFF
--- a/BoxContentSDK/BoxContentSDK/External/ISO8601DateFormatter/BOXISO8601DateFormatter.m
+++ b/BoxContentSDK/BoxContentSDK/External/ISO8601DateFormatter/BOXISO8601DateFormatter.m
@@ -700,6 +700,7 @@ static BOOL is_leap_year(NSUInteger year);
 		unparsingFormatter = [[NSDateFormatter alloc] init];
 		unparsingFormatter.formatterBehavior = NSDateFormatterBehavior10_4;
 		unparsingFormatter.dateFormat = dateFormat;
+		unparsingFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
 		unparsingFormatter.calendar = unparsingCalendar;
 		unparsingFormatter.timeZone = timeZone;
 	}


### PR DESCRIPTION
We need to specify the locale of our date formatter to ensure we produce consistent results across a variety of device language and time settings. en_US_POSIX produces strings that satisfy RFC 3339.

See https://developer.apple.com/library/mac/qa/qa1480/_index.html
