### PR TITLE
IOS-12165: fix crash upon launching EMM because we try to extract use…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -237,10 +237,12 @@ static BOXContentClient *defaultInstance = nil;
 
 - (void)didReceiveUserWasLoggedOutNotification:(NSNotification *)notification
 {
-    NSDictionary *userInfo = (NSDictionary *)notification.object;
-    NSString *userID = [userInfo objectForKey:BOXUserIDKey];
-    if ([userID isEqualToString:self.user.modelID]) {
-        [self logOut];
+    if ([notification.object isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *userInfo = (NSDictionary *)notification.object;
+        NSString *userID = [userInfo objectForKey:BOXUserIDKey];
+        if ([userID isEqualToString:self.user.modelID]) {
+            [self logOut];
+        }
     }
 }
 


### PR DESCRIPTION
…rID from a string userInfo
