### PR TITLE
Uncomment out a test case

### DIFF
--- a/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
@@ -790,7 +790,6 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-/*
 - (void)test_that_invalid_token_401_error_does_not_trigger_logout_notification
 {
     NSString *fileNameOnServer = @"tempFile.txt";
@@ -821,6 +820,5 @@
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
- */
 
 @end


### PR DESCRIPTION
Crash only seems to be occurring locally, not when run by Travis CI. We should leave it in to make sure the test is run.
