### PR TITLE
Update the UIApplication category to be truly extension safe if the box-ios-sdk is used as a dylib.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.h
+++ b/BoxContentSDK/BoxContentSDK/Categories/UIApplication+ExtensionSafeAdditions.h
@@ -8,8 +8,6 @@
 
 /**
  *  This category's purpose is to allow successful compilation when using BOXContentSDK in an extension.
- *  If the target is an extension, simply add the build flag BOX_TARGET_IS_EXTENSION to it to avoid any
- *  build failures because of unsafe API calls.
  */
 @interface UIApplication (ExtensionSafeAdditions)
 
@@ -18,5 +16,7 @@
 - (BOOL)box_openURL:(NSURL *)url;
 
 - (BOOL)box_canOpenURL:(NSURL *)url;
+
+- (UIWindow *)box_window;
 
 @end


### PR DESCRIPTION
If compiling with `APPLICATION_EXTENSION_API_ONLY` set to `YES` and using the SDK as a pod, compilation would fail as calls to `sharedApplication` would be detected by the compiler, even with build flags checks.
