### PR TITLE
Change our categories naming to be +BOXContentSDKAdditions.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXContentSDKAdditions.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSDate (BOXAdditions)
+@interface NSDate (BOXContentSDKAdditions)
 
 + (NSDate *)box_dateWithISO8601String:(NSString *)timestamp;
 

--- a/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSDate+BOXContentSDKAdditions.m
@@ -6,10 +6,10 @@
 //  Copyright (c) 2014 Box. All rights reserved.
 //
 
-#import "NSDate+BOXAdditions.h"
+#import "NSDate+BOXContentSDKAdditions.h"
 #import "BoxISO8601DateFormatter.h"
 
-@implementation NSDate (BOXAdditions)
+@implementation NSDate (BOXContentSDKAdditions)
 
 + (NSDate *)box_dateWithISO8601String:(NSString *)timestamp
 {

--- a/BoxContentSDK/BoxContentSDK/Categories/NSError+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSError+BOXContentSDKAdditions.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface NSError (BOXAdditions)
+@interface NSError (BOXContentSDKAdditions)
 
 - (NSString *)box_localizedFailureReasonString;
 - (NSString *)box_localizedShortFailureReasonString;

--- a/BoxContentSDK/BoxContentSDK/Categories/NSError+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSError+BOXContentSDKAdditions.m
@@ -5,10 +5,10 @@
 //  Copyright (c) 2015 Box. All rights reserved.
 //
 
-#import "NSError+BOXAdditions.h"
+#import "NSError+BOXContentSDKAdditions.h"
 #import "BOXContentSDKErrors.h"
 
-@implementation NSError (BOXAdditions)
+@implementation NSError (BOXContentSDKAdditions)
 
 - (NSString *)box_localizedFailureReasonString
 {

--- a/BoxContentSDK/BoxContentSDK/Categories/NSJSONSerialization+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSJSONSerialization+BOXContentSDKAdditions.h
@@ -14,7 +14,7 @@
  *
  * This category is used by BoxModel subclasses to extract properties from [BoxModel rawResponseJSON].
  */
-@interface NSJSONSerialization (BOXAdditions)
+@interface NSJSONSerialization (BOXContentSDKAdditions)
 
 /** @name Reflection helpers */
 

--- a/BoxContentSDK/BoxContentSDK/Categories/NSJSONSerialization+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSJSONSerialization+BOXContentSDKAdditions.m
@@ -6,11 +6,11 @@
 //  Copyright (c) 2013 Box. All rights reserved.
 //
 
-#import "NSJSONSerialization+BOXAdditions.h"
+#import "NSJSONSerialization+BOXContentSDKAdditions.h"
 
 #import "BOXLog.h"
 
-@implementation NSJSONSerialization (BOXAdditions)
+@implementation NSJSONSerialization (BOXContentSDKAdditions)
 
 + (id)box_ensureObjectForKey:(NSString *)key inDictionary:(NSDictionary *)dictionary hasExpectedType:(Class)cls nullAllowed:(BOOL)nullAllowed
 {

--- a/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.h
@@ -12,7 +12,7 @@
  * The BoxAdditions category on NSString provides a method for
  * generating strings representing file size.
  */
-@interface NSString (BOXAdditions)
+@interface NSString (BOXContentSDKAdditions)
 
 /**
  * Returns a readable string of the size of the item.

--- a/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.m
@@ -11,9 +11,9 @@ long long const BOX_MEGABYTE = BOX_KILOBYTE * 1024;
 long long const BOX_GIGABYTE = BOX_MEGABYTE * 1024;
 long long const BOX_TERABYTE = BOX_GIGABYTE * 1024;
 
-#import "NSString+BOXAdditions.h"
+#import "NSString+BOXContentSDKAdditions.h"
 
-@implementation NSString (BOXAdditions)
+@implementation NSString (BOXContentSDKAdditions)
 
 + (NSString *)box_humanReadableStringForByteSize:(NSNumber *)size
 {

--- a/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface UIDevice (BOXAdditions)
+@interface UIDevice (BOXContentSDKAdditions)
 
 - (NSString *)detailedModelName;
 

--- a/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.m
@@ -6,10 +6,10 @@
 //  Copyright © 2016 Box. All rights reserved.
 //
 
-#import "UIDevice+BOXAdditions.h"
+#import "UIDevice+BOXContentSDKAdditions.h"
 #include <sys/sysctl.h>
 
-@implementation UIDevice (BOXAdditions)
+@implementation UIDevice (BOXContentSDKAdditions)
 
 /*
  From iOS 6.1 beta Downloads listing:

--- a/BoxContentSDK/BoxContentSDK/Models/BOXModel.h
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXModel.h
@@ -5,8 +5,8 @@
 //
 
 #import "BOXContentSDKConstants.h"
-#import "NSJSONSerialization+BOXAdditions.h"
-#import "NSDate+BOXAdditions.h"
+#import "NSJSONSerialization+BOXContentSDKAdditions.h"
+#import "NSDate+BOXContentSDKAdditions.h"
 #import "BOXLog.h"
 
 /**

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -16,7 +16,7 @@
 #import "BOXKeychainItemWrapper.h"
 #import "BOXUserRequest.h"
 #import "BOXUser_Private.h"
-#import "NSDate+BOXAdditions.h"
+#import "NSDate+BOXContentSDKAdditions.h"
 #import "BOXAbstractSession_Private.h"
 
 #define keychainRefreshTokenKey @"refresh_token"

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
@@ -4,7 +4,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "NSDate+BOXAdditions.h"
+#import "NSDate+BOXContentSDKAdditions.h"
 
 @class BOXCollaboration;
 @class BOXFile;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
@@ -12,8 +12,8 @@
 #import "BOXContentSDKErrors.h"
 #import "BOXISO8601DateFormatter.h"
 #import "BOXAppUserSession.h"
-#import "NSString+BOXAdditions.h"
-#import "UIDevice+BOXAdditions.h"
+#import "NSString+BOXContentSDKAdditions.h"
+#import "UIDevice+BOXContentSDKAdditions.h"
 
 #define BOX_API_MULTIPART_FILENAME_DEFAULT (@"upload")
 


### PR DESCRIPTION
This allows better identifications of dependencies and better identification of where the imported code lives.
