### PR TITLE
Call completion block after BOXParallelOAuth2Session token refresh

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -82,6 +82,10 @@
                 // case, we don't want to ever try refreshing that again.
                 [self.expiredOAuth2Tokens removeObject:expiredAccessToken];
             }
+                        
+            if (block) {
+                block(session, error);
+            }
         }];
     }
 }


### PR DESCRIPTION
Previously, the completion block would only be called if there was already an existing refresh in progress.
