### PR TITLE
Make sure the authorization header is set not added for requests

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.m
@@ -88,7 +88,7 @@ static NSString *staticKeychainAccessGroup;
 - (void)addAuthorizationParametersToRequest:(NSMutableURLRequest *)request
 {
     NSString *bearerToken = [NSString stringWithFormat:@"Bearer %@", self.accessToken];
-    [request addValue:bearerToken forHTTPHeaderField:BOXAPIHTTPHeaderAuthorization];
+    [request setValue:bearerToken forHTTPHeaderField:BOXAPIHTTPHeaderAuthorization];
 }
 
 #pragma mark - Keychain

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
@@ -60,7 +60,7 @@
     [super prepareAPIRequest];
     if ([self.HTTPMethod isEqualToString:BOXAPIHTTPMethodPOST] || [self.HTTPMethod isEqualToString:BOXAPIHTTPMethodPUT])
     {
-        [self.APIRequest addValue:BOX_API_CONTENT_TYPE_JSON forHTTPHeaderField:BOXAPIHTTPHeaderContentType];
+        [self.APIRequest setValue:BOX_API_CONTENT_TYPE_JSON forHTTPHeaderField:BOXAPIHTTPHeaderContentType];
     }
 }
 


### PR DESCRIPTION
There should only be one Bearer header entry for each authenticated request
