### PR TITLE
IOS-13281 migrating capture to tot.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDK.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDK.h
@@ -100,6 +100,7 @@
 #import "BOXMetadataCreateRequest.h"
 #import "BOXMetadataUpdateRequest.h"
 #import "BOXMetadataTemplateRequest.h"
+#import "BOXStreamOperation.h"
 
 // API Operation queues
 #import "BOXAPIQueueManager.h"


### PR DESCRIPTION
A contentSDK header is being exposed directly in the preview SDK. To remove, we need to add the content sdk header to the main header. BOXStreamOperation.h