### PR TITLE
Move methods that are used across our SDKs and our app into the BOXContentSDKAdditions UIDevice category.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIDevice+BOXContentSDKAdditions.h
@@ -8,8 +8,30 @@
 
 #import <UIKit/UIKit.h>
 
+typedef NS_ENUM(NSUInteger, BOXiOSVersion) {
+    BOXiOSVersionUnknown,
+    BOXiOSVersionTooOld,
+    BOXiOSVersion7,
+    BOXiOSVersion7_1,
+    BOXiOSVersion8,
+    BOXiOSVersion9,
+    BOXiOSVersionLatest
+};
+
 @interface UIDevice (BOXContentSDKAdditions)
 
++ (BOXiOSVersion)iOSVersion;
+
++ (BOOL)isSingleCore;
+- (BOOL)isIpad;
+- (BOOL)isIphone;
+- (BOOL)isRunningiOS71;
+- (BOOL)isRunningiOS7xOrEarlier;
+
+- (NSString *)deviceName;
+
+- (NSString *)modelID;
+- (NSString *)deviceTypeString;
 - (NSString *)detailedModelName;
 
 @end


### PR DESCRIPTION
This will allow us to remove duplicates categories and methods in the preview sdk and our app.
