### PR TITLE
Revert "Update Travis CI script to latest image"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c
 before_install:
   - gem install xcpretty
-osx_image: xcode7.3
+  - gem install cocoapods -v '0.38.2'
+podfile: BoxContentSDK/Podfile
+osx_image: xcode6.4
 script: 
-  - xcodebuild test -scheme BoxContentSDKTests -sdk iphonesimulator9.3 -workspace BoxContentSDK/BoxContentSDK.xcworkspace -configuration Debug  | xcpretty -c && exit ${PIPESTATUS[0]}
+  - xcodebuild test -scheme BoxContentSDKTests -sdk iphonesimulator8.4 -workspace BoxContentSDK/BoxContentSDK.xcworkspace -configuration Debug  | xcpretty -c && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This reverts commit 65b637bcb2d24c9dbaa80173b7e3aa71ef382ae5.

Travis CI doesn't seem to be stable on Xcode 7, so reverting this for now to unblock testing.
