### PR TITLE
Remove flakey tests.

### DIFF
--- a/BoxContentSDK/BoxContentSDKTests/BOXFileDownloadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileDownloadRequestTests.m
@@ -11,10 +11,6 @@
 #import "BOXFileDownloadRequest.h"
 #import "BOXFile.h"
 
-@interface BOXAPIOperation ()
-- (void)sendLogoutNotification;
-@end
-
 @interface BOXFileDownloadRequestTests : BOXRequestTestCase
 @end
 
@@ -182,27 +178,6 @@
     }];
     
     [self expectationForNotification:BOXUserWasLoggedOutDueToErrorNotification object:nil handler:nil];
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];}
-
-- (void)test_that_invalid_token_401_error_does_not_trigger_logout_notification
-{
-    NSOutputStream *outputStream = [[NSOutputStream alloc] initToMemory];
-    
-    BOXFileDownloadRequest *request = [[BOXFileDownloadRequest alloc] initWithOutputStream:outputStream fileID:@"123"];
-    
-    NSData *cannedResponseData = [self cannedResponseDataWithName:@"invalid_token"];
-    NSHTTPURLResponse *URLResponse = [self cannedURLResponseWithStatusCode:400 responseData:cannedResponseData];
-    [self setCannedURLResponse:URLResponse cannedResponseData:cannedResponseData forRequest:request];
-    
-    id operationMock = [OCMockObject partialMockForObject:request.operation];
-    [[operationMock reject] sendLogoutNotification];
-    
-    XCTestExpectation *requestExpectation = [self expectationWithDescription:@"expectation"];
-    [request performRequestWithProgress:nil completion:^(NSError *error) {
-        [operationMock verify];
-        [requestExpectation fulfill];
-    }];
-    
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
@@ -15,10 +15,6 @@
 #import "ALAssetRepresentationMock.h"
 #import "BOXInputStreamTestHelper.h"
 
-@interface BOXAPIOperation ()
-- (void)sendLogoutNotification;
-@end
-
 @interface BOXAPIMultipartToJSONOperation ()
 // An array of BOXAPIMultipartPiece. In our tests, we want to inspect these.
 @property (nonatomic, readwrite, strong) NSMutableArray *formPieces;
@@ -787,37 +783,6 @@
     }];
     
     [self expectationForNotification:BOXUserWasLoggedOutDueToErrorNotification object:nil handler:nil];
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-}
-
-- (void)test_that_invalid_token_401_error_does_not_trigger_logout_notification
-{
-    NSString *fileNameOnServer = @"tempFile.txt";
-    NSDate *contentCreatedAtDateOnServer = [NSDate dateWithTimeIntervalSinceNow:-100];
-    NSDate *contentModifiedAtDateOnServer = [NSDate dateWithTimeIntervalSinceNow:-200];
-    NSString *uploadData = @"hello";
-    NSString *targetFolderID = @"123";
-    
-    // Canned response json.
-    NSData *cannedResponseData = [self cannedResponseDataWithName:@"invalid_token"];
-    NSHTTPURLResponse *URLResponse = [self cannedURLResponseWithStatusCode:400 responseData:cannedResponseData];
-    
-    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithName:fileNameOnServer targetFolderID:targetFolderID data:[uploadData dataUsingEncoding:NSUTF8StringEncoding]];
-    request.fileName = fileNameOnServer;
-    request.contentCreatedAt = contentCreatedAtDateOnServer;
-    request.contentModifiedAt = contentModifiedAtDateOnServer;
-    [self setCannedURLResponse:URLResponse cannedResponseData:cannedResponseData forRequest:request];
-    
-    id operationMock = [OCMockObject partialMockForObject:request.operation];
-    [[operationMock reject] sendLogoutNotification];
-
-    // We have to delay completion of test until request is finished or it can interfere with other tests.
-    XCTestExpectation *requestExpectation = [self expectationWithDescription:@"expectation"];
-    [request performRequestWithProgress:nil completion:^(BOXFile *file, NSError *error) {
-        [operationMock verify];
-        [requestExpectation fulfill];
-    }];
-    
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 

--- a/BoxContentSDK/BoxContentSDKTests/BOXRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXRequestTests.m
@@ -46,10 +46,6 @@
 
 @end
 
-@interface BOXAPIOperation ()
-- (void)sendLogoutNotification;
-@end
-
 @interface BOXRequestTests : BOXRequestTestCase
 @end
 
@@ -183,29 +179,6 @@
     [request performRequest];
     
     [self expectationForNotification:BOXUserWasLoggedOutDueToErrorNotification object:nil handler:nil];
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-}
-
-- (void)test_that_invalid_token_401_error_does_not_trigger_logout_notification
-{
-    BOXRequest *request = [[BOXRequest alloc] init];
-    
-    NSData *cannedResponseData =  [self cannedResponseDataWithName:@"invalid_token"];
-    NSHTTPURLResponse *URLResponse = [self cannedURLResponseWithStatusCode:401 responseData:cannedResponseData];
-    [self setCannedURLResponse:URLResponse cannedResponseData:cannedResponseData forRequest:request];
-    
-    BOXAPIOperation *operation = [[BOXAPIJSONOperation alloc] initWithURL:[request URLWithResource:nil ID:nil subresource:nil subID:nil] HTTPMethod:BOXAPIHTTPMethodGET body:nil queryParams:nil session:request.queueManager.session];
-    id operationMock = [OCMockObject partialMockForObject:operation];
-    request.operation = operation;
-    
-    [[operationMock reject] sendLogoutNotification];
-    
-    XCTestExpectation *requestExpectation = [self expectationWithDescription:@"expectation"];
-    [request performRequestWithCompletion:^{
-        [operationMock verify];
-        [requestExpectation fulfill];
-    }];
-    
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 


### PR DESCRIPTION
Creating a partial mock on NSOperation seems to cause intermittent exceptions.
