### PR TITLE
Resolve an issue with the default behavior for safe extension compilation

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.h
@@ -8,7 +8,8 @@
 
 /**
  *  This category's purpose is to allow successful compilation when using BOXContentSDK in an extension.
- *  If the target you're running is not an extension extension, simply add the build flag TARGET_IS_NOT_EXTENSION to it to avoid any build failures because of unsafe API calls.
+ *  If the target is an extension, simply add the build flag BOX_TARGET_IS_EXTENSION to it to avoid any
+ *  build failures because of unsafe API calls.
  */
 @interface UIApplication (ExtensionSafeAdditions)
 

--- a/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.m
@@ -10,7 +10,7 @@
 
 + (UIApplication *)box_sharedApplication
 {
-#ifdef TARGET_IS_NOT_EXTENSION
+#ifndef BOX_TARGET_IS_EXTENSION
     // If we are compiling from a non-extension target, use the regular sharedApplication.
     return [UIApplication sharedApplication];
 #else
@@ -21,7 +21,7 @@
 
 - (BOOL)box_canOpenURL:(NSURL *)url
 {
-#ifdef TARGET_IS_NOT_EXTENSION
+#ifndef BOX_TARGET_IS_EXTENSION
     // If we are compiling from a non-extension target, use the regular sharedApplication.
     return [[UIApplication sharedApplication] canOpenURL:url];
 #else
@@ -32,7 +32,7 @@
 
 - (BOOL)box_openURL:(NSURL*)url
 {
-#ifdef TARGET_IS_NOT_EXTENSION
+#ifndef BOX_TARGET_IS_EXTENSION
     // If we are compiling from a non-extension target, use the regular sharedApplication.
     return [[UIApplication sharedApplication] openURL:url];
 #else


### PR DESCRIPTION
Make the app-level behavior the default and extension behavior declarable
via pre-processor const.
This also fixes the functionality of the sample app.
