### PR TITLE
Allow specifying token expiration time when retrieving new tokens

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -81,6 +81,10 @@ extern NSString *const BOXAuthTokenRequestRefreshTokenKey;
 extern NSString *const BOXAuthTokenRequestClientIDKey;
 extern NSString *const BOXAuthTokenRequestClientSecretKey;
 extern NSString *const BOXAuthTokenRequestRedirectURIKey;
+extern NSString *const BOXAuthTokenRequestDeviceIDKey;
+extern NSString *const BOXAuthTokenRequestDeviceNameKey;
+extern NSString *const BOXAuthTokenRequestAccessTokenExpiresAtKey;
+extern NSString *const BOXAuthTokenRequestRefreshTokenExpiresAtKey;
 
 extern NSString *const BOXAuthTokenRequestGrantTypeAuthorizationCode;
 extern NSString *const BOXAuthTokenRequestGrantTypeRefreshToken;

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
@@ -76,6 +76,10 @@ NSString *const BOXAuthTokenRequestRefreshTokenKey = @"refresh_token";
 NSString *const BOXAuthTokenRequestClientIDKey = @"client_id";
 NSString *const BOXAuthTokenRequestClientSecretKey = @"client_secret";
 NSString *const BOXAuthTokenRequestRedirectURIKey = @"redirect_uri";
+NSString *const BOXAuthTokenRequestDeviceIDKey = @"box_device_id";
+NSString *const BOXAuthTokenRequestDeviceNameKey = @"box_device_name";
+NSString *const BOXAuthTokenRequestAccessTokenExpiresAtKey = @"box_access_token_expires_at";
+NSString *const BOXAuthTokenRequestRefreshTokenExpiresAtKey = @"box_refresh_token_expires_at";
 
 NSString *const BOXAuthTokenRequestGrantTypeAuthorizationCode = @"authorization_code";
 NSString *const BOXAuthTokenRequestGrantTypeRefreshToken = @"refresh_token";

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -203,8 +203,29 @@
  * token cannot be exchanged for a new set of tokens (for example if it has been revoked or is expired)
  *
  * @param expiredAccessToken The access token that expired.
+ * @param block              The completion block to be called when the token refresh has finished.
  */
 - (void)performRefreshTokenGrant:(NSString *)expiredAccessToken withCompletionBlock:(void(^)(BOXOAuth2Session *session, NSError *error))block;
+
+/**
+ * This method exchanges a refresh token for a new access token and refresh token with specific expiration times.
+ * Expiration times must be sooner than the defaults of 60 minutes for the access token and 60 days for the refresh token.
+ *
+ * This method should send the `BOXAuthSessionDidRefreshTokensNotification` notification upon successfully
+ * exchanging a refresh token for a new access token and refresh token.
+ *
+ * This method should send the `BOXAuthSessionDidReceiveRefreshErrorNotification` notification if a refresh
+ * token cannot be exchanged for a new set of tokens (for example if it has been revoked or is expired)
+ *
+ * @param expiredAccessToken                The access token that expired.
+ * @param accessTokenExpirationTimestamp    Unix timestamp for when the access token should expire (or nil for the default).
+ * @param refreshTokenExpirationTimestamp   Unix timestamp for when the refresh token should expire (or nil for the default).
+ * @param block                             The completion block to be called when the token refresh has finished.
+ */
+- (void)performRefreshTokenGrant:(NSString *)expiredAccessToken
+      newAccessTokenExpirationAt:(NSNumber *)accessTokenExpirationTimestamp
+     newRefreshTokenExpirationAt:(NSNumber *)refreshTokenExpirationTimestamp
+             withCompletionBlock:(void (^)(BOXOAuth2Session *session, NSError *error))block;
 
 #pragma mark Token Helpers
 /** @name Token Helpers */

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -39,6 +39,17 @@
 
 - (void)performRefreshTokenGrant:(NSString *)expiredAccessToken withCompletionBlock:(void(^)(BOXOAuth2Session *session, NSError *error))block
 {
+    [self performRefreshTokenGrant:expiredAccessToken
+        newAccessTokenExpirationAt:nil
+       newRefreshTokenExpirationAt:nil
+               withCompletionBlock:block];
+}
+
+- (void)performRefreshTokenGrant:(NSString *)expiredAccessToken
+      newAccessTokenExpirationAt:(NSString *)accessTokenExpirationTimestamp
+     newRefreshTokenExpirationAt:(NSString *)refreshTokenExpirationTimestamp
+             withCompletionBlock:(void (^)(BOXOAuth2Session *session, NSError *error))block
+{
     @synchronized(self)
     {
         if ([self.expiredOAuth2Tokens containsObject:expiredAccessToken])
@@ -60,7 +71,10 @@
             [self.expiredOAuth2Tokens addObject:expiredAccessToken];
         }
         
-        [super performRefreshTokenGrant:expiredAccessToken withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
+        [super performRefreshTokenGrant:expiredAccessToken
+             newAccessTokenExpirationAt:accessTokenExpirationTimestamp
+            newRefreshTokenExpirationAt:refreshTokenExpirationTimestamp
+                    withCompletionBlock:^(BOXAbstractSession *session, NSError *error) {
             if (expiredAccessToken.length > 0 && error != nil && ![self isInvalidGrantError:error]) {
                 // If there was an error, remove from 'expiredOAuth2Tokens' so that we can try again. For example, if there was a network
                 // error, then we would not want to block ourselves from trying to refresh the tokens again later.


### PR DESCRIPTION
The API now allows you to specify what time the access token and refresh token will expire.
