### PR TITLE
multiple commits to support non-background/background uploads with NS…

### DIFF
--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -204,10 +204,8 @@
 		596C9E001BCDBE8B00D85F19 /* BOXContentCacheClientProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 596C9DFF1BCDBE8B00D85F19 /* BOXContentCacheClientProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		59AB005E1A3943BD005A6D89 /* BOXFolderPaginatedItemsRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 59AB005D1A3943BD005A6D89 /* BOXFolderPaginatedItemsRequestTests.m */; };
 		59C8E3351BEAC0DE005FA4BB /* empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 59C8E3341BEAC0DE005FA4BB /* empty.json */; };
-		6A48930F1E049419008E30BE /* BOXNSURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A48930D1E049419008E30BE /* BOXNSURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6A4893101E049419008E30BE /* BOXNSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A48930E1E049419008E30BE /* BOXNSURLSessionManager.m */; };
-		6A4893131E049445008E30BE /* BOXNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A4893111E049445008E30BE /* BOXNSURLSessionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6A4893141E049445008E30BE /* BOXNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4893121E049445008E30BE /* BOXNSURLSessionDelegate.m */; };
+		6A48930F1E049419008E30BE /* BOXURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A48930D1E049419008E30BE /* BOXURLSessionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A4893101E049419008E30BE /* BOXURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A48930E1E049419008E30BE /* BOXURLSessionManager.m */; };
 		6AA425711E39743800EF2677 /* BOXURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */; };
 		6AA425721E39743800EF2677 /* BOXURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */; };
 		700C39371ACB455E00466CA9 /* BOXFolderItemsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 700C39351ACB455E00466CA9 /* BOXFolderItemsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -681,10 +679,8 @@
 		596C9DFF1BCDBE8B00D85F19 /* BOXContentCacheClientProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BOXContentCacheClientProtocol.h; path = Protocols/BOXContentCacheClientProtocol.h; sourceTree = "<group>"; };
 		59AB005D1A3943BD005A6D89 /* BOXFolderPaginatedItemsRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXFolderPaginatedItemsRequestTests.m; sourceTree = "<group>"; };
 		59C8E3341BEAC0DE005FA4BB /* empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = empty.json; sourceTree = "<group>"; };
-		6A48930D1E049419008E30BE /* BOXNSURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXNSURLSessionManager.h; sourceTree = "<group>"; };
-		6A48930E1E049419008E30BE /* BOXNSURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXNSURLSessionManager.m; sourceTree = "<group>"; };
-		6A4893111E049445008E30BE /* BOXNSURLSessionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXNSURLSessionDelegate.h; sourceTree = "<group>"; };
-		6A4893121E049445008E30BE /* BOXNSURLSessionDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXNSURLSessionDelegate.m; sourceTree = "<group>"; };
+		6A48930D1E049419008E30BE /* BOXURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXURLSessionManager.h; sourceTree = "<group>"; };
+		6A48930E1E049419008E30BE /* BOXURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXURLSessionManager.m; sourceTree = "<group>"; };
 		6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXURLRequestSerialization.h; sourceTree = "<group>"; };
 		6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXURLRequestSerialization.m; sourceTree = "<group>"; };
 		700C39351ACB455E00466CA9 /* BOXFolderItemsRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXFolderItemsRequest.h; sourceTree = "<group>"; };
@@ -1389,10 +1385,8 @@
 				862EF28D1B1FBA880044526F /* BOXAppUserSession.h */,
 				862EF28E1B1FBA880044526F /* BOXAppUserSession.m */,
 				862EF2921B1FE7650044526F /* BOXAbstractSession_Private.h */,
-				6A48930D1E049419008E30BE /* BOXNSURLSessionManager.h */,
-				6A48930E1E049419008E30BE /* BOXNSURLSessionManager.m */,
-				6A4893111E049445008E30BE /* BOXNSURLSessionDelegate.h */,
-				6A4893121E049445008E30BE /* BOXNSURLSessionDelegate.m */,
+				6A48930D1E049419008E30BE /* BOXURLSessionManager.h */,
+				6A48930E1E049419008E30BE /* BOXURLSessionManager.m */,
 			);
 			name = Sessions;
 			sourceTree = "<group>";
@@ -1699,7 +1693,7 @@
 				150C27981A69C2DE00099850 /* BOXContentClient+SharedLink.h in Headers */,
 				15280E3E1A37E70B008D4F5D /* BOXBookmark.h in Headers */,
 				0E5E14651A40F82800B205F6 /* BOXCollaborationRequest.h in Headers */,
-				6A48930F1E049419008E30BE /* BOXNSURLSessionManager.h in Headers */,
+				6A48930F1E049419008E30BE /* BOXURLSessionManager.h in Headers */,
 				C59605591CC5917E0096DD59 /* UIDevice+BOXContentSDKAdditions.h in Headers */,
 				700C39371ACB455E00466CA9 /* BOXFolderItemsRequest.h in Headers */,
 				E1CAD4DB1A16C85C006ECAFD /* BOXFolderDeleteRequest.h in Headers */,
@@ -1766,7 +1760,6 @@
 				0E16F1541A4A042F00BDDA21 /* BOXTrashedItemArrayRequest.h in Headers */,
 				C5972A981A408CAE00225CBA /* BOXEvent.h in Headers */,
 				E1DD60351A3A8DBD00C4BD41 /* BOXBookmarkUnshareRequest.h in Headers */,
-				6A4893131E049445008E30BE /* BOXNSURLSessionDelegate.h in Headers */,
 				86B18F061B2428E3000EAE8C /* BOXAPIOperation_Private.h in Headers */,
 				C53EC2441A3873090007C8A7 /* BOXComment.h in Headers */,
 				C53EC29C1A389FAE0007C8A7 /* BOXCommentRequest.h in Headers */,
@@ -2130,7 +2123,7 @@
 				8676E0CA1B2E36F200AC2677 /* BOXMetadataCreateRequest.m in Sources */,
 				C5972A401A3B313700225CBA /* BOXCollection.m in Sources */,
 				3DE35CAD1A5B57B500694F6D /* BOXFileVersionPromoteRequest.m in Sources */,
-				6A4893101E049419008E30BE /* BOXNSURLSessionManager.m in Sources */,
+				6A4893101E049419008E30BE /* BOXURLSessionManager.m in Sources */,
 				C59605601CC5917E0096DD59 /* NSJSONSerialization+BOXContentSDKAdditions.m in Sources */,
 				E4FAD9DB172CE2C50052AD11 /* BOXAPIAuthenticatedOperation.m in Sources */,
 				15958E281A14338A00AEBCEE /* BOXFileUploadRequest.m in Sources */,
@@ -2218,7 +2211,6 @@
 				0E16F1131A426AB200BDDA21 /* BOXGroup.m in Sources */,
 				E1CAD4E91A16F262006ECAFD /* BOXUserRequest.m in Sources */,
 				0E16F1201A43774C00BDDA21 /* BOXCollaborationPendingRequest.m in Sources */,
-				6A4893141E049445008E30BE /* BOXNSURLSessionDelegate.m in Sources */,
 				E1CAD4DC1A16C85C006ECAFD /* BOXFolderDeleteRequest.m in Sources */,
 				E1DD60361A3A8DBD00C4BD41 /* BOXBookmarkUnshareRequest.m in Sources */,
 				E1CAD4D81A16C85C006ECAFD /* BOXFileDownloadRequest.m in Sources */,

--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -208,6 +208,8 @@
 		6A4893101E049419008E30BE /* BOXNSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A48930E1E049419008E30BE /* BOXNSURLSessionManager.m */; };
 		6A4893131E049445008E30BE /* BOXNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A4893111E049445008E30BE /* BOXNSURLSessionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6A4893141E049445008E30BE /* BOXNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4893121E049445008E30BE /* BOXNSURLSessionDelegate.m */; };
+		6AA425711E39743800EF2677 /* BOXURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */; };
+		6AA425721E39743800EF2677 /* BOXURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */; };
 		700C39371ACB455E00466CA9 /* BOXFolderItemsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 700C39351ACB455E00466CA9 /* BOXFolderItemsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		700C39381ACB455E00466CA9 /* BOXFolderItemsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 700C39361ACB455E00466CA9 /* BOXFolderItemsRequest.m */; };
 		704DBA211AD1F7D8001E28BB /* get_items_3_5_duped.json in Resources */ = {isa = PBXBuildFile; fileRef = 704DBA201AD1F7D8001E28BB /* get_items_3_5_duped.json */; };
@@ -683,6 +685,8 @@
 		6A48930E1E049419008E30BE /* BOXNSURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXNSURLSessionManager.m; sourceTree = "<group>"; };
 		6A4893111E049445008E30BE /* BOXNSURLSessionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXNSURLSessionDelegate.h; sourceTree = "<group>"; };
 		6A4893121E049445008E30BE /* BOXNSURLSessionDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXNSURLSessionDelegate.m; sourceTree = "<group>"; };
+		6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXURLRequestSerialization.h; sourceTree = "<group>"; };
+		6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXURLRequestSerialization.m; sourceTree = "<group>"; };
 		700C39351ACB455E00466CA9 /* BOXFolderItemsRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXFolderItemsRequest.h; sourceTree = "<group>"; };
 		700C39361ACB455E00466CA9 /* BOXFolderItemsRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXFolderItemsRequest.m; sourceTree = "<group>"; };
 		704DBA201AD1F7D8001E28BB /* get_items_3_5_duped.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get_items_3_5_duped.json; sourceTree = "<group>"; };
@@ -1370,6 +1374,8 @@
 				C562DB1A1A44666E0002E510 /* BOXSharedLinkHeadersHelper.m */,
 				C562DB481A4831270002E510 /* BOXSharedLinkHeadersDefaultManager.h */,
 				C562DB491A4831270002E510 /* BOXSharedLinkHeadersDefaultManager.m */,
+				6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */,
+				6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -1735,6 +1741,7 @@
 				0ED881AC1A5F4793009FED90 /* BOXAPIJSONPatchOperation.h in Headers */,
 				155170BA1A54872D004C00AF /* BOXFileVersion.h in Headers */,
 				E4FAD9DA172CE2C50052AD11 /* BOXAPIAuthenticatedOperation.h in Headers */,
+				6AA425711E39743800EF2677 /* BOXURLRequestSerialization.h in Headers */,
 				15280E441A37E70B008D4F5D /* BOXFile.h in Headers */,
 				E4FAD9DC172CE2C50052AD11 /* BOXAPIDataOperation.h in Headers */,
 				0E16F11F1A43774C00BDDA21 /* BOXCollaborationPendingRequest.h in Headers */,
@@ -2160,6 +2167,7 @@
 				862EF2901B1FBA880044526F /* BOXAppUserSession.m in Sources */,
 				0E5E14721A4116EA00B205F6 /* BOXContentClient+Collaboration.m in Sources */,
 				15280E601A37E70B008D4F5D /* BOXUser.m in Sources */,
+				6AA425721E39743800EF2677 /* BOXURLRequestSerialization.m in Sources */,
 				E18896EB1A3BBA30007F7330 /* BOXRequestWithSharedLinkHeader.m in Sources */,
 				E4FAD9E7172CE2C50052AD11 /* BOXAPIQueueManager.m in Sources */,
 				E4FAD9E9172CE2C50052AD11 /* BOXSerialAPIQueueManager.m in Sources */,

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDK.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDK.h
@@ -35,7 +35,7 @@
 #import "BOXOAuth2Session.h"
 #import "BOXParallelOAuth2Session.h"
 #import "BOXAppUserSession.h"
-#import "BOXNSURLSessionManager.h"
+#import "BOXURLSessionManager.h"
 
 // AppToApp
 

--- a/BoxContentSDK/BoxContentSDK/BOXNSURLSessionManager.h
+++ b/BoxContentSDK/BoxContentSDK/BOXNSURLSessionManager.h
@@ -56,6 +56,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@protocol BOXNSURLSessionUploadTaskDelegate <BOXNSURLSessionTaskDelegate>
+
+@optional
+
+/**
+ * To be called to report ongoing progress of the task
+ */
+- (void)progressWithTotalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
+
+
+@end
+
 @protocol BOXNSURLSessionManagerDelegate <NSObject>
 
 /**
@@ -69,6 +81,13 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite;
  * Sent when a download session task has finish downloading into a url location
  */
 - (void)downloadTask:(NSURLSessionTask *)sessionTask didFinishDownloadingToURL:(NSURL *)location;
+
+/**
+ * Notify delegate about upload progress
+ */
+- (void)uploadTask:(NSURLSessionDataTask *)sessionTask
+    totalBytesSent:(int64_t)totalBytesSent
+totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 
 /**
  * Sent when a session task finishes
@@ -111,12 +130,17 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite;
 /**
  Create a NSURLSessionDownloadTask to be resumed
  */
-- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithResumeData:(NSData *)resumeData;
+- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithResumeData:(NSData *)resumeData taskDelegate:(id <BOXNSURLSessionDownloadTaskDelegate>)taskDelegate;
 
 /**
  Create a NSURLSessionUploadTask which can be run in background
  */
-- (NSURLSessionUploadTask *)createBackgroundUploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL;
+- (NSURLSessionUploadTask *)createBackgroundUploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL taskDelegate:(id <BOXNSURLSessionUploadTaskDelegate>)taskDelegate;
+
+/**
+ Create a non-background upload task given stream request
+ */
+- (NSURLSessionUploadTask *)createNonBackgroundUploadTaskWithStreamedRequest:(NSURLRequest *)request taskDelegate:(id <BOXNSURLSessionUploadTaskDelegate>)taskDelegate;
 
 /**
  * Associate a session task with its task delegate to handle callbacks for it, taskDelegate is not retained

--- a/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.h
@@ -246,6 +246,15 @@ forHTTPHeaderField:(NSString *)field;
                               constructingBodyWithBlock:(nullable void (^)(id <BOXMultipartFormData> formData))block
                                                   error:(NSError * _Nullable __autoreleasing *)error;
 
+/**
+ Get a multipart-formatted input stream which could be used as HTTPBodyStream for a NSURLRequest
+
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param boundary multi-part form boundary
+ @param block A block that takes a single argument and appends data to the HTTP body. The block argument is an object adopting the `BOXMultipartFormData` protocol.
+
+ @return An `BOXMultipartBodyStream` object
+ */
 - (BOXMultipartBodyStream *)multipartInputStreamWithParameters:(NSDictionary *)parameters
                                                      boundary:(NSString *)boundary
                                     constructingBodyWithBlock:(void (^)(id <BOXMultipartFormData> formData))block;

--- a/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.h
@@ -1,0 +1,470 @@
+// BOXURLRequestSerialization.h
+// Based on AFURLRequestSerialization.h in 3.1.0 Release
+
+#import <Foundation/Foundation.h>
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+#import <UIKit/UIKit.h>
+#elif TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BOXMultipartBodyStream : NSInputStream <NSStreamDelegate>
+
+@property (readonly, nonatomic, assign) unsigned long long contentLength;
+
+@end
+
+/**
+ Returns a percent-escaped string following RFC 3986 for a query string key or value.
+ RFC 3986 states that the following characters are "reserved" characters.
+ - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+ - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+
+ In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+ query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+ should be percent-escaped in the query string.
+
+ @param string The string to be percent-escaped.
+
+ @return The percent-escaped string.
+ */
+FOUNDATION_EXPORT NSString * BOXPercentEscapedStringFromString(NSString *string);
+
+/**
+ A helper method to generate encoded url query parameters for appending to the end of a URL.
+
+ @param parameters A dictionary of key/values to be encoded.
+
+ @return A url encoded query string
+ */
+FOUNDATION_EXPORT NSString * BOXQueryStringFromParameters(NSDictionary *parameters);
+
+/**
+ The `BOXURLRequestSerialization` protocol is adopted by an object that encodes parameters for a specified HTTP requests. Request serializers may encode parameters as query strings, HTTP bodies, setting the appropriate HTTP header fields as necessary.
+
+ For example, a JSON request serializer may set the HTTP body of the request to a JSON representation, and set the `Content-Type` HTTP header field value to `application/json`.
+ */
+@protocol BOXURLRequestSerialization <NSObject, NSSecureCoding, NSCopying>
+
+/**
+ Returns a request with the specified parameters encoded into a copy of the original request.
+
+ @param request The original request.
+ @param parameters The parameters to be encoded.
+ @param error The error that occurred while attempting to encode the request parameters.
+
+ @return A serialized request.
+ */
+- (nullable NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
+                               withParameters:(nullable id)parameters
+                                        error:(NSError * _Nullable __autoreleasing *)error NS_SWIFT_NOTHROW;
+
+@end
+
+#pragma mark -
+
+/**
+
+ */
+typedef NS_ENUM(NSUInteger, BOXHTTPRequestQueryStringSerializationStyle) {
+    BOXHTTPRequestQueryStringDefaultStyle = 0,
+};
+
+@protocol BOXMultipartFormData;
+
+/**
+ `BOXHTTPRequestSerializer` conforms to the `BOXURLRequestSerialization` & `BOXURLResponseSerialization` protocols, offering a concrete base implementation of query string / URL form-encoded parameter serialization and default request headers, as well as response status code and content type validation.
+
+ Any request or response serializer dealing with HTTP is encouraged to subclass `BOXHTTPRequestSerializer` in order to ensure consistent default behavior.
+ */
+@interface BOXHTTPRequestSerializer : NSObject <BOXURLRequestSerialization>
+
+/**
+ The string encoding used to serialize parameters. `NSUTF8StringEncoding` by default.
+ */
+@property (nonatomic, assign) NSStringEncoding stringEncoding;
+
+/**
+ Whether created requests can use the device’s cellular radio (if present). `YES` by default.
+
+ @see NSMutableURLRequest -setAllowsCellularAccess:
+ */
+@property (nonatomic, assign) BOOL allowsCellularAccess;
+
+/**
+ The cache policy of created requests. `NSURLRequestUseProtocolCachePolicy` by default.
+
+ @see NSMutableURLRequest -setCachePolicy:
+ */
+@property (nonatomic, assign) NSURLRequestCachePolicy cachePolicy;
+
+/**
+ Whether created requests should use the default cookie handling. `YES` by default.
+
+ @see NSMutableURLRequest -setHTTPShouldHandleCookies:
+ */
+@property (nonatomic, assign) BOOL HTTPShouldHandleCookies;
+
+/**
+ Whether created requests can continue transmitting data before receiving a response from an earlier transmission. `NO` by default
+
+ @see NSMutableURLRequest -setHTTPShouldUsePipelining:
+ */
+@property (nonatomic, assign) BOOL HTTPShouldUsePipelining;
+
+/**
+ The network service type for created requests. `NSURLNetworkServiceTypeDefault` by default.
+
+ @see NSMutableURLRequest -setNetworkServiceType:
+ */
+@property (nonatomic, assign) NSURLRequestNetworkServiceType networkServiceType;
+
+/**
+ The timeout interval, in seconds, for created requests. The default timeout interval is 60 seconds.
+
+ @see NSMutableURLRequest -setTimeoutInterval:
+ */
+@property (nonatomic, assign) NSTimeInterval timeoutInterval;
+
+///---------------------------------------
+/// @name Configuring HTTP Request Headers
+///---------------------------------------
+
+/**
+ Default HTTP header field values to be applied to serialized requests. By default, these include the following:
+
+ - `Accept-Language` with the contents of `NSLocale +preferredLanguages`
+ - `User-Agent` with the contents of various bundle identifiers and OS designations
+
+ @discussion To add or remove default request headers, use `setValue:forHTTPHeaderField:`.
+ */
+@property (readonly, nonatomic, strong) NSDictionary <NSString *, NSString *> *HTTPRequestHeaders;
+
+/**
+ Creates and returns a serializer with default configuration.
+ */
++ (instancetype)serializer;
+
+/**
+ Sets the value for the HTTP headers set in request objects made by the HTTP client. If `nil`, removes the existing value for that header.
+
+ @param field The HTTP header to set a default value for
+ @param value The value set as default for the specified header, or `nil`
+ */
+- (void)setValue:(nullable NSString *)value
+forHTTPHeaderField:(NSString *)field;
+
+/**
+ Returns the value for the HTTP headers set in the request serializer.
+
+ @param field The HTTP header to retrieve the default value for
+
+ @return The value set as default for the specified header, or `nil`
+ */
+- (nullable NSString *)valueForHTTPHeaderField:(NSString *)field;
+
+/**
+ Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.
+
+ @param username The HTTP basic auth username
+ @param password The HTTP basic auth password
+ */
+- (void)setAuthorizationHeaderFieldWithUsername:(NSString *)username
+                                       password:(NSString *)password;
+
+/**
+ Clears any existing value for the "Authorization" HTTP header.
+ */
+- (void)clearAuthorizationHeader;
+
+///-------------------------------------------------------
+/// @name Configuring Query String Parameter Serialization
+///-------------------------------------------------------
+
+/**
+ HTTP methods for which serialized requests will encode parameters as a query string. `GET`, `HEAD`, and `DELETE` by default.
+ */
+@property (nonatomic, strong) NSSet <NSString *> *HTTPMethodsEncodingParametersInURI;
+
+/**
+ Set the method of query string serialization according to one of the pre-defined styles.
+
+ @param style The serialization style.
+
+ @see BOXHTTPRequestQueryStringSerializationStyle
+ */
+- (void)setQueryStringSerializationWithStyle:(BOXHTTPRequestQueryStringSerializationStyle)style;
+
+/**
+ Set the a custom method of query string serialization according to the specified block.
+
+ @param block A block that defines a process of encoding parameters into a query string. This block returns the query string and takes three arguments: the request, the parameters to encode, and the error that occurred when attempting to encode parameters for the given request.
+ */
+- (void)setQueryStringSerializationWithBlock:(nullable NSString * (^)(NSURLRequest *request, id parameters, NSError * __autoreleasing *error))block;
+
+///-------------------------------
+/// @name Creating Request Objects
+///-------------------------------
+
+/**
+ Creates an `NSMutableURLRequest` object with the specified HTTP method and URL string.
+
+ If the HTTP method is `GET`, `HEAD`, or `DELETE`, the parameters will be used to construct a url-encoded query string that is appended to the request's URL. Otherwise, the parameters will be encoded according to the value of the `parameterEncoding` property, and set as the request body.
+
+ @param method The HTTP method for the request, such as `GET`, `POST`, `PUT`, or `DELETE`. This parameter must not be `nil`.
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be either set as a query string for `GET` requests, or the request HTTP body.
+ @param error The error that occurred while constructing the request.
+
+ @return An `NSMutableURLRequest` object.
+ */
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                 URLString:(NSString *)URLString
+                                parameters:(nullable id)parameters
+                                     error:(NSError * _Nullable __autoreleasing *)error;
+
+/**
+ Creates an `NSMutableURLRequest` object with the specified HTTP method and URLString, and constructs a `multipart/form-data` HTTP body, using the specified parameters and multipart form data block. See http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.2
+
+ Multipart form requests are automatically streamed, reading files directly from disk along with in-memory data in a single HTTP body. The resulting `NSMutableURLRequest` object has an `HTTPBodyStream` property, so refrain from setting `HTTPBodyStream` or `HTTPBody` on this request object, as it will clear out the multipart form body stream.
+
+ @param method The HTTP method for the request. This parameter must not be `GET` or `HEAD`, or `nil`.
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param block A block that takes a single argument and appends data to the HTTP body. The block argument is an object adopting the `BOXMultipartFormData` protocol.
+ @param error The error that occurred while constructing the request.
+
+ @return An `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(nullable NSDictionary <NSString *, id> *)parameters
+                              constructingBodyWithBlock:(nullable void (^)(id <BOXMultipartFormData> formData))block
+                                                  error:(NSError * _Nullable __autoreleasing *)error;
+
+- (BOXMultipartBodyStream *)multipartInputStreamWithParameters:(NSDictionary *)parameters
+                                                     boundary:(NSString *)boundary
+                                    constructingBodyWithBlock:(void (^)(id <BOXMultipartFormData> formData))block;
+/**
+ Creates an `NSMutableURLRequest` by removing the `HTTPBodyStream` from a request, and asynchronously writing its contents into the specified file, invoking the completion handler when finished.
+
+ @param request The multipart form request. The `HTTPBodyStream` property of `request` must not be `nil`.
+ @param fileURL The file URL to write multipart form contents to.
+ @param handler A handler block to execute.
+
+ @discussion There is a bug in `NSURLSessionTask` that causes requests to not send a `Content-Length` header when streaming contents from an HTTP body, which is notably problematic when interacting with the Amazon S3 webservice. As a workaround, this method takes a request constructed with `multipartFormRequestWithMethod:URLString:parameters:constructingBodyWithBlock:error:`, or any other request with an `HTTPBodyStream`, writes the contents to the specified file and returns a copy of the original request with the `HTTPBodyStream` property set to `nil`. From here, the file can either be passed to `BOXURLSessionManager -uploadTaskWithRequest:fromFile:progress:completionHandler:`, or have its contents read into an `NSData` that's assigned to the `HTTPBody` property of the request.
+
+ @see https://github.com/AFNetworking/AFNetworking/issues/1398
+ */
+- (NSMutableURLRequest *)requestWithMultipartFormRequest:(NSURLRequest *)request
+                             writingStreamContentsToFile:(NSURL *)fileURL
+                                       completionHandler:(nullable void (^)(NSError * _Nullable error))handler;
+
+@end
+
+#pragma mark -
+
+/**
+ The `BOXMultipartFormData` protocol defines the methods supported by the parameter in the block argument of `BOXHTTPRequestSerializer -multipartFormRequestWithMethod:URLString:parameters:constructingBodyWithBlock:`.
+ */
+@protocol BOXMultipartFormData
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{generated filename}; name=#{name}"` and `Content-Type: #{generated mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ The filename and MIME type for this data in the form will be automatically generated, using the last path component of the `fileURL` and system associated MIME type for the `fileURL` extension, respectively.
+
+ @param fileURL The URL corresponding to the file whose content will be appended to the form. This parameter must not be `nil`.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param error If an error occurs, upon return contains an `NSError` object that describes the problem.
+
+ @return `YES` if the file data was successfully appended, otherwise `NO`.
+ */
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                        error:(NSError * _Nullable __autoreleasing *)error;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ @param fileURL The URL corresponding to the file whose content will be appended to the form. This parameter must not be `nil`.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param fileName The file name to be used in the `Content-Disposition` header. This parameter must not be `nil`.
+ @param mimeType The declared MIME type of the file data. This parameter must not be `nil`.
+ @param error If an error occurs, upon return contains an `NSError` object that describes the problem.
+
+ @return `YES` if the file data was successfully appended otherwise `NO`.
+ */
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                     fileName:(NSString *)fileName
+                     mimeType:(NSString *)mimeType
+                        error:(NSError * _Nullable __autoreleasing *)error;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the data from the input stream and the multipart form boundary.
+
+ @param inputStream The input stream to be appended to the form data
+ @param name The name to be associated with the specified input stream. This parameter must not be `nil`.
+ @param fileName The filename to be associated with the specified input stream. This parameter must not be `nil`.
+ @param length The length of the specified input stream in bytes.
+ @param mimeType The MIME type of the specified data. (For example, the MIME type for a JPEG image is image/jpeg.) For a list of valid MIME types, see http://www.iana.org/assignments/media-types/. This parameter must not be `nil`.
+ */
+- (void)appendPartWithInputStream:(nullable NSInputStream *)inputStream
+                             name:(NSString *)name
+                         fileName:(NSString *)fileName
+                           length:(int64_t)length
+                         mimeType:(NSString *)mimeType;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ @param data The data to be encoded and appended to the form data.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param fileName The filename to be associated with the specified data. This parameter must not be `nil`.
+ @param mimeType The MIME type of the specified data. (For example, the MIME type for a JPEG image is image/jpeg.) For a list of valid MIME types, see http://www.iana.org/assignments/media-types/. This parameter must not be `nil`.
+ */
+- (void)appendPartWithFileData:(NSData *)data
+                          name:(NSString *)name
+                      fileName:(NSString *)fileName
+                      mimeType:(NSString *)mimeType;
+
+/**
+ Appends the HTTP headers `Content-Disposition: form-data; name=#{name}"`, followed by the encoded data and the multipart form boundary.
+
+ @param data The data to be encoded and appended to the form data.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ */
+
+- (void)appendPartWithFormData:(NSData *)data
+                          name:(NSString *)name;
+
+
+/**
+ Appends HTTP headers, followed by the encoded data and the multipart form boundary.
+
+ @param headers The HTTP headers to be appended to the form data.
+ @param body The data to be encoded and appended to the form data. This parameter must not be `nil`.
+ */
+- (void)appendPartWithHeaders:(nullable NSDictionary <NSString *, NSString *> *)headers
+                         body:(NSData *)body;
+
+/**
+ Throttles request bandwidth by limiting the packet size and adding a delay for each chunk read from the upload stream.
+
+ When uploading over a 3G or EDGE connection, requests may fail with "request body stream exhausted". Setting a maximum packet size and delay according to the recommended values (`kBOXUploadStream3GSuggestedPacketSize` and `kBOXUploadStream3GSuggestedDelay`) lowers the risk of the input stream exceeding its allocated bandwidth. Unfortunately, there is no definite way to distinguish between a 3G, EDGE, or LTE connection over `NSURLConnection`. As such, it is not recommended that you throttle bandwidth based solely on network reachability. Instead, you should consider checking for the "request body stream exhausted" in a failure block, and then retrying the request with throttled bandwidth.
+
+ @param numberOfBytes Maximum packet size, in number of bytes. The default packet size for an input stream is 16kb.
+ @param delay Duration of delay each time a packet is read. By default, no delay is set.
+ */
+- (void)throttleBandwidthWithPacketSize:(NSUInteger)numberOfBytes
+                                  delay:(NSTimeInterval)delay;
+
+@end
+
+#pragma mark -
+
+/**
+ `BOXJSONRequestSerializer` is a subclass of `BOXHTTPRequestSerializer` that encodes parameters as JSON using `NSJSONSerialization`, setting the `Content-Type` of the encoded request to `application/json`.
+ */
+@interface BOXJSONRequestSerializer : BOXHTTPRequestSerializer
+
+/**
+ Options for writing the request JSON data from Foundation objects. For possible values, see the `NSJSONSerialization` documentation section "NSJSONWritingOptions". `0` by default.
+ */
+@property (nonatomic, assign) NSJSONWritingOptions writingOptions;
+
+/**
+ Creates and returns a JSON serializer with specified reading and writing options.
+
+ @param writingOptions The specified JSON writing options.
+ */
++ (instancetype)serializerWithWritingOptions:(NSJSONWritingOptions)writingOptions;
+
+@end
+
+#pragma mark -
+
+/**
+ `BOXPropertyListRequestSerializer` is a subclass of `BOXHTTPRequestSerializer` that encodes parameters as JSON using `NSPropertyListSerializer`, setting the `Content-Type` of the encoded request to `application/x-plist`.
+ */
+@interface BOXPropertyListRequestSerializer : BOXHTTPRequestSerializer
+
+/**
+ The property list format. Possible values are described in "NSPropertyListFormat".
+ */
+@property (nonatomic, assign) NSPropertyListFormat format;
+
+/**
+ @warning The `writeOptions` property is currently unused.
+ */
+@property (nonatomic, assign) NSPropertyListWriteOptions writeOptions;
+
+/**
+ Creates and returns a property list serializer with a specified format, read options, and write options.
+
+ @param format The property list format.
+ @param writeOptions The property list write options.
+
+ @warning The `writeOptions` property is currently unused.
+ */
++ (instancetype)serializerWithFormat:(NSPropertyListFormat)format
+                        writeOptions:(NSPropertyListWriteOptions)writeOptions;
+
+@end
+
+#pragma mark -
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## Error Domains
+
+ The following error domain is predefined.
+
+ - `NSString * const BOXURLRequestSerializationErrorDomain`
+
+ ### Constants
+
+ `BOXURLRequestSerializationErrorDomain`
+ BOXURLRequestSerializer errors. Error codes for `BOXURLRequestSerializationErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ */
+FOUNDATION_EXPORT NSString * const BOXURLRequestSerializationErrorDomain;
+
+/**
+ ## User info dictionary keys
+
+ These keys may exist in the user info dictionary, in addition to those defined for NSError.
+
+ - `NSString * const BOXNetworkingOperationFailingURLRequestErrorKey`
+
+ ### Constants
+
+ `BOXNetworkingOperationFailingURLRequestErrorKey`
+ The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `BOXURLRequestSerializationErrorDomain`.
+ */
+FOUNDATION_EXPORT NSString * const BOXNetworkingOperationFailingURLRequestErrorKey;
+
+/**
+ ## Throttling Bandwidth for HTTP Request Input Streams
+
+ @see -throttleBandwidthWithPacketSize:delay:
+
+ ### Constants
+
+ `kBOXUploadStream3GSuggestedPacketSize`
+ Maximum packet size, in number of bytes. Equal to 16kb.
+
+ `kBOXUploadStream3GSuggestedDelay`
+ Duration of delay each time a packet is read. Equal to 0.2 seconds.
+ */
+FOUNDATION_EXPORT NSUInteger const kBOXUploadStream3GSuggestedPacketSize;
+FOUNDATION_EXPORT NSTimeInterval const kBOXUploadStream3GSuggestedDelay;
+
+NS_ASSUME_NONNULL_END

--- a/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.m
@@ -1,0 +1,1419 @@
+// BOXURLRequestSerialization.m
+// Copyright (c) 2011–2016 Alamofire Software Foundation ( http://alamofire.org/ )
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "BOXURLRequestSerialization.h"
+
+#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
+#import <MobileCoreServices/MobileCoreServices.h>
+#else
+#import <CoreServices/CoreServices.h>
+#endif
+
+NSString * const BOXURLRequestSerializationErrorDomain = @"com.alamofire.error.serialization.request";
+NSString * const BOXNetworkingOperationFailingURLRequestErrorKey = @"com.alamofire.serialization.request.error.response";
+
+typedef NSString * (^BOXQueryStringSerializationBlock)(NSURLRequest *request, id parameters, NSError *__autoreleasing *error);
+
+/**
+ Returns a percent-escaped string following RFC 3986 for a query string key or value.
+ RFC 3986 states that the following characters are "reserved" characters.
+    - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+    - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+
+ In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+ query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+ should be percent-escaped in the query string.
+    - parameter string: The string to be percent-escaped.
+    - returns: The percent-escaped string.
+ */
+NSString * BOXPercentEscapedStringFromString(NSString *string) {
+    static NSString * const kBOXCharactersGeneralDelimitersToEncode = @":#[]@"; // does not include "?" or "/" due to RFC 3986 - Section 3.4
+    static NSString * const kBOXCharactersSubDelimitersToEncode = @"!$&'()*+,;=";
+
+    NSMutableCharacterSet * allowedCharacterSet = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [allowedCharacterSet removeCharactersInString:[kBOXCharactersGeneralDelimitersToEncode stringByAppendingString:kBOXCharactersSubDelimitersToEncode]];
+
+	// FIXME: https://github.com/AFNetworking/AFNetworking/pull/3028
+    // return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacterSet];
+
+    static NSUInteger const batchSize = 50;
+
+    NSUInteger index = 0;
+    NSMutableString *escaped = @"".mutableCopy;
+
+    while (index < string.length) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wgnu"
+        NSUInteger length = MIN(string.length - index, batchSize);
+#pragma GCC diagnostic pop
+        NSRange range = NSMakeRange(index, length);
+
+        // To avoid breaking up character sequences such as 👴🏻👮🏽
+        range = [string rangeOfComposedCharacterSequencesForRange:range];
+
+        NSString *substring = [string substringWithRange:range];
+        NSString *encoded = [substring stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacterSet];
+        [escaped appendString:encoded];
+
+        index += range.length;
+    }
+
+	return escaped;
+}
+
+#pragma mark -
+
+@interface BOXQueryStringPair : NSObject
+@property (readwrite, nonatomic, strong) id field;
+@property (readwrite, nonatomic, strong) id value;
+
+- (instancetype)initWithField:(id)field value:(id)value;
+
+- (NSString *)URLEncodedStringValue;
+@end
+
+@implementation BOXQueryStringPair
+
+- (instancetype)initWithField:(id)field value:(id)value {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.field = field;
+    self.value = value;
+
+    return self;
+}
+
+- (NSString *)URLEncodedStringValue {
+    if (!self.value || [self.value isEqual:[NSNull null]]) {
+        return BOXPercentEscapedStringFromString([self.field description]);
+    } else {
+        return [NSString stringWithFormat:@"%@=%@", BOXPercentEscapedStringFromString([self.field description]), BOXPercentEscapedStringFromString([self.value description])];
+    }
+}
+
+@end
+
+#pragma mark -
+
+FOUNDATION_EXPORT NSArray * BOXQueryStringPairsFromDictionary(NSDictionary *dictionary);
+FOUNDATION_EXPORT NSArray * BOXQueryStringPairsFromKeyAndValue(NSString *key, id value);
+
+NSString * BOXQueryStringFromParameters(NSDictionary *parameters) {
+    NSMutableArray *mutablePairs = [NSMutableArray array];
+    for (BOXQueryStringPair *pair in BOXQueryStringPairsFromDictionary(parameters)) {
+        [mutablePairs addObject:[pair URLEncodedStringValue]];
+    }
+
+    return [mutablePairs componentsJoinedByString:@"&"];
+}
+
+NSArray * BOXQueryStringPairsFromDictionary(NSDictionary *dictionary) {
+    return BOXQueryStringPairsFromKeyAndValue(nil, dictionary);
+}
+
+NSArray * BOXQueryStringPairsFromKeyAndValue(NSString *key, id value) {
+    NSMutableArray *mutableQueryStringComponents = [NSMutableArray array];
+
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"description" ascending:YES selector:@selector(compare:)];
+
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dictionary = value;
+        // Sort dictionary keys to ensure consistent ordering in query string, which is important when deserializing potentially ambiguous sequences, such as an array of dictionaries
+        for (id nestedKey in [dictionary.allKeys sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
+            id nestedValue = dictionary[nestedKey];
+            if (nestedValue) {
+                [mutableQueryStringComponents addObjectsFromArray:BOXQueryStringPairsFromKeyAndValue((key ? [NSString stringWithFormat:@"%@[%@]", key, nestedKey] : nestedKey), nestedValue)];
+            }
+        }
+    } else if ([value isKindOfClass:[NSArray class]]) {
+        NSArray *array = value;
+        for (id nestedValue in array) {
+            [mutableQueryStringComponents addObjectsFromArray:BOXQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+        }
+    } else if ([value isKindOfClass:[NSSet class]]) {
+        NSSet *set = value;
+        for (id obj in [set sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
+            [mutableQueryStringComponents addObjectsFromArray:BOXQueryStringPairsFromKeyAndValue(key, obj)];
+        }
+    } else {
+        [mutableQueryStringComponents addObject:[[BOXQueryStringPair alloc] initWithField:key value:value]];
+    }
+
+    return mutableQueryStringComponents;
+}
+
+#pragma mark -
+
+@interface BOXStreamingMultipartFormData : NSObject <BOXMultipartFormData>
+- (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+                    stringEncoding:(NSStringEncoding)encoding;
+- (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+                    stringEncoding:(NSStringEncoding)encoding
+                          boundary:(NSString *)boundary;
+- (NSMutableURLRequest *)requestByFinalizingMultipartFormData;
+- (NSInputStream *)getBodyStream;
+@end
+
+#pragma mark -
+
+static NSArray * BOXHTTPRequestSerializerObservedKeyPaths() {
+    static NSArray *_BOXHTTPRequestSerializerObservedKeyPaths = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _BOXHTTPRequestSerializerObservedKeyPaths = @[NSStringFromSelector(@selector(allowsCellularAccess)), NSStringFromSelector(@selector(cachePolicy)), NSStringFromSelector(@selector(HTTPShouldHandleCookies)), NSStringFromSelector(@selector(HTTPShouldUsePipelining)), NSStringFromSelector(@selector(networkServiceType)), NSStringFromSelector(@selector(timeoutInterval))];
+    });
+
+    return _BOXHTTPRequestSerializerObservedKeyPaths;
+}
+
+static void *BOXHTTPRequestSerializerObserverContext = &BOXHTTPRequestSerializerObserverContext;
+
+@interface BOXHTTPRequestSerializer ()
+@property (readwrite, nonatomic, strong) NSMutableSet *mutableObservedChangedKeyPaths;
+@property (readwrite, nonatomic, strong) NSMutableDictionary *mutableHTTPRequestHeaders;
+@property (readwrite, nonatomic, assign) BOXHTTPRequestQueryStringSerializationStyle queryStringSerializationStyle;
+@property (readwrite, nonatomic, copy) BOXQueryStringSerializationBlock queryStringSerialization;
+@end
+
+@implementation BOXHTTPRequestSerializer
+
++ (instancetype)serializer {
+    return [[self alloc] init];
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.stringEncoding = NSUTF8StringEncoding;
+
+    self.mutableHTTPRequestHeaders = [NSMutableDictionary dictionary];
+
+    // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+    NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
+    [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        float q = 1.0f - (idx * 0.1f);
+        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
+        *stop = q <= 0.5f;
+    }];
+    [self setValue:[acceptLanguagesComponents componentsJoinedByString:@", "] forHTTPHeaderField:@"Accept-Language"];
+
+    NSString *userAgent = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+#if TARGET_OS_IOS
+    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[UIDevice currentDevice] model], [[UIDevice currentDevice] systemVersion], [[UIScreen mainScreen] scale]];
+#elif TARGET_OS_WATCH
+    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; watchOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[WKInterfaceDevice currentDevice] model], [[WKInterfaceDevice currentDevice] systemVersion], [[WKInterfaceDevice currentDevice] screenScale]];
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+    userAgent = [NSString stringWithFormat:@"%@/%@ (Mac OS X %@)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[NSProcessInfo processInfo] operatingSystemVersionString]];
+#endif
+#pragma clang diagnostic pop
+    if (userAgent) {
+        if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+            NSMutableString *mutableUserAgent = [userAgent mutableCopy];
+            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false)) {
+                userAgent = mutableUserAgent;
+            }
+        }
+        [self setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+    }
+
+    // HTTP Method Definitions; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
+    self.HTTPMethodsEncodingParametersInURI = [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];
+
+    self.mutableObservedChangedKeyPaths = [NSMutableSet set];
+    for (NSString *keyPath in BOXHTTPRequestSerializerObservedKeyPaths()) {
+        if ([self respondsToSelector:NSSelectorFromString(keyPath)]) {
+            [self addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:BOXHTTPRequestSerializerObserverContext];
+        }
+    }
+
+    return self;
+}
+
+- (void)dealloc {
+    for (NSString *keyPath in BOXHTTPRequestSerializerObservedKeyPaths()) {
+        if ([self respondsToSelector:NSSelectorFromString(keyPath)]) {
+            [self removeObserver:self forKeyPath:keyPath context:BOXHTTPRequestSerializerObserverContext];
+        }
+    }
+}
+
+#pragma mark -
+
+// Workarounds for crashing behavior using Key-Value Observing with XCTest
+// See https://github.com/AFNetworking/AFNetworking/issues/2523
+
+- (void)setAllowsCellularAccess:(BOOL)allowsCellularAccess {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(allowsCellularAccess))];
+    _allowsCellularAccess = allowsCellularAccess;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(allowsCellularAccess))];
+}
+
+- (void)setCachePolicy:(NSURLRequestCachePolicy)cachePolicy {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(cachePolicy))];
+    _cachePolicy = cachePolicy;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(cachePolicy))];
+}
+
+- (void)setHTTPShouldHandleCookies:(BOOL)HTTPShouldHandleCookies {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(HTTPShouldHandleCookies))];
+    _HTTPShouldHandleCookies = HTTPShouldHandleCookies;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(HTTPShouldHandleCookies))];
+}
+
+- (void)setHTTPShouldUsePipelining:(BOOL)HTTPShouldUsePipelining {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(HTTPShouldUsePipelining))];
+    _HTTPShouldUsePipelining = HTTPShouldUsePipelining;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(HTTPShouldUsePipelining))];
+}
+
+- (void)setNetworkServiceType:(NSURLRequestNetworkServiceType)networkServiceType {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(networkServiceType))];
+    _networkServiceType = networkServiceType;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(networkServiceType))];
+}
+
+- (void)setTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    [self willChangeValueForKey:NSStringFromSelector(@selector(timeoutInterval))];
+    _timeoutInterval = timeoutInterval;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(timeoutInterval))];
+}
+
+#pragma mark -
+
+- (NSDictionary *)HTTPRequestHeaders {
+    return [NSDictionary dictionaryWithDictionary:self.mutableHTTPRequestHeaders];
+}
+
+- (void)setValue:(NSString *)value
+forHTTPHeaderField:(NSString *)field
+{
+	[self.mutableHTTPRequestHeaders setValue:value forKey:field];
+}
+
+- (NSString *)valueForHTTPHeaderField:(NSString *)field {
+    return [self.mutableHTTPRequestHeaders valueForKey:field];
+}
+
+- (void)setAuthorizationHeaderFieldWithUsername:(NSString *)username
+                                       password:(NSString *)password
+{
+    NSData *basicAuthCredentials = [[NSString stringWithFormat:@"%@:%@", username, password] dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *base64AuthCredentials = [basicAuthCredentials base64EncodedStringWithOptions:(NSDataBase64EncodingOptions)0];
+    [self setValue:[NSString stringWithFormat:@"Basic %@", base64AuthCredentials] forHTTPHeaderField:@"Authorization"];
+}
+
+- (void)clearAuthorizationHeader {
+	[self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
+}
+
+#pragma mark -
+
+- (void)setQueryStringSerializationWithStyle:(BOXHTTPRequestQueryStringSerializationStyle)style {
+    self.queryStringSerializationStyle = style;
+    self.queryStringSerialization = nil;
+}
+
+- (void)setQueryStringSerializationWithBlock:(NSString *(^)(NSURLRequest *, id, NSError *__autoreleasing *))block {
+    self.queryStringSerialization = block;
+}
+
+#pragma mark -
+
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                 URLString:(NSString *)URLString
+                                parameters:(id)parameters
+                                     error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(method);
+    NSParameterAssert(URLString);
+
+    NSURL *url = [NSURL URLWithString:URLString];
+
+    NSParameterAssert(url);
+
+    NSMutableURLRequest *mutableRequest = [[NSMutableURLRequest alloc] initWithURL:url];
+    mutableRequest.HTTPMethod = method;
+
+    for (NSString *keyPath in BOXHTTPRequestSerializerObservedKeyPaths()) {
+        if ([self.mutableObservedChangedKeyPaths containsObject:keyPath]) {
+            [mutableRequest setValue:[self valueForKeyPath:keyPath] forKey:keyPath];
+        }
+    }
+
+    mutableRequest = [[self requestBySerializingRequest:mutableRequest withParameters:parameters error:error] mutableCopy];
+
+	return mutableRequest;
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                              URLString:(NSString *)URLString
+                                             parameters:(NSDictionary *)parameters
+                              constructingBodyWithBlock:(void (^)(id <BOXMultipartFormData> formData))block
+                                                  error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(method);
+    NSParameterAssert(![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"]);
+
+    NSMutableURLRequest *mutableRequest = [self requestWithMethod:method URLString:URLString parameters:nil error:error];
+
+    BOXStreamingMultipartFormData *formData = [self formDataWithRequest:mutableRequest parameters:parameters boundary:nil constructingBodyWithBlock:block];
+
+    return [formData requestByFinalizingMultipartFormData];
+}
+
+- (BOXMultipartBodyStream *)multipartInputStreamWithParameters:(NSDictionary *)parameters
+                                                     boundary:(NSString *)boundary
+                                    constructingBodyWithBlock:(void (^)(id <BOXMultipartFormData> formData))block
+{
+    BOXStreamingMultipartFormData *formData = [self formDataWithRequest:nil parameters:parameters boundary:boundary constructingBodyWithBlock:block];
+
+    return [formData getBodyStream];
+}
+
+- (BOXStreamingMultipartFormData *)formDataWithRequest:(NSMutableURLRequest *)request
+                                           parameters:(NSDictionary *)parameters
+                                             boundary:(NSString *)boundary
+                            constructingBodyWithBlock:(void (^)(id <BOXMultipartFormData> formData))block
+{
+    __block BOXStreamingMultipartFormData *formData = [[BOXStreamingMultipartFormData alloc] initWithURLRequest:request stringEncoding:NSUTF8StringEncoding boundary:boundary];
+
+    if (parameters) {
+        for (BOXQueryStringPair *pair in BOXQueryStringPairsFromDictionary(parameters)) {
+            NSData *data = nil;
+            if ([pair.value isKindOfClass:[NSData class]]) {
+                data = pair.value;
+            } else if ([pair.value isEqual:[NSNull null]]) {
+                data = [NSData data];
+            } else {
+                data = [[pair.value description] dataUsingEncoding:self.stringEncoding];
+            }
+
+            if (data) {
+                [formData appendPartWithFormData:data name:[pair.field description]];
+            }
+        }
+    }
+
+    if (block) {
+        block(formData);
+    }
+
+    return formData;
+}
+
+- (NSMutableURLRequest *)requestWithMultipartFormRequest:(NSURLRequest *)request
+                             writingStreamContentsToFile:(NSURL *)fileURL
+                                       completionHandler:(void (^)(NSError *error))handler
+{
+    NSParameterAssert(request.HTTPBodyStream);
+    NSParameterAssert([fileURL isFileURL]);
+
+    NSInputStream *inputStream = request.HTTPBodyStream;
+    NSOutputStream *outputStream = [[NSOutputStream alloc] initWithURL:fileURL append:NO];
+    __block NSError *error = nil;
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        [outputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+
+        [inputStream open];
+        [outputStream open];
+
+        while ([inputStream hasBytesAvailable] && [outputStream hasSpaceAvailable]) {
+            uint8_t buffer[1024];
+
+            NSInteger bytesRead = [inputStream read:buffer maxLength:1024];
+            if (inputStream.streamError || bytesRead < 0) {
+                error = inputStream.streamError;
+                break;
+            }
+
+            NSInteger bytesWritten = [outputStream write:buffer maxLength:(NSUInteger)bytesRead];
+            if (outputStream.streamError || bytesWritten < 0) {
+                error = outputStream.streamError;
+                break;
+            }
+
+            if (bytesRead == 0 && bytesWritten == 0) {
+                break;
+            }
+        }
+
+        [outputStream close];
+        [inputStream close];
+
+        if (handler) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                handler(error);
+            });
+        }
+    });
+
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+    mutableRequest.HTTPBodyStream = nil;
+
+    return mutableRequest;
+}
+
+#pragma mark - BOXURLRequestSerialization
+
+- (NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
+                               withParameters:(id)parameters
+                                        error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(request);
+
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+
+    [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
+        if (![request valueForHTTPHeaderField:field]) {
+            [mutableRequest setValue:value forHTTPHeaderField:field];
+        }
+    }];
+
+    NSString *query = nil;
+    if (parameters) {
+        if (self.queryStringSerialization) {
+            NSError *serializationError;
+            query = self.queryStringSerialization(request, parameters, &serializationError);
+
+            if (serializationError) {
+                if (error) {
+                    *error = serializationError;
+                }
+
+                return nil;
+            }
+        } else {
+            switch (self.queryStringSerializationStyle) {
+                case BOXHTTPRequestQueryStringDefaultStyle:
+                    query = BOXQueryStringFromParameters(parameters);
+                    break;
+            }
+        }
+    }
+
+    if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {
+        if (query && query.length > 0) {
+            mutableRequest.URL = [NSURL URLWithString:[[mutableRequest.URL absoluteString] stringByAppendingFormat:mutableRequest.URL.query ? @"&%@" : @"?%@", query]];
+        }
+    } else {
+        // #2864: an empty string is a valid x-www-form-urlencoded payload
+        if (!query) {
+            query = @"";
+        }
+        if (![mutableRequest valueForHTTPHeaderField:@"Content-Type"]) {
+            [mutableRequest setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+        }
+        [mutableRequest setHTTPBody:[query dataUsingEncoding:self.stringEncoding]];
+    }
+
+    return mutableRequest;
+}
+
+#pragma mark - NSKeyValueObserving
+
++ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
+    if ([BOXHTTPRequestSerializerObservedKeyPaths() containsObject:key]) {
+        return NO;
+    }
+
+    return [super automaticallyNotifiesObserversForKey:key];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(__unused id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context
+{
+    if (context == BOXHTTPRequestSerializerObserverContext) {
+        if ([change[NSKeyValueChangeNewKey] isEqual:[NSNull null]]) {
+            [self.mutableObservedChangedKeyPaths removeObject:keyPath];
+        } else {
+            [self.mutableObservedChangedKeyPaths addObject:keyPath];
+        }
+    }
+}
+
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+    self = [self init];
+    if (!self) {
+        return nil;
+    }
+
+    self.mutableHTTPRequestHeaders = [[decoder decodeObjectOfClass:[NSDictionary class] forKey:NSStringFromSelector(@selector(mutableHTTPRequestHeaders))] mutableCopy];
+    self.queryStringSerializationStyle = (BOXHTTPRequestQueryStringSerializationStyle)[[decoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(queryStringSerializationStyle))] unsignedIntegerValue];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:self.mutableHTTPRequestHeaders forKey:NSStringFromSelector(@selector(mutableHTTPRequestHeaders))];
+    [coder encodeInteger:self.queryStringSerializationStyle forKey:NSStringFromSelector(@selector(queryStringSerializationStyle))];
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    BOXHTTPRequestSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    serializer.mutableHTTPRequestHeaders = [self.mutableHTTPRequestHeaders mutableCopyWithZone:zone];
+    serializer.queryStringSerializationStyle = self.queryStringSerializationStyle;
+    serializer.queryStringSerialization = self.queryStringSerialization;
+
+    return serializer;
+}
+
+@end
+
+#pragma mark -
+
+static NSString * BOXCreateMultipartFormBoundary() {
+    return [NSString stringWithFormat:@"Boundary+%08X%08X", arc4random(), arc4random()];
+}
+
+static NSString * const kBOXMultipartFormCRLF = @"\r\n";
+
+static inline NSString * BOXMultipartFormInitialBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"--%@%@", boundary, kBOXMultipartFormCRLF];
+}
+
+static inline NSString * BOXMultipartFormEncapsulationBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"%@--%@%@", kBOXMultipartFormCRLF, boundary, kBOXMultipartFormCRLF];
+}
+
+static inline NSString * BOXMultipartFormFinalBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"%@--%@--%@", kBOXMultipartFormCRLF, boundary, kBOXMultipartFormCRLF];
+}
+
+static inline NSString * BOXContentTypeForPathExtension(NSString *extension) {
+    NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+    NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
+    if (!contentType) {
+        return @"application/octet-stream";
+    } else {
+        return contentType;
+    }
+}
+
+NSUInteger const kBOXUploadStream3GSuggestedPacketSize = 1024 * 16;
+NSTimeInterval const kBOXUploadStream3GSuggestedDelay = 0.2;
+
+@interface BOXHTTPBodyPart : NSObject
+@property (nonatomic, assign) NSStringEncoding stringEncoding;
+@property (nonatomic, strong) NSDictionary *headers;
+@property (nonatomic, copy) NSString *boundary;
+@property (nonatomic, strong) id body;
+@property (nonatomic, assign) unsigned long long bodyContentLength;
+@property (nonatomic, strong) NSInputStream *inputStream;
+
+@property (nonatomic, assign) BOOL hasInitialBoundary;
+@property (nonatomic, assign) BOOL hasFinalBoundary;
+
+@property (readonly, nonatomic, assign, getter = hasBytesAvailable) BOOL bytesAvailable;
+@property (readonly, nonatomic, assign) unsigned long long contentLength;
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length;
+@end
+
+@interface BOXMultipartBodyStream()
+@property (nonatomic, assign) NSUInteger numberOfBytesInPacket;
+@property (nonatomic, assign) NSTimeInterval delay;
+@property (nonatomic, strong) NSInputStream *inputStream;
+@property (readonly, nonatomic, assign, getter = isEmpty) BOOL empty;
+
+- (instancetype)initWithStringEncoding:(NSStringEncoding)encoding;
+- (void)setInitialAndFinalBoundaries;
+- (void)appendHTTPBodyPart:(BOXHTTPBodyPart *)bodyPart;
+@end
+
+#pragma mark -
+
+@interface BOXStreamingMultipartFormData ()
+@property (readwrite, nonatomic, copy) NSMutableURLRequest *request;
+@property (readwrite, nonatomic, assign) NSStringEncoding stringEncoding;
+@property (readwrite, nonatomic, copy) NSString *boundary;
+@property (readwrite, nonatomic, strong) BOXMultipartBodyStream *bodyStream;
+@end
+
+@implementation BOXStreamingMultipartFormData
+
+- (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+                    stringEncoding:(NSStringEncoding)encoding
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.request = urlRequest;
+    self.stringEncoding = encoding;
+    self.boundary = BOXCreateMultipartFormBoundary();
+    self.bodyStream = [[BOXMultipartBodyStream alloc] initWithStringEncoding:encoding];
+
+    return self;
+}
+
+- (instancetype)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+                    stringEncoding:(NSStringEncoding)encoding
+                          boundary:(NSString *)boundary
+{
+    self = [self initWithURLRequest:urlRequest stringEncoding:encoding];
+    if (self != nil) {
+        if (boundary != nil) {
+            self.boundary = boundary;
+        }
+    }
+    return self;
+}
+
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                        error:(NSError * __autoreleasing *)error
+{
+    NSParameterAssert(fileURL);
+    NSParameterAssert(name);
+
+    NSString *fileName = [fileURL lastPathComponent];
+    NSString *mimeType = BOXContentTypeForPathExtension([fileURL pathExtension]);
+
+    return [self appendPartWithFileURL:fileURL name:name fileName:fileName mimeType:mimeType error:error];
+}
+
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                     fileName:(NSString *)fileName
+                     mimeType:(NSString *)mimeType
+                        error:(NSError * __autoreleasing *)error
+{
+    NSParameterAssert(fileURL);
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+
+    if (![fileURL isFileURL]) {
+        NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedStringFromTable(@"Expected URL to be a file URL", @"BOXNetworking", nil)};
+        if (error) {
+            *error = [[NSError alloc] initWithDomain:BOXURLRequestSerializationErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
+        }
+
+        return NO;
+    } else if ([fileURL checkResourceIsReachableAndReturnError:error] == NO) {
+        NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedStringFromTable(@"File URL not reachable.", @"BOXNetworking", nil)};
+        if (error) {
+            *error = [[NSError alloc] initWithDomain:BOXURLRequestSerializationErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
+        }
+
+        return NO;
+    }
+
+    NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileURL path] error:error];
+    if (!fileAttributes) {
+        return NO;
+    }
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    if (mimeType != nil) {
+        [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+    }
+
+    BOXHTTPBodyPart *bodyPart = [[BOXHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = mutableHeaders;
+    bodyPart.boundary = self.boundary;
+    bodyPart.body = fileURL;
+    bodyPart.bodyContentLength = [fileAttributes[NSFileSize] unsignedLongLongValue];
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+
+    return YES;
+}
+
+- (void)appendPartWithInputStream:(NSInputStream *)inputStream
+                             name:(NSString *)name
+                         fileName:(NSString *)fileName
+                           length:(int64_t)length
+                         mimeType:(NSString *)mimeType
+{
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    if (mimeType != nil) {
+        [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+    }
+
+    BOXHTTPBodyPart *bodyPart = [[BOXHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = mutableHeaders;
+    bodyPart.boundary = self.boundary;
+    bodyPart.body = inputStream;
+
+    bodyPart.bodyContentLength = (unsigned long long)length;
+
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+}
+
+- (void)appendPartWithFileData:(NSData *)data
+                          name:(NSString *)name
+                      fileName:(NSString *)fileName
+                      mimeType:(NSString *)mimeType
+{
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    if (mimeType != nil) {
+        [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+    }
+
+    [self appendPartWithHeaders:mutableHeaders body:data];
+}
+
+- (void)appendPartWithFormData:(NSData *)data
+                          name:(NSString *)name
+{
+    NSParameterAssert(name);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"", name] forKey:@"Content-Disposition"];
+
+    [self appendPartWithHeaders:mutableHeaders body:data];
+}
+
+- (void)appendPartWithHeaders:(NSDictionary *)headers
+                         body:(NSData *)body
+{
+    NSParameterAssert(body);
+
+    BOXHTTPBodyPart *bodyPart = [[BOXHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = headers;
+    bodyPart.boundary = self.boundary;
+    bodyPart.bodyContentLength = [body length];
+    bodyPart.body = body;
+
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+}
+
+- (void)throttleBandwidthWithPacketSize:(NSUInteger)numberOfBytes
+                                  delay:(NSTimeInterval)delay
+{
+    self.bodyStream.numberOfBytesInPacket = numberOfBytes;
+    self.bodyStream.delay = delay;
+}
+
+- (NSMutableURLRequest *)requestByFinalizingMultipartFormData {
+    if ([self.bodyStream isEmpty]) {
+        return self.request;
+    }
+
+    // Reset the initial and final boundaries to ensure correct Content-Length
+    [self.bodyStream setInitialAndFinalBoundaries];
+    [self.request setHTTPBodyStream:self.bodyStream];
+
+    [self.request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", self.boundary] forHTTPHeaderField:@"Content-Type"];
+    [self.request setValue:[NSString stringWithFormat:@"%llu", [self.bodyStream contentLength]] forHTTPHeaderField:@"Content-Length"];
+
+    return self.request;
+}
+
+- (BOXMultipartBodyStream *)getBodyStream {
+    // Reset the initial and final boundaries to ensure correct Content-Length
+    [self.bodyStream setInitialAndFinalBoundaries];
+    return self.bodyStream;
+}
+
+@end
+
+#pragma mark -
+
+@interface NSStream ()
+@property (readwrite) NSStreamStatus streamStatus;
+@property (readwrite, copy) NSError *streamError;
+@end
+
+@interface BOXMultipartBodyStream () <NSCopying>
+@property (readwrite, nonatomic, assign) NSStringEncoding stringEncoding;
+@property (readwrite, nonatomic, strong) NSMutableArray *HTTPBodyParts;
+@property (readwrite, nonatomic, strong) NSEnumerator *HTTPBodyPartEnumerator;
+@property (readwrite, nonatomic, strong) BOXHTTPBodyPart *currentHTTPBodyPart;
+@property (readwrite, nonatomic, strong) NSOutputStream *outputStream;
+@property (readwrite, nonatomic, strong) NSMutableData *buffer;
+@end
+
+@implementation BOXMultipartBodyStream
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-atomic-properties"
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1100)
+@synthesize delegate;
+#endif
+@synthesize streamStatus;
+@synthesize streamError;
+#pragma clang diagnostic pop
+
+- (instancetype)initWithStringEncoding:(NSStringEncoding)encoding {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.stringEncoding = encoding;
+    self.HTTPBodyParts = [NSMutableArray array];
+    self.numberOfBytesInPacket = NSIntegerMax;
+
+    return self;
+}
+
+- (void)setInitialAndFinalBoundaries {
+    if ([self.HTTPBodyParts count] > 0) {
+        for (BOXHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+            bodyPart.hasInitialBoundary = NO;
+            bodyPart.hasFinalBoundary = NO;
+        }
+
+        [[self.HTTPBodyParts firstObject] setHasInitialBoundary:YES];
+        [[self.HTTPBodyParts lastObject] setHasFinalBoundary:YES];
+    }
+}
+
+- (void)appendHTTPBodyPart:(BOXHTTPBodyPart *)bodyPart {
+    [self.HTTPBodyParts addObject:bodyPart];
+}
+
+- (BOOL)isEmpty {
+    return [self.HTTPBodyParts count] == 0;
+}
+
+#pragma mark - NSInputStream
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length
+{
+    if ([self streamStatus] == NSStreamStatusClosed) {
+        return 0;
+    }
+
+    NSInteger totalNumberOfBytesRead = 0;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+    while ((NSUInteger)totalNumberOfBytesRead < MIN(length, self.numberOfBytesInPacket)) {
+        if (!self.currentHTTPBodyPart || ![self.currentHTTPBodyPart hasBytesAvailable]) {
+            if (!(self.currentHTTPBodyPart = [self.HTTPBodyPartEnumerator nextObject])) {
+                break;
+            }
+        } else {
+            NSUInteger maxLength = MIN(length, self.numberOfBytesInPacket) - (NSUInteger)totalNumberOfBytesRead;
+            NSInteger numberOfBytesRead = [self.currentHTTPBodyPart read:&buffer[totalNumberOfBytesRead] maxLength:maxLength];
+            if (numberOfBytesRead == -1) {
+                self.streamError = self.currentHTTPBodyPart.inputStream.streamError;
+                break;
+            } else {
+                totalNumberOfBytesRead += numberOfBytesRead;
+
+                if (self.delay > 0.0f) {
+                    [NSThread sleepForTimeInterval:self.delay];
+                }
+            }
+        }
+    }
+#pragma clang diagnostic pop
+
+    return totalNumberOfBytesRead;
+}
+
+- (BOOL)getBuffer:(__unused uint8_t **)buffer
+           length:(__unused NSUInteger *)len
+{
+    return NO;
+}
+
+- (BOOL)hasBytesAvailable {
+    return [self streamStatus] == NSStreamStatusOpen;
+}
+
+#pragma mark - NSStream
+
+- (void)open {
+    if (self.streamStatus == NSStreamStatusOpen) {
+        return;
+    }
+
+    self.streamStatus = NSStreamStatusOpen;
+
+    [self setInitialAndFinalBoundaries];
+    self.HTTPBodyPartEnumerator = [self.HTTPBodyParts objectEnumerator];
+}
+
+- (void)close {
+    self.streamStatus = NSStreamStatusClosed;
+}
+
+- (id)propertyForKey:(__unused NSString *)key {
+    return nil;
+}
+
+- (BOOL)setProperty:(__unused id)property
+             forKey:(__unused NSString *)key
+{
+    return NO;
+}
+
+- (void)scheduleInRunLoop:(__unused NSRunLoop *)aRunLoop
+                  forMode:(__unused NSString *)mode
+{}
+
+- (void)removeFromRunLoop:(__unused NSRunLoop *)aRunLoop
+                  forMode:(__unused NSString *)mode
+{}
+
+- (unsigned long long)contentLength {
+    unsigned long long length = 0;
+    for (BOXHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+        length += [bodyPart contentLength];
+    }
+
+    return length;
+}
+
+#pragma mark - Undocumented CFReadStream Bridged Methods
+
+- (void)_scheduleInCFRunLoop:(__unused CFRunLoopRef)aRunLoop
+                     forMode:(__unused CFStringRef)aMode
+{}
+
+- (void)_unscheduleFromCFRunLoop:(__unused CFRunLoopRef)aRunLoop
+                         forMode:(__unused CFStringRef)aMode
+{}
+
+- (BOOL)_setCFClientFlags:(__unused CFOptionFlags)inFlags
+                 callback:(__unused CFReadStreamClientCallBack)inCallback
+                  context:(__unused CFStreamClientContext *)inContext {
+    return NO;
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    BOXMultipartBodyStream *bodyStreamCopy = [[[self class] allocWithZone:zone] initWithStringEncoding:self.stringEncoding];
+
+    for (BOXHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+        [bodyStreamCopy appendHTTPBodyPart:[bodyPart copy]];
+    }
+
+    [bodyStreamCopy setInitialAndFinalBoundaries];
+
+    return bodyStreamCopy;
+}
+
+@end
+
+#pragma mark -
+
+typedef enum {
+    BOXEncapsulationBoundaryPhase = 1,
+    BOXHeaderPhase                = 2,
+    BOXBodyPhase                  = 3,
+    BOXFinalBoundaryPhase         = 4,
+} BOXHTTPBodyPartReadPhase;
+
+@interface BOXHTTPBodyPart () <NSCopying> {
+    BOXHTTPBodyPartReadPhase _phase;
+    NSInputStream *_inputStream;
+    unsigned long long _phaseReadOffset;
+}
+
+- (BOOL)transitionToNextPhase;
+- (NSInteger)readData:(NSData *)data
+           intoBuffer:(uint8_t *)buffer
+            maxLength:(NSUInteger)length;
+@end
+
+@implementation BOXHTTPBodyPart
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    [self transitionToNextPhase];
+
+    return self;
+}
+
+- (void)dealloc {
+    if (_inputStream) {
+        [_inputStream close];
+        _inputStream = nil;
+    }
+}
+
+- (NSInputStream *)inputStream {
+    if (!_inputStream) {
+        if ([self.body isKindOfClass:[NSData class]]) {
+            _inputStream = [NSInputStream inputStreamWithData:self.body];
+        } else if ([self.body isKindOfClass:[NSURL class]]) {
+            _inputStream = [NSInputStream inputStreamWithURL:self.body];
+        } else if ([self.body isKindOfClass:[NSInputStream class]]) {
+            _inputStream = self.body;
+        } else {
+            _inputStream = [NSInputStream inputStreamWithData:[NSData data]];
+        }
+    }
+
+    return _inputStream;
+}
+
+- (NSString *)stringForHeaders {
+    NSMutableString *headerString = [NSMutableString string];
+    for (NSString *field in [self.headers allKeys]) {
+        [headerString appendString:[NSString stringWithFormat:@"%@: %@%@", field, [self.headers valueForKey:field], kBOXMultipartFormCRLF]];
+    }
+    [headerString appendString:kBOXMultipartFormCRLF];
+
+    return [NSString stringWithString:headerString];
+}
+
+- (unsigned long long)contentLength {
+    unsigned long long length = 0;
+
+    NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? BOXMultipartFormInitialBoundary(self.boundary) : BOXMultipartFormEncapsulationBoundary(self.boundary)) dataUsingEncoding:self.stringEncoding];
+    length += [encapsulationBoundaryData length];
+
+    NSData *headersData = [[self stringForHeaders] dataUsingEncoding:self.stringEncoding];
+    length += [headersData length];
+
+    length += _bodyContentLength;
+
+    NSData *closingBoundaryData = ([self hasFinalBoundary] ? [BOXMultipartFormFinalBoundary(self.boundary) dataUsingEncoding:self.stringEncoding] : [NSData data]);
+    length += [closingBoundaryData length];
+
+    return length;
+}
+
+- (BOOL)hasBytesAvailable {
+    // Allows `read:maxLength:` to be called again if `BOXMultipartFormFinalBoundary` doesn't fit into the available buffer
+    if (_phase == BOXFinalBoundaryPhase) {
+        return YES;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+    switch (self.inputStream.streamStatus) {
+        case NSStreamStatusNotOpen:
+        case NSStreamStatusOpening:
+        case NSStreamStatusOpen:
+        case NSStreamStatusReading:
+        case NSStreamStatusWriting:
+            return YES;
+        case NSStreamStatusAtEnd:
+        case NSStreamStatusClosed:
+        case NSStreamStatusError:
+        default:
+            return NO;
+    }
+#pragma clang diagnostic pop
+}
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length
+{
+    NSInteger totalNumberOfBytesRead = 0;
+
+    if (_phase == BOXEncapsulationBoundaryPhase) {
+        NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? BOXMultipartFormInitialBoundary(self.boundary) : BOXMultipartFormEncapsulationBoundary(self.boundary)) dataUsingEncoding:self.stringEncoding];
+        totalNumberOfBytesRead += [self readData:encapsulationBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    if (_phase == BOXHeaderPhase) {
+        NSData *headersData = [[self stringForHeaders] dataUsingEncoding:self.stringEncoding];
+        totalNumberOfBytesRead += [self readData:headersData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    if (_phase == BOXBodyPhase) {
+        NSInteger numberOfBytesRead = 0;
+
+        numberOfBytesRead = [self.inputStream read:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+        if (numberOfBytesRead == -1) {
+            return -1;
+        } else {
+            totalNumberOfBytesRead += numberOfBytesRead;
+
+            if ([self.inputStream streamStatus] >= NSStreamStatusAtEnd) {
+                [self transitionToNextPhase];
+            }
+        }
+    }
+
+    if (_phase == BOXFinalBoundaryPhase) {
+        NSData *closingBoundaryData = ([self hasFinalBoundary] ? [BOXMultipartFormFinalBoundary(self.boundary) dataUsingEncoding:self.stringEncoding] : [NSData data]);
+        totalNumberOfBytesRead += [self readData:closingBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    return totalNumberOfBytesRead;
+}
+
+- (NSInteger)readData:(NSData *)data
+           intoBuffer:(uint8_t *)buffer
+            maxLength:(NSUInteger)length
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+    NSRange range = NSMakeRange((NSUInteger)_phaseReadOffset, MIN([data length] - ((NSUInteger)_phaseReadOffset), length));
+    [data getBytes:buffer range:range];
+#pragma clang diagnostic pop
+
+    _phaseReadOffset += range.length;
+
+    if (((NSUInteger)_phaseReadOffset) >= [data length]) {
+        [self transitionToNextPhase];
+    }
+
+    return (NSInteger)range.length;
+}
+
+- (BOOL)transitionToNextPhase {
+    if (![[NSThread currentThread] isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self transitionToNextPhase];
+        });
+        return YES;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+    switch (_phase) {
+        case BOXEncapsulationBoundaryPhase:
+            _phase = BOXHeaderPhase;
+            break;
+        case BOXHeaderPhase:
+            [self.inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+            [self.inputStream open];
+            _phase = BOXBodyPhase;
+            break;
+        case BOXBodyPhase:
+            [self.inputStream close];
+            _phase = BOXFinalBoundaryPhase;
+            break;
+        case BOXFinalBoundaryPhase:
+        default:
+            _phase = BOXEncapsulationBoundaryPhase;
+            break;
+    }
+    _phaseReadOffset = 0;
+#pragma clang diagnostic pop
+
+    return YES;
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    BOXHTTPBodyPart *bodyPart = [[[self class] allocWithZone:zone] init];
+
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = self.headers;
+    bodyPart.bodyContentLength = self.bodyContentLength;
+    bodyPart.body = self.body;
+    bodyPart.boundary = self.boundary;
+
+    return bodyPart;
+}
+
+@end
+
+#pragma mark -
+
+@implementation BOXJSONRequestSerializer
+
++ (instancetype)serializer {
+    return [self serializerWithWritingOptions:(NSJSONWritingOptions)0];
+}
+
++ (instancetype)serializerWithWritingOptions:(NSJSONWritingOptions)writingOptions
+{
+    BOXJSONRequestSerializer *serializer = [[self alloc] init];
+    serializer.writingOptions = writingOptions;
+
+    return serializer;
+}
+
+#pragma mark - BOXURLRequestSerialization
+
+- (NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
+                               withParameters:(id)parameters
+                                        error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(request);
+
+    if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {
+        return [super requestBySerializingRequest:request withParameters:parameters error:error];
+    }
+
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+
+    [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
+        if (![request valueForHTTPHeaderField:field]) {
+            [mutableRequest setValue:value forHTTPHeaderField:field];
+        }
+    }];
+
+    if (parameters) {
+        if (![mutableRequest valueForHTTPHeaderField:@"Content-Type"]) {
+            [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+        }
+
+        [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];
+    }
+
+    return mutableRequest;
+}
+
+#pragma mark - NSSecureCoding
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+    self = [super initWithCoder:decoder];
+    if (!self) {
+        return nil;
+    }
+
+    self.writingOptions = [[decoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(writingOptions))] unsignedIntegerValue];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [super encodeWithCoder:coder];
+
+    [coder encodeInteger:self.writingOptions forKey:NSStringFromSelector(@selector(writingOptions))];
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    BOXJSONRequestSerializer *serializer = [super copyWithZone:zone];
+    serializer.writingOptions = self.writingOptions;
+
+    return serializer;
+}
+
+@end
+
+#pragma mark -
+
+@implementation BOXPropertyListRequestSerializer
+
++ (instancetype)serializer {
+    return [self serializerWithFormat:NSPropertyListXMLFormat_v1_0 writeOptions:0];
+}
+
++ (instancetype)serializerWithFormat:(NSPropertyListFormat)format
+                        writeOptions:(NSPropertyListWriteOptions)writeOptions
+{
+    BOXPropertyListRequestSerializer *serializer = [[self alloc] init];
+    serializer.format = format;
+    serializer.writeOptions = writeOptions;
+
+    return serializer;
+}
+
+#pragma mark - BOXURLRequestSerializer
+
+- (NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
+                               withParameters:(id)parameters
+                                        error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(request);
+
+    if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {
+        return [super requestBySerializingRequest:request withParameters:parameters error:error];
+    }
+
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+
+    [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
+        if (![request valueForHTTPHeaderField:field]) {
+            [mutableRequest setValue:value forHTTPHeaderField:field];
+        }
+    }];
+
+    if (parameters) {
+        if (![mutableRequest valueForHTTPHeaderField:@"Content-Type"]) {
+            [mutableRequest setValue:@"application/x-plist" forHTTPHeaderField:@"Content-Type"];
+        }
+
+        [mutableRequest setHTTPBody:[NSPropertyListSerialization dataWithPropertyList:parameters format:self.format options:self.writeOptions error:error]];
+    }
+
+    return mutableRequest;
+}
+
+#pragma mark - NSSecureCoding
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+    self = [super initWithCoder:decoder];
+    if (!self) {
+        return nil;
+    }
+
+    self.format = (NSPropertyListFormat)[[decoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(format))] unsignedIntegerValue];
+    self.writeOptions = [[decoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(writeOptions))] unsignedIntegerValue];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [super encodeWithCoder:coder];
+
+    [coder encodeInteger:self.format forKey:NSStringFromSelector(@selector(format))];
+    [coder encodeObject:@(self.writeOptions) forKey:NSStringFromSelector(@selector(writeOptions))];
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    BOXPropertyListRequestSerializer *serializer = [super copyWithZone:zone];
+    serializer.format = self.format;
+    serializer.writeOptions = self.writeOptions;
+
+    return serializer;
+}
+
+@end

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
@@ -1,5 +1,5 @@
 //
-//  BOXNSURLSessionManager.h
+//  BOXURLSessionManager.h
 //  BoxContentSDK
 //
 //  Created by Thuy Nguyen on 12/15/16.
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol BOXNSURLSessionTaskDelegate <NSObject>
+@protocol BOXURLSessionTaskDelegate <NSObject>
 
 /**
  * To be called to finish the operation for a NSURLSessionTask upon its completion
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param response  The response received from Box as a result of the API call.
  * @param error     An error in the NSURLErrorDomain
  */
-- (void)finishURLSessionTaskWithResponse:(NSURLResponse *)response error:(NSError *)error;
+- (void)sessionTask:(NSURLSessionTask *)sessionTask didFinishWithResponse:(NSURLResponse *)response error:(NSError *)error;
 
 @optional
 
@@ -38,43 +38,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@protocol BOXNSURLSessionDownloadTaskDelegate <BOXNSURLSessionTaskDelegate>
+
+@protocol BOXURLSessionDownloadTaskDelegate <BOXURLSessionTaskDelegate>
 
 @optional
-
-/**
- * To be called to report ongoing progress of the task
- */
-- (void)progressWithTotalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite;
-
-/**
- * Notify that the file has been downloaded to the location
- * The delegate should copy or move the file at the given location to a new location as it will be
- * removed when the delegate message returns.
- */
-- (void)didFinishDownloadingToURL:(NSURL *)location;
-
-@end
-
-@protocol BOXNSURLSessionUploadTaskDelegate <BOXNSURLSessionTaskDelegate>
-
-@optional
-
-/**
- * To be called to report ongoing progress of the task
- */
-- (void)progressWithTotalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
-
-
-@end
-
-@protocol BOXNSURLSessionManagerDelegate <NSObject>
 
 /**
  * Notify delegate about download progress
  */
 - (void)downloadTask:(NSURLSessionDownloadTask *)downloadTask
-   totalBytesWritten:(int64_t)totalBytesWritten
+   didWriteTotalBytes:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite;
 
 /**
@@ -82,34 +55,40 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite;
  */
 - (void)downloadTask:(NSURLSessionTask *)sessionTask didFinishDownloadingToURL:(NSURL *)location;
 
+@end
+
+
+@protocol BOXURLSessionUploadTaskDelegate <BOXURLSessionTaskDelegate>
+
+@optional
+
 /**
  * Notify delegate about upload progress
  */
-- (void)uploadTask:(NSURLSessionDataTask *)sessionTask
-    totalBytesSent:(int64_t)totalBytesSent
+- (void)sessionTask:(NSURLSessionTask *)sessionTask
+    didSendTotalBytes:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 
-/**
- * Sent when a session task finishes
- */
-- (void)finishURLSessionTask:(NSURLSessionTask *)sessionTask withResponse:(NSURLResponse *)response error:(NSError *)error;
+@end
 
+
+@protocol BOXURLSessionManagerDelegate <BOXURLSessionDownloadTaskDelegate, BOXURLSessionUploadTaskDelegate>
 @end
 
 /**
  This class is responsible for creating different NSURLSessionTask
  */
-@interface BOXNSURLSessionManager : NSObject
+@interface BOXURLSessionManager : NSObject
 
 /**
  * This method needs to be called once to set up the manager to be ready to perform other public methods
  * @param defaultDelegate   handle callbacks from session tasks that do not have associated task delegates
- *                          possible if the background tasks were created outside of BOXNSURLSessionManager
+ *                          possible if the background tasks were created outside of BOXURLSessionManager
  *                          (e.g. app restarts)
  *                          A task delegate can always be re-associated with a session task by calling
  *                          associateSessionTaskId:withTaskDelegate:
  */
-- (void)setUpWithDefaultDelegate:(id<BOXNSURLSessionManagerDelegate>)defaultDelegate;
+- (void)setUpWithDefaultDelegate:(id<BOXURLSessionManagerDelegate>)defaultDelegate;
 
 /**
  Create a NSURLSessionDataTask which does not need to be run in background,
@@ -120,32 +99,32 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 /**
  Create a NSURLSessionDownloadTask which can be run in the background and download to an outputstream
  */
-- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithRequest:(NSURLRequest *)request taskDelegate:(id <BOXNSURLSessionDownloadTaskDelegate>)taskDelegate;
+- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithRequest:(NSURLRequest *)request taskDelegate:(id <BOXURLSessionDownloadTaskDelegate>)taskDelegate;
 
 /**
  Create a NSURLSessionDataTask which can be run to download data into a destination path but not run in the background
  */
-- (NSURLSessionDataTask *)createNonBackgroundDownloadTaskWithRequest:(NSURLRequest *)request taskDelegate:(id <BOXNSURLSessionDownloadTaskDelegate>)taskDelegate;
+- (NSURLSessionDataTask *)createNonBackgroundDownloadTaskWithRequest:(NSURLRequest *)request taskDelegate:(id <BOXURLSessionDownloadTaskDelegate>)taskDelegate;
 
 /**
  Create a NSURLSessionDownloadTask to be resumed
  */
-- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithResumeData:(NSData *)resumeData taskDelegate:(id <BOXNSURLSessionDownloadTaskDelegate>)taskDelegate;
+- (NSURLSessionDownloadTask *)createBackgroundDownloadTaskWithResumeData:(NSData *)resumeData taskDelegate:(id <BOXURLSessionDownloadTaskDelegate>)taskDelegate;
 
 /**
  Create a NSURLSessionUploadTask which can be run in background
  */
-- (NSURLSessionUploadTask *)createBackgroundUploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL taskDelegate:(id <BOXNSURLSessionUploadTaskDelegate>)taskDelegate;
+- (NSURLSessionUploadTask *)createBackgroundUploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL taskDelegate:(id <BOXURLSessionUploadTaskDelegate>)taskDelegate;
 
 /**
  Create a non-background upload task given stream request
  */
-- (NSURLSessionUploadTask *)createNonBackgroundUploadTaskWithStreamedRequest:(NSURLRequest *)request taskDelegate:(id <BOXNSURLSessionUploadTaskDelegate>)taskDelegate;
+- (NSURLSessionUploadTask *)createNonBackgroundUploadTaskWithStreamedRequest:(NSURLRequest *)request taskDelegate:(id <BOXURLSessionUploadTaskDelegate>)taskDelegate;
 
 /**
  * Associate a session task with its task delegate to handle callbacks for it, taskDelegate is not retained
  */
-- (void)associateSessionTaskId:(NSUInteger)sessionTaskId withTaskDelegate:(id <BOXNSURLSessionTaskDelegate> )taskDelegate;
+- (void)associateSessionTaskId:(NSUInteger)sessionTaskId withTaskDelegate:(id <BOXURLSessionTaskDelegate> )taskDelegate;
 
 /**
  * Dessociate a session task with its task delegate so the task delegate will no longer handle callbacks for the task

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
@@ -98,17 +98,17 @@
                                         fromLocalFilePath:(NSString *)localFilePath;
 
 /**
- *  Generate a request to upload a local file to Box in background unless tempUploadFilePath is not provided
+ *  Generate a request to upload a local file to Box in background unless uploadMultipartCopyFilePath is not provided
  *
  *  @param folderID      Folder ID of the folder to upload the file into.
  *  @param localFilePath Path to local file to be uploaded.
- *  @param tempUploadFilePath Path to write the multi-part formatted temporary file for upload in the background
+ *  @param uploadMultipartCopyFilePath Path to write the multi-part formatted temporary file for upload in the background
  *
  *  @return A request that can be customized and then executed.
  */
-- (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
-                                        fromLocalFilePath:(NSString *)localFilePath
-                                       tempUploadFilePath:(NSString *)tempUploadFilePath;
+- (BOXFileUploadRequest *)fileUploadRequestInBackgroundToFolderWithID:(NSString *)folderID
+                                                    fromLocalFilePath:(NSString *)localFilePath
+                                          uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath;
 
 /**
  *  Generate a request to upload a byte-buffer to Box.
@@ -149,17 +149,17 @@
 
 /**
  *  Generate a request to upload a new version of a file from a local file in the background
- *  (continue running even if app terminates) unless tempUploadFilePath is not provided.
+ *  (continue running even if app terminates) unless uploadMultipartCopyFilePath is not provided.
  *
  *  @param fileID        File ID.
  *  @param localFilePath Path to local file to be uploaded.
- *  @param tempUploadFilePath Path to write the multi-part formatted temporary file for upload in the background
+ *  @param uploadMultipartCopyFilePath Path to write the multi-part formatted temporary file for upload in the background
  *
  *  @return A request that can be customized and then executed.
  */
-- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
-                                                    fromLocalFilePath:(NSString *)localFilePath
-                                                   tempUploadFilePath:(NSString *)tempUploadFilePath;
+- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestInBackgroundWithFileID:(NSString *)fileID
+                                                                    fromLocalFilePath:(NSString *)localFilePath
+                                                          uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath;
 
 /**
  *  Generate a request to upload a new version of a file from a byte-buffer.

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
@@ -98,6 +98,19 @@
                                         fromLocalFilePath:(NSString *)localFilePath;
 
 /**
+ *  Generate a request to upload a local file to Box in background unless tempUploadFilePath is not provided
+ *
+ *  @param folderID      Folder ID of the folder to upload the file into.
+ *  @param localFilePath Path to local file to be uploaded.
+ *  @param tempUploadFilePath Path to write the multi-part formatted temporary file for upload in the background
+ *
+ *  @return A request that can be customized and then executed.
+ */
+- (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
+                                        fromLocalFilePath:(NSString *)localFilePath
+                                       tempUploadFilePath:(NSString *)tempUploadFilePath;
+
+/**
  *  Generate a request to upload a byte-buffer to Box.
  *
  *  @param folderID Folder ID of the folder to upload the file into.
@@ -133,6 +146,20 @@
  */
 - (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
                                                     fromLocalFilePath:(NSString *)localFilePath;
+
+/**
+ *  Generate a request to upload a new version of a file from a local file in the background
+ *  (continue running even if app terminates) unless tempUploadFilePath is not provided.
+ *
+ *  @param fileID        File ID.
+ *  @param localFilePath Path to local file to be uploaded.
+ *  @param tempUploadFilePath Path to write the multi-part formatted temporary file for upload in the background
+ *
+ *  @return A request that can be customized and then executed.
+ */
+- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
+                                                    fromLocalFilePath:(NSString *)localFilePath
+                                                   tempUploadFilePath:(NSString *)tempUploadFilePath;
 
 /**
  *  Generate a request to upload a new version of a file from a byte-buffer.

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
@@ -117,17 +117,14 @@
 - (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
                                         fromLocalFilePath:(NSString *)localFilePath
 {
-    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID];
-    [self prepareRequest:request];
-    
-    return request;
+    return [self fileUploadRequestInBackgroundToFolderWithID:folderID fromLocalFilePath:localFilePath uploadMultipartCopyFilePath:nil];
 }
 
-- (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
-                                         fromLocalFilePath:(NSString *)localFilePath
-                                       tempUploadFilePath:(NSString *)tempUploadFilePath
+- (BOXFileUploadRequest *)fileUploadRequestInBackgroundToFolderWithID:(NSString *)folderID
+                                                    fromLocalFilePath:(NSString *)localFilePath
+                                          uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
 {
-    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID tempUploadFilePath:tempUploadFilePath];
+    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID uploadMultipartCopyFilePath:uploadMultipartCopyFilePath];
     [self prepareRequest:request];
 
     return request;
@@ -156,17 +153,14 @@
 - (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
                                                     fromLocalFilePath:(NSString *)localFilePath
 {
-    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath];
-    [self prepareRequest:request];
-    
-    return request;
+    return [self fileUploadNewVersionRequestInBackgroundWithFileID:fileID fromLocalFilePath:localFilePath uploadMultipartCopyFilePath:nil];
 }
 
-- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
-                                                     fromLocalFilePath:(NSString *)localFilePath
-                                                   tempUploadFilePath:(NSString *)tempUploadFilePath
+- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestInBackgroundWithFileID:(NSString *)fileID
+                                                                fromLocalFilePath:(NSString *)localFilePath
+                                                      uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
 {
-    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath tempUploadFilePath:tempUploadFilePath];
+    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath uploadMultipartCopyFilePath:uploadMultipartCopyFilePath];
     [self prepareRequest:request];
 
     return request;

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
@@ -124,6 +124,16 @@
 }
 
 - (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
+                                         fromLocalFilePath:(NSString *)localFilePath
+                                       tempUploadFilePath:(NSString *)tempUploadFilePath
+{
+    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID tempUploadFilePath:tempUploadFilePath];
+    [self prepareRequest:request];
+
+    return request;
+}
+
+- (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
                                                  fromData:(NSData *)data
                                                  fileName:(NSString *)fileName
 {
@@ -149,6 +159,16 @@
     BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath];
     [self prepareRequest:request];
     
+    return request;
+}
+
+- (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
+                                                     fromLocalFilePath:(NSString *)localFilePath
+                                                   tempUploadFilePath:(NSString *)tempUploadFilePath
+{
+    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath tempUploadFilePath:tempUploadFilePath];
+    [self prepareRequest:request];
+
     return request;
 }
 

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -21,7 +21,7 @@
 #import "BOXContentSDKErrors.h"
 #import "BOXUserRequest.h"
 #import "BOXContentClient+User.h"
-#import "BOXNSURLSessionManager.h"
+#import "BOXURLSessionManager.h"
 
 @interface BOXContentClient ()
 
@@ -174,7 +174,7 @@ static BOXContentClient *defaultInstance = nil;
         // manager uses the session as a lock object when enqueuing operations.
         _queueManager = [[BOXParallelAPIQueueManager alloc] init];
 
-        _urlSessionManager = [[BOXNSURLSessionManager alloc] init];
+        _urlSessionManager = [[BOXURLSessionManager alloc] init];
 
         _OAuth2Session = [[BOXParallelOAuth2Session alloc] initWithClientID:staticClientID
                                                                      secret:staticClientSecret

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient_Private.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient_Private.h
@@ -12,14 +12,14 @@
 @class BOXAbstractSession;
 @class BOXAppUserSession;
 @class BOXRequest;
-@class BOXNSURLSessionManager;
+@class BOXURLSessionManager;
 
 @interface BOXContentClient ()
 
 @property (nonatomic, readwrite, strong) BOXOAuth2Session *OAuth2Session;
 @property (nonatomic, readwrite, strong) BOXAppUserSession *appSession;
 @property (nonatomic, readwrite, strong) BOXAbstractSession *session;
-@property (nonatomic, readwrite, strong) BOXNSURLSessionManager *urlSessionManager;
+@property (nonatomic, readwrite, strong) BOXURLSessionManager *urlSessionManager;
 
 + (NSMutableDictionary *)SDKClients;
 - (void)prepareRequest:(BOXRequest *)request;

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "BOXAPIQueueManager.h"
 #import "BOXUser.h"
-#import "BOXNSURLSessionManager.h"
+#import "BOXURLSessionManager.h"
 
 #pragma mark Notifications
 extern NSString *const BOXSessionDidBecomeAuthenticatedNotification;
@@ -64,7 +64,7 @@ extern NSString *const BOXUserIDKey;
  * The BOXAPIQueueManager on which to enqueue [BOXAPIOAuth2ToJSONOperation](BOXAPIOAuth2ToJSONOperation) or [BOXAPIAppAuthOperation](BOXAPIAppAuthOperation).
  */
 @property (nonatomic, readwrite, weak) BOXAPIQueueManager *queueManager;
-@property (nonatomic, readonly, strong) BOXNSURLSessionManager *urlSessionManager;
+@property (nonatomic, readonly, strong) BOXURLSessionManager *urlSessionManager;
 
 #pragma mark Authorization Properties
 /** @name Authorization Properties */
@@ -117,7 +117,7 @@ extern NSString *const BOXUserIDKey;
  *
  * @return A BOXAbstractSession capable of authorizing a user and signing requests.
  */
-- (instancetype)initWithAPIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager urlSessionManager:(BOXNSURLSessionManager *)urlSessionManager;
+- (instancetype)initWithAPIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager urlSessionManager:(BOXURLSessionManager *)urlSessionManager;
 
 #pragma mark Access Token Authorization
 /** @name Token Authorization */

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.m
@@ -29,7 +29,7 @@ static NSString *staticKeychainAccessGroup;
 
 @interface BOXAbstractSession ()
 
-@property (nonatomic, readwrite, strong) BOXNSURLSessionManager *urlSessionManager;
+@property (nonatomic, readwrite, strong) BOXURLSessionManager *urlSessionManager;
 
 @end
 
@@ -44,7 +44,7 @@ static NSString *staticKeychainAccessGroup;
     return self;
 }
 
-- (instancetype)initWithAPIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager urlSessionManager:(BOXNSURLSessionManager *)urlSessionManager
+- (instancetype)initWithAPIBaseURL:(NSString *)baseURL queueManager:(BOXAPIQueueManager *)queueManager urlSessionManager:(BOXURLSessionManager *)urlSessionManager
 {
     self = [self init];
     if (self) {

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -113,7 +113,7 @@
                       APIBaseURL:(NSString *)baseURL
                   APIAuthBaseURL:(NSString *)authBaseURL
                     queueManager:(BOXAPIQueueManager *)queueManager
-               urlSessionManager:(BOXNSURLSessionManager *)urlSessionManager;
+               urlSessionManager:(BOXURLSessionManager *)urlSessionManager;
 
 #pragma mark - Authorization
 /** @name Authorization */

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -39,7 +39,7 @@
                       APIBaseURL:(NSString *)baseURL
                   APIAuthBaseURL:(NSString *)authBaseURL
                     queueManager:(BOXAPIQueueManager *)queueManager
-               urlSessionManager:(BOXNSURLSessionManager *)urlSessionManager
+               urlSessionManager:(BOXURLSessionManager *)urlSessionManager
 {
     self = [self initWithAPIBaseURL:baseURL queueManager:queueManager urlSessionManager:urlSessionManager];
     if (self) {

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -27,7 +27,7 @@
             APIBaseURL:(NSString *)baseURL
         APIAuthBaseURL:(NSString *)authBaseURL
           queueManager:(BOXAPIQueueManager *)queueManager
-     urlSessionManager:(BOXNSURLSessionManager *)urlSessionManager
+     urlSessionManager:(BOXURLSessionManager *)urlSessionManager
 {
     self = [super initWithClientID:ID secret:secret APIBaseURL:baseURL APIAuthBaseURL:authBaseURL queueManager:queueManager urlSessionManager:urlSessionManager];
     if (self != nil)

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
@@ -44,7 +44,7 @@ typedef void (^BOXAPIDataProgressBlock)(long long expectedTotalBytes, unsigned l
  * of an expired access token. In this case, the operation will fail with error code
  * `BoxContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued`.
  */
-@interface BOXAPIDataOperation : BOXAPIAuthenticatedOperation <NSStreamDelegate, BOXNSURLSessionDownloadTaskDelegate>
+@interface BOXAPIDataOperation : BOXAPIAuthenticatedOperation <NSStreamDelegate, BOXURLSessionDownloadTaskDelegate>
 
 /** @name Streams */
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -264,7 +264,7 @@
     [self close];
 }
 
-#pragma mark - BOXNSURLSessionTaskDelegate
+#pragma mark - BOXURLSessionTaskDelegate
 
 - (void)processIntermediateResponse:(NSURLResponse *)response
 {
@@ -329,10 +329,10 @@
     }
 }
 
-- (void)finishURLSessionTaskWithResponse:(NSURLResponse *)response error:(NSError *)error
+- (void)sessionTask:(NSURLSessionTask *)sessionTask didFinishWithResponse:(NSURLResponse *)response error:(NSError *)error
 {
     @synchronized (self) {
-        [super finishURLSessionTaskWithResponse:response error:error];
+        [super sessionTask:sessionTask didFinishWithResponse:response error:error];
     }
 }
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.h
@@ -34,13 +34,13 @@ typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsi
  * of an expired access token. In this case, the operation will fail with error code
  * `BoxContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued`.
  */
-@interface BOXAPIMultipartToJSONOperation : BOXAPIJSONOperation <NSStreamDelegate, BOXNSURLSessionUploadTaskDelegate>
+@interface BOXAPIMultipartToJSONOperation : BOXAPIJSONOperation <NSStreamDelegate>
 
 /**
  * Location to write a multi-part formatted file of the uploaded content into for background upload
  * If nil, upload will be a non-background upload
  */
-@property (nonatomic, readwrite, strong) NSString *tempUploadFilePath;
+@property (nonatomic, readwrite, strong) NSString *uploadMultipartCopyFilePath;
 
 /** @name Callbacks */
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.h
@@ -7,6 +7,7 @@
 //
 
 #import "BOXAPIJSONOperation.h"
+#import "BOXURLRequestSerialization.h"
 
 typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsigned long long bytesSent);
 
@@ -33,7 +34,13 @@ typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsi
  * of an expired access token. In this case, the operation will fail with error code
  * `BoxContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued`.
  */
-@interface BOXAPIMultipartToJSONOperation : BOXAPIJSONOperation <NSStreamDelegate>
+@interface BOXAPIMultipartToJSONOperation : BOXAPIJSONOperation <NSStreamDelegate, BOXNSURLSessionUploadTaskDelegate>
+
+/**
+ * Location to write a multi-part formatted file of the uploaded content into for background upload
+ * If nil, upload will be a non-background upload
+ */
+@property (nonatomic, readwrite, strong) NSString *tempUploadFilePath;
 
 /** @name Callbacks */
 
@@ -43,13 +50,6 @@ typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsi
  */
 @property (nonatomic, readwrite, strong) BOXAPIMultipartProgressBlock progressBlock;
 
-/**
- * When data is successfully written to [self.connection]([BOXAPIOperation connection])'s input stream,
- * this method is called to trigger progressBlock.
- * @see progressBlock
- */
-- (void)performProgressCallback;
-
 /** @name Multipart data handling */
 
 /**
@@ -57,6 +57,19 @@ typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsi
  */
 - (unsigned long long)contentLength;
 
+/**
+ * Append the contents of file at filePath as a multipart piece in the multipart form data. Data will be
+ * attached with a Content-Disposition header derived from fieldName and filename.
+ *
+ * @param filePath  Location of a file, whose content to be included in the body of this multipart piece.
+ * @param fieldName The value of the name component of the Content-Disposition header for this piece.
+ * @param filename  If this piece is a file, the value of the filename parameter of the Content-Disposition
+ *   header for this piece. filename should only be provided if this piece represents a file upload. Pass nil
+ *   otherwise.
+ * @param MIMEType  The MIME type of the provided data. This value will be included in this piece's Content-Type
+ *   header. MIMEType is optional. Pass nil if you do not wish to provide it.
+ */
+- (void)appendMultipartPieceWithFilePath:(NSString *)filePath fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType;
 /**
  * Append the contents of data as a multipart piece in the multipart form data. Data will be
  * attached with a Content-Disposition header derived from fieldName and filename.
@@ -109,253 +122,5 @@ typedef void (^BOXAPIMultipartProgressBlock)(unsigned long long totalBytes, unsi
  * @return nil
  */
 - (NSData *)encodeBody:(NSDictionary *)bodyDictionary;
-
-@end
-
-#pragma mark - Multipart Form pieces
-
-typedef enum {
-    BOXAPIMultipartPieceStateNotOpen = 0,
-    BOXAPIMultipartPieceStateInitialBoundary,
-    BOXAPIMultipartPieceStateHeaders,
-    BOXAPIMultipartPieceStateBodyData,
-    BOXAPIMultipartPieceStateFinalBoundary,
-    BOXAPIMultipartPieceStateClosed,
-} BOXAPIMultipartPieceState;
-
-/**
- * This class encapsulates one multipart form parameter. It provides one
- * interface to extract the data associated with this multipart piece that
- * will ouput raw bytes from the underlying components that make up the piece.
- * All components are represented as sreams. Components that are not streams
- * are converted to streams.
- *
- * These components are:
- *
- * - A form boundary (either initial or encapsulation)
- * - Headers included in the multipart piece (i.e.: Content-Type, Content-Disposition)
- * - The body data associated with this piece
- * - An optional final form boundary
- *
- * Clients of this class are expected to configure these components through the given
- * properties before reading from the underlying components.
- *
- * Reading data from an instance of this class is implemented as a state machine.
- * Reading from each component is represented as a distinct state. The read method
- * will only read data from one component during a single invocation.
- *
- * The states are:
- * - not open
- * - initial boundary
- * - headers
- * - body data
- * - final boundary
- * - closed
- *
- * @warning This class is used internally by BOXAPIMultipartTOJSONOperation
- * to implement [RFC 1876](http://tools.ietf.org/rfc/rfc1867.txt) compliant uploads.
- *
- * @warning This class presents an interface like an NSOutputStream, but it differs in several
- * key ways.
- */
-@interface BOXAPIMultipartPiece : NSObject
-
-/** @name State */
-
-/**
- * Headers associated with the multipart piece. These include Content-Disposition,
- * Content-Length, and Content-Type.
- */
-@property (nonatomic, readwrite, strong) NSMutableDictionary *headers;
-
-/**
- * An input stream generated from encoding headers.
- */
-@property (nonatomic, readwrite, strong) NSInputStream *headersInputStream;
-
-/**
- * An input stream for the body of the piece.
- */
-@property (nonatomic, readonly) NSInputStream *bodyInputStream;
-
-/**
- * The length of the data in bodyInputStream.
- */
-@property (nonatomic, readwrite, assign) unsigned long long bodyContentLength;
-
-/**
- * Whether this piece is the first piece in the request. Consumers of this class
- * should set this property to `YES` on the first instance of this class
- * written to a connection's input stream.
- *
- * This property determines whether startBoundaryInputStream is an encapsulation
- * boundary or an initial boundary.
- */
-@property (nonatomic, readwrite, assign) BOOL hasInitialBoundary;
-
-/**
- * An input stream generated from the first boundary of this piece. This boundary
- * may either be an initial boundary or an encapsulation boundary.
- */
-@property (nonatomic, readwrite, strong) NSInputStream *startBoundaryInputStream;
-
-/**
- * Whether this piece is the last piece in the request. Consumers of this class
- * should set this property to `YES` on the last instance of this class
- * written to a connection's input stream.
- *
- * This property determines whether endBoundaryInputStream is empty or
- * a final boundary.
- */
-@property (nonatomic, readwrite, assign) BOOL hasFinalBoundary;
-
-/**
- * An input stream generated from the end boundary of this piece. This boundary
- * may either be empty or a final boundary.
- */
-@property (nonatomic, readwrite, strong) NSInputStream *endBoundaryInputStream;
-
-/**
- * Encapsulates the current input stream this piece is reading from.
- */
-@property (nonatomic, readwrite, assign) BOXAPIMultipartPieceState state;
-
-/** @name Initializers */
-
-/**
- * Initialize a multipart piece with data as the body data
- *
- * @param data The data to be sent as the body of this multipart piece
- * @param fieldName The value of the name component of the Content-Disposition header for this piece.
- * @param filename If this piece is a file, the value of the filename parameter of the Content-Disposition
- *   header for this piece. filename should only be provided if this piece represents a file upload. Pass nil
- *   otherwise.
- */
-- (id)initWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename;
-
-/**
- * Initialize a multipart piece with data as the body data
- *
- * @param data The data to be sent as the body of this multipart piece
- * @param fieldName The value of the name component of the Content-Disposition header for this piece.
- * @param filename If this piece is a file, the value of the filename parameter of the Content-Disposition
- *   header for this piece. filename should only be provided if this piece represents a file upload. Pass nil
- *   otherwise.
- * @param MIMEType The MIME type of the provided data. This value will be included in this piece's Content-Type
- *   header. MIMEType is optional. Pass nil if you do not wish to provide it.
- */
-- (id)initWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType;
-
-/**
- * Initialize a multipart piece with inputStream as the body data
- *
- * @param inputStream A stream containing the data to be sent as the body of this multipart piece
- * @param fieldName The value of the name component of the Content-Disposition header for this piece.
- * @param filename If this piece is a file, the value of the filename parameter of the Content-Disposition
- *   header for this piece. filename should only be provided if this piece represents a file upload. Pass nil
- *   otherwise.
- */
-- (id)initWithInputStream:(NSInputStream *)inputStream fieldName:(NSString *)fieldName filename:(NSString *)filename;
-
-/**
- * Initialize a multipart piece with inputStream as the body data
- *
- * @param inputStream A stream containing the data to be sent as the body of this multipart piece
- * @param fieldName The value of the name component of the Content-Disposition header for this piece.
- * @param filename If this piece is a file, the value of the filename parameter of the Content-Disposition
- *   header for this piece. filename should only be provided if this piece represents a file upload. Pass nil
- *   otherwise.
- * @param MIMEType The MIME type of the provided data. This value will be included in this piece's Content-Type
- *   header. MIMEType is optional. Pass nil if you do not wish to provide it.
- */
-- (id)initWithInputStream:(NSInputStream *)inputStream fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType;
-
-/** @name Piece data */
-
-/**
- * The length in bytes of all components of this piece.
- *
- * @return The length in bytes of all components of this piece.
- */
-- (unsigned long long)contentLength;
-
-/**
- * The bytes representing the start boundary of this piece. This may be an encapsulation
- * boundary or an initial boundary.
- *
- * @see hasInitialBoundary
- *
- * @return The bytes representing the start boundary of this piece.
- */
-- (NSData *)startBoundaryData;
-
-/**
- * The bytes representing the end boundary of this piece. This may be empty
- * or a final boundary.
- *
- * @see hasFinalBoundary
- *
- * @return The bytes representing the end boundary of this piece.
- */
-- (NSData *)endBoundaryData;
-
-/**
- * The bytes representing the headers of this multipart piece.
- *
- * @return The bytes representing the headers of this multipart piece.
- */
-- (NSData *)headersData;
-
-/** @name Stream interaction */
-
-/**
- * This method is the main interface of this class. It reads from the streams of the
- * underlying piece components and places read bytes into outputData.
- *
- * This method returns -1 on failure to read from any of its underlying streams.
- *
- * @warning Unlike an NSInputStream, this method may return 0, yet still have data left to
- * read. This occurs whenever the multipart piece is switching between its component
- * input streams. To determine whether a piece has data left to read, use hasBytesAvailable.
- *
- * @see hasBytesAvailable
- *
- * @warning Neither outputData nor *outputData may be nil. If either are nil, an assertion
- * failure will be raised.
- *
- * @param outputData Data read from the underlying streams will be written into outputData's byte array
- * @param length The maximum amount of data to read into outputData
- * @param error an NSError pointer to be populated with a stream error if any. error will be populated if
- *   this method returns `-1`.
- *
- * @return The number of bytes written to outputData, or -1 on a stream error.
- */
-- (NSInteger)read:(NSMutableData **)outputData maxLength:(NSUInteger)length error:(NSError **)error;
-
-/**
- * Create the streams of the underlying components for reading.
- *
- * This method should be called on the state transition from `BOXAPIMultipartPieceStateNotOpen`
- * to `BOXAPIMultipartPieceStateInitialBoundary`.
- */
-- (void)initializeInputStreams;
-
-/**
- * Close the current stream and open the next one for reading.
- *
- * This method should be called when the input stream of one component reaches its end.
- */
-- (void)transitionToNextState;
-
-/**
- * Whether the multipart piece still has data left to read. This method returns true as long
- * as state is not `BOXAPIMultipartPieceStateClosed`
- */
-- (BOOL)hasBytesAvailable;
-
-/**
- * Closes all underlying component streams and advances state to `BOXAPIMultipartPieceStateClosed`.
- */
-- (void)close;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
@@ -12,7 +12,6 @@
 #import "BOXContentSDKErrors.h"
 #import "BOXLog.h"
 
-#define BOX_API_MULTIPART_CONTENT_DISPOSITION (@"Content-Disposition")
 #define BOX_API_MULTIPART_CONTENT_TYPE        (@"Content-Type")
 #define BOX_API_MULTIPART_CONTENT_LENGTH      (@"Content-Length")
 
@@ -21,346 +20,12 @@
 #pragma mark - Form Boundary Helpers
 
 static NSString *const BOXAPIMultipartFormBoundary = @"0xBoXSdKMulTiPaRtFoRmBoUnDaRy";
-static NSString *const BOXAPIMultipartFormCRLF     = @"\r\n";
-
-static NSString * BOXAPIMultipartInitialBoundary(void)
-{
-    return [NSString stringWithFormat:@"--%@%@", BOXAPIMultipartFormBoundary, BOXAPIMultipartFormCRLF];
-}
-
-static NSString * BOXAPIMultipartEncapsulationBoundary(void)
-{
-    return [NSString stringWithFormat:@"%@--%@%@", BOXAPIMultipartFormCRLF, BOXAPIMultipartFormBoundary, BOXAPIMultipartFormCRLF];
-}
-
-static NSString * BOXAPIMultipartFinalBoundary(void)
-{
-    return [NSString stringWithFormat:@"%@--%@--%@", BOXAPIMultipartFormCRLF, BOXAPIMultipartFormBoundary, BOXAPIMultipartFormCRLF];
-}
 
 static NSString * BOXAPIMultipartContentTypeHeader(void)
 {
     return [NSString stringWithFormat:@"multipart/form-data; boundary=%@", BOXAPIMultipartFormBoundary];
 }
 
-@implementation BOXAPIMultipartPiece
-
-@synthesize headers = _headers;
-@synthesize headersInputStream = _headersInputStream;
-@synthesize bodyInputStream = _bodyInputStream;
-@synthesize bodyContentLength = _bodyContentLength;
-@synthesize hasInitialBoundary = _hasInitialBoundary;
-@synthesize startBoundaryInputStream = _startBoundaryInputStream;
-@synthesize hasFinalBoundary = _hasFinalBoundary;
-@synthesize endBoundaryInputStream = _endBoundaryInputStream;
-@synthesize state = _state;
-
-- (id)initWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename
-{
-    self = [self initWithData:data fieldName:fieldName filename:filename MIMEType:nil];
-
-    return self;
-}
-
-- (id)initWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
-{
-    self = [self initWithInputStream:[NSInputStream inputStreamWithData:data] fieldName:fieldName filename:filename MIMEType:MIMEType];
-
-    if (self != nil)
-    {
-        _bodyContentLength = data.length;
-    }
-
-    return self;
-}
-
-- (id)initWithInputStream:(NSInputStream *)inputStream fieldName:(NSString *)fieldName filename:(NSString *)filename
-{
-    self = [self initWithInputStream:inputStream fieldName:fieldName filename:filename MIMEType:nil];
-
-    return self;
-}
-
-- (id)initWithInputStream:(NSInputStream *)inputStream fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
-{
-    self = [super init];
-    if (self != nil)
-    {
-        _state = BOXAPIMultipartPieceStateNotOpen;
-
-        _bodyContentLength = 0;
-        _hasInitialBoundary = NO;
-        _hasFinalBoundary = NO;
-
-        _headers = [NSMutableDictionary dictionary];
-
-        // attach the parameter name as the Content-Disposition header
-        BOXAssert(fieldName != nil, @"field name must be specified when sending multipart form data");
-        NSString *contentDispositionHeader = [NSString stringWithFormat:@"form-data; name=\"%@\"", fieldName];
-        if (filename != nil)
-        {
-            contentDispositionHeader = [contentDispositionHeader stringByAppendingFormat:@"; filename=\"%@\"", filename];
-        }
-        [_headers setObject:contentDispositionHeader forKey:BOX_API_MULTIPART_CONTENT_DISPOSITION];
-
-        // add the optionally given MIME Type as the Content-Type header
-        if (MIMEType != nil)
-        {
-            [_headers setObject:MIMEType forKey:BOX_API_MULTIPART_CONTENT_TYPE];
-        }
-
-        _bodyInputStream = inputStream;
-    }
-
-    return self;
-}
-
-- (unsigned long long)contentLength
-{
-    unsigned long long contentLength = 0;
-
-    contentLength += [self startBoundaryData].length;
-    contentLength += [self headersData].length;
-    contentLength += self.bodyContentLength;
-    contentLength += [self endBoundaryData].length;
-
-    return contentLength;
-}
-
-- (NSData *)startBoundaryData
-{
-    NSData *startBoundaryData = nil;
-    if (self.hasInitialBoundary)
-    {
-        startBoundaryData = [BOXAPIMultipartInitialBoundary() dataUsingEncoding:NSUTF8StringEncoding];
-    }
-    else
-    {
-        startBoundaryData = [BOXAPIMultipartEncapsulationBoundary() dataUsingEncoding:NSUTF8StringEncoding];
-    }
-
-    return startBoundaryData;
-}
-
-- (NSData *)endBoundaryData
-{
-    NSData *endBoundaryData = nil;
-    if (self.hasFinalBoundary)
-    {
-        endBoundaryData = [BOXAPIMultipartFinalBoundary() dataUsingEncoding:NSUTF8StringEncoding];
-    }
-    else
-    {
-        endBoundaryData = [[NSData alloc] init];
-    }
-
-    return endBoundaryData;
-}
-
-- (NSData *)headersData
-{
-    NSMutableData *headersData = [NSMutableData data];
-
-    for (id headerName in self.headers)
-    {
-        id headerValue = [self.headers valueForKey:headerName];
-        NSString *headerString = [NSString stringWithFormat:@"%@: %@%@", headerName, headerValue, BOXAPIMultipartFormCRLF];
-        [headersData appendData:[headerString dataUsingEncoding:NSUTF8StringEncoding]];
-    }
-
-    [headersData appendData:[BOXAPIMultipartFormCRLF dataUsingEncoding:NSUTF8StringEncoding]];
-    return headersData;
-}
-
-- (NSInteger)read:(NSMutableData **)outputData maxLength:(NSUInteger)length error:(NSError **)error
-{
-    NSInteger bytesRead = 0;
-
-    BOXAssert(outputData != nil, @"outputData is a required out param. It must be non nil");
-    NSMutableData *data = *outputData;
-    BOXAssert(data != nil, @"ouputData is a required out param. It must point to the address of a non-nil NSMutableData");
-
-    data.length = length;
-    uint8_t *buffer = [data mutableBytes];
-
-    if (self.state == BOXAPIMultipartPieceStateNotOpen)
-    {
-        [self initializeInputStreams];
-        [self transitionToNextState];
-    }
-    else if (self.state == BOXAPIMultipartPieceStateInitialBoundary)
-    {
-        if ([self.startBoundaryInputStream hasBytesAvailable])
-        {
-            bytesRead += [self.startBoundaryInputStream read:buffer maxLength:length];
-        }
-        else
-        {
-            [self transitionToNextState];
-        }
-    }
-    else if (self.state == BOXAPIMultipartPieceStateHeaders)
-    {
-        if ([self.headersInputStream hasBytesAvailable])
-        {
-            bytesRead += [self.headersInputStream read:buffer maxLength:length];
-        }
-        else
-        {
-            [self transitionToNextState];
-        }
-    }
-    else if (self.state == BOXAPIMultipartPieceStateBodyData)
-    {
-        if ([self.bodyInputStream hasBytesAvailable])
-        {
-            bytesRead += [self.bodyInputStream read:buffer maxLength:length];
-        }
-        else
-        {
-            [self transitionToNextState];
-        }
-    }
-    else if (self.state == BOXAPIMultipartPieceStateFinalBoundary)
-    {
-        if ([self.endBoundaryInputStream hasBytesAvailable])
-        {
-            bytesRead += [self.endBoundaryInputStream read:buffer maxLength:length];
-        }
-        else
-        {
-            [self transitionToNextState];
-        }
-    }
-
-    BOXAssert(bytesRead == -1 || bytesRead <= length, @"should have read no more than %lu bytes", (unsigned long) length);
-
-    if (bytesRead == -1)
-    {
-        switch (self.state)
-        {
-            case BOXAPIMultipartPieceStateInitialBoundary:
-                BOXLog(@"failed to read from input stream for multipart piece %@ during phase %@", self, @"initial boundary");
-                if (error != NULL)
-                {
-                    *error = [self.startBoundaryInputStream streamError];
-                }
-                break;
-            case BOXAPIMultipartPieceStateHeaders:
-                BOXLog(@"failed to read from input stream for multipart piece %@ during phase %@", self, @"headers");
-                if (error != NULL)
-                {
-                    *error = [self.headersInputStream streamError];
-                }
-                break;
-            case BOXAPIMultipartPieceStateBodyData:
-                BOXLog(@"failed to read from input stream for multipart piece %@ during phase %@", self, @"body data");
-                if (error != NULL)
-                {
-                    *error = [self.bodyInputStream streamError];
-                }
-                break;
-            case BOXAPIMultipartPieceStateFinalBoundary:
-                BOXLog(@"failed to read from input stream for multipart piece %@ during phase %@", self, @"final boundary");
-                if (error != NULL)
-                {
-                    *error = [self.endBoundaryInputStream streamError];
-                }
-                break;
-            case BOXAPIMultipartPieceStateClosed:
-                // fall through
-            case BOXAPIMultipartPieceStateNotOpen:
-                // fall through
-            default:
-                BOXAssertFail(@"This state should not be reachable. We are not reading from streams during these states");
-        }
-
-        [self close];
-    }
-    else
-    {
-        // only set length of buffer if read was successful
-        data.length = bytesRead;
-    }
-
-    return bytesRead;
-}
-
-- (void)initializeInputStreams
-{
-    self.startBoundaryInputStream = [NSInputStream inputStreamWithData:[self startBoundaryData]];
-    self.endBoundaryInputStream = [NSInputStream inputStreamWithData:[self endBoundaryData]];
-    self.headersInputStream = [NSInputStream inputStreamWithData:[self headersData]];
-}
-
-- (void)transitionToNextState
-{
-    BOXAPIMultipartPieceState nextState = BOXAPIMultipartPieceStateClosed;
-
-    switch (self.state)
-    {
-        case BOXAPIMultipartPieceStateNotOpen:
-            nextState = BOXAPIMultipartPieceStateInitialBoundary;
-            [self.startBoundaryInputStream open];
-            break;
-        case BOXAPIMultipartPieceStateInitialBoundary:
-            nextState = BOXAPIMultipartPieceStateHeaders;
-            [self.startBoundaryInputStream close];
-            [self.headersInputStream open];
-            break;
-        case BOXAPIMultipartPieceStateHeaders:
-            nextState = BOXAPIMultipartPieceStateBodyData;
-            [self.headersInputStream close];
-            [self.bodyInputStream open];
-            break;
-        case BOXAPIMultipartPieceStateBodyData:
-            nextState = BOXAPIMultipartPieceStateFinalBoundary;
-            [self.bodyInputStream close];
-            [self.endBoundaryInputStream open];
-            break;
-        case BOXAPIMultipartPieceStateFinalBoundary:
-            nextState = BOXAPIMultipartPieceStateClosed;
-            [self.endBoundaryInputStream close];
-            break;
-        case BOXAPIMultipartPieceStateClosed:
-            // fall through
-        default:
-            nextState = BOXAPIMultipartPieceStateClosed;
-    }
-
-    self.state = nextState;
-}
-
-- (BOOL)hasBytesAvailable
-{
-    if (self.state == BOXAPIMultipartPieceStateClosed)
-    {
-        return NO;
-    }
-    else
-    {
-        return YES;
-    }
-}
-
-- (void)close
-{
-    [self.startBoundaryInputStream close];
-    [self.headersInputStream close];
-    [self.bodyInputStream close];
-    [self.endBoundaryInputStream close];
-
-    self.state = BOXAPIMultipartPieceStateClosed;
-}
-
-- (NSString *)description
-{
-    return [[super description] stringByAppendingFormat:@" BOXAPIMultipartPiece with body content-disposition: %@, content-length: %llu",
-            [self.headers objectForKey:BOX_API_MULTIPART_CONTENT_DISPOSITION],
-            [self contentLength]];
-}
-
-@end
 
 #pragma mark - Upload Operation
 
@@ -369,19 +34,10 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
     dispatch_once_t _pred;
 }
 
-@property (nonatomic, readwrite, strong) NSMutableArray *formPieces;
-@property (nonatomic, readwrite, assign) unsigned long long bytesWritten;
-
-@property (nonatomic, readonly) NSOutputStream *outputStream;
-@property (nonatomic, readonly) NSMutableData *outputBuffer;
-@property (nonatomic, readonly) NSInputStream *inputStream;
-
-@property (nonatomic, readwrite, strong) BOXAPIMultipartPiece *currentPiece;
-@property (nonatomic, readwrite, strong) NSEnumerator *pieceEnumerator;
+@property (nonatomic, readwrite, strong) BOXMultipartBodyStream *inputStream;
 
 - (NSDictionary *)HTTPHeaders;
 
-- (void)initStreams;
 - (void)close;
 
 // called on stream read error
@@ -391,84 +47,103 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
 
 @implementation BOXAPIMultipartToJSONOperation
 
-@synthesize responseJSON = _responseJSON;
-@synthesize formPieces = _formPieces;
-@synthesize bytesWritten = _bytesWritten;
-@synthesize outputStream = _outputStream;
-@synthesize outputBuffer = _outputBuffer;
-@synthesize inputStream = _inputStream;
-
-@synthesize currentPiece = _currentPiece;
-@synthesize pieceEnumerator = _pieceEnumerator;
-
-@synthesize progressBlock = _progressBlock;
-
-#pragma mark - Upload operation initializers
-
-- (id)initWithURL:(NSURL *)URL HTTPMethod:(NSString *)HTTPMethod body:(NSDictionary *)body queryParams:(NSDictionary *)queryParams session:(BOXAbstractSession *)session
-{
-    // do not pass body to super because we do not wish to JSON-encode it. The body will be converted to
-    // NSDatas and appended as multipart form pieces
-    self = [super initWithURL:URL HTTPMethod:HTTPMethod body:nil queryParams:queryParams session:session];
-    if (self != nil)
-    {
-        _formPieces = [NSMutableArray array];
-        _bytesWritten = 0;
-        _outputBuffer = [NSMutableData dataWithCapacity:0];
-        for (id bodyKey in body)
-        {
-            NSData *formDataToAppend = nil;
-            id bodyValue = [body valueForKey:bodyKey];
-            if ([bodyValue isKindOfClass:[NSData class]])
-            {
-                formDataToAppend = bodyValue;
-            }
-            else if ([bodyValue isKindOfClass:[NSNull class]])
-            {
-                formDataToAppend = [NSData data];
-            }
-            else // most likely this is a string
-            {
-                formDataToAppend = [[bodyValue description] dataUsingEncoding:NSUTF8StringEncoding];
-            }
-
-            BOXAPIMultipartPiece *piece = [[BOXAPIMultipartPiece alloc] initWithData:formDataToAppend fieldName:[bodyKey description] filename:nil];
-            [_formPieces addObject:piece];
-        }
-    }
-
-    return self;
-}
-
 #pragma mark - Append data to upload operation
 
 - (void)appendMultipartPieceWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
 {
-    BOXAPIMultipartPiece *piece = [[BOXAPIMultipartPiece alloc] initWithData:data fieldName:fieldName filename:filename MIMEType:MIMEType];
-    [self.formPieces addObject:piece];
+    self.inputStream = [[BOXHTTPRequestSerializer serializer] multipartInputStreamWithParameters:self.body boundary:BOXAPIMultipartFormBoundary constructingBodyWithBlock:^(id<BOXMultipartFormData> formData) {
+        [formData appendPartWithFileData:data name:fieldName fileName:filename mimeType:MIMEType];
+    }];
 }
 
 - (void)appendMultipartPieceWithInputStream:(NSInputStream *)inputStream contentLength:(unsigned long long)length fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
 {
-    BOXAPIMultipartPiece *piece = [[BOXAPIMultipartPiece alloc] initWithInputStream:inputStream fieldName:fieldName filename:filename MIMEType:MIMEType];
-    piece.bodyContentLength = length;
-    [self.formPieces addObject:piece];
+    self.inputStream = [[BOXHTTPRequestSerializer serializer] multipartInputStreamWithParameters:self.body boundary:BOXAPIMultipartFormBoundary constructingBodyWithBlock:^(id<BOXMultipartFormData> formData) {
+        [formData appendPartWithInputStream:inputStream name:fieldName fileName:filename length:length mimeType:MIMEType];
+    }];
 }
 
+- (void)appendMultipartPieceWithFilePath:(NSString *)filePath fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
+{
+    self.inputStream = [[BOXHTTPRequestSerializer serializer] multipartInputStreamWithParameters:self.body boundary:BOXAPIMultipartFormBoundary constructingBodyWithBlock:^(id<BOXMultipartFormData> formData) {
+        [formData appendPartWithFileURL:[NSURL fileURLWithPath:filePath] name:fieldName fileName:filename mimeType:MIMEType error:nil];
+    }];
+}
 #pragma mark -
+
+- (BOOL)shouldUseSessionTask
+{
+    return YES;
+}
+
+- (BOOL)shouldRunInBackground
+{
+    return self.tempUploadFilePath != nil;
+}
+
+- (NSURLSessionTask *)createSessionTask
+{
+    NSURLSessionTask *sessionTask;
+    if (self.shouldRunInBackground == YES) {
+        NSURL *url = [[NSURL alloc] initFileURLWithPath:self.tempUploadFilePath];
+        sessionTask = [self.session.urlSessionManager createBackgroundUploadTaskWithRequest:self.APIRequest fromFile:url taskDelegate:self];
+    } else {
+        sessionTask = [self.session.urlSessionManager createNonBackgroundUploadTaskWithStreamedRequest:self.APIRequest taskDelegate:self];
+    }
+    return sessionTask;
+}
+
+- (void)progressWithTotalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
+{
+    if (self.progressBlock) {
+        self.progressBlock(totalBytesExpectedToSend, totalBytesSent);
+    }
+}
+
+- (void)processIntermediateData:(NSData *)data
+{
+    @synchronized (self) {
+        if (data != nil) {
+            [self processResponseData:data];
+        }
+    }
+}
+
+- (void)finishURLSessionTaskWithResponse:(NSURLResponse *)response error:(NSError *)error
+{
+    @synchronized (self) {
+        if (error == nil && self.error == nil && self.responseJSON == nil) {
+            self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKJSONErrorDecodeFailed userInfo:nil];
+        }
+        [super finishURLSessionTaskWithResponse:response error:error];
+    }
+}
 
 - (void)prepareAPIRequest
 {
     [super prepareAPIRequest];
 
-    // HTTPHeaders is dependent on the content-length of the underlying pieces.
-    // initialize the pieces first so boundaries can be set
-    [self initStreams];
-
     [self.APIRequest setAllHTTPHeaderFields:[self HTTPHeaders]];
-
-    // attach body stream to request
     [self.APIRequest setHTTPBodyStream:self.inputStream];
+
+    //if provided tempUploadFilePath, write the APIRequest's HTTPBodyStream into a multi-part formatted file
+    //which is required for background upload
+    if (self.shouldRunInBackground == YES) {
+        NSURL *tempUploadFileURL = [[NSURL alloc] initFileURLWithPath:self.tempUploadFilePath];
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        __weak BOXAPIMultipartToJSONOperation *weakSelf = self;
+
+        self.APIRequest = [[BOXHTTPRequestSerializer serializer] requestWithMultipartFormRequest:self.APIRequest
+                                                   writingStreamContentsToFile:tempUploadFileURL
+                                                             completionHandler:^(NSError * error){
+                                                                 if (error != nil) {
+                                                                     [weakSelf abortWithError:error];
+                                                                 }
+                                                                 dispatch_semaphore_signal(sema);
+        }];
+
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    }
 }
 
 // Override this method to turn it into a NO-OP. The multipart operation will attach itself
@@ -478,25 +153,11 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
     return nil;
 }
 
-- (void)performProgressCallback
-{
-    if (self.progressBlock)
-    {
-        self.progressBlock([self contentLength], self.bytesWritten);
-    }
-}
-
 #pragma mark - Multipart Stream methods
 
 - (unsigned long long)contentLength
 {
-    unsigned long long contentLength = 0;
-    for (BOXAPIMultipartPiece *piece in self.formPieces)
-    {
-        contentLength += piece.contentLength;
-    }
-
-    return contentLength;
+    return [self.inputStream contentLength];
 }
 
 - (NSDictionary *)HTTPHeaders
@@ -504,185 +165,17 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     [headers setObject:BOXAPIMultipartContentTypeHeader() forKey:BOX_API_MULTIPART_CONTENT_TYPE];
     [headers setObject:[NSString stringWithFormat:@"%llu", [self contentLength]] forKey:BOX_API_MULTIPART_CONTENT_LENGTH];
-
     return [NSDictionary dictionaryWithDictionary:headers];
-}
-
-- (void)initStreams
-{
-    dispatch_once(&_pred, ^{
-        CFReadStreamRef readStream;
-        CFWriteStreamRef writeStream;
-        CFStreamCreateBoundPair(NULL, &readStream, &writeStream, BOX_API_OUTPUT_STREAM_BUFFER_SIZE);
-        _inputStream = CFBridgingRelease(readStream);
-        _outputStream = CFBridgingRelease(writeStream);
-
-        _outputStream.delegate = self;
-        [_outputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-
-        [_outputStream open];
-
-        BOXAPIMultipartPiece *initialPiece = [self.formPieces objectAtIndex:0];
-        initialPiece.hasInitialBoundary = YES;
-
-        BOXAPIMultipartPiece *finalPiece = [self.formPieces lastObject];
-        finalPiece.hasFinalBoundary = YES;
-    });
-}
-
-- (void)close
-{
-    self.outputStream.delegate = nil;
-    [self.outputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-
-    [self.outputStream close];
-    _outputStream = nil;
 }
 
 - (void)abortWithError:(NSError *)error
 {
-    [self close];
     [self.connection cancel];
     [self.sessionTask cancel];
     [self connection:self.connection didFailWithError:error];
 }
 
-#pragma mark - NSStream Delegate
-
-/**
- *This retry works around a nasty problem in which mutli-part uploads
- * will fail due to the stream delegate being sent a `NSStreamEventHasSpaceAvailable`
- * event before the input stream has finished opening. This workaround simply replays
- * the event after allowing the run-loop to cycle, providing enough time for the input
- * stream to finish opening. It appears that this bug is in the CFNetwork layer.
- * (See https://github.com/AFNetworking/AFNetworking/issues/948)
- *
- * @param stream The stream to resend a `NSStreamEventHasSpaceAvailable` event to
- */
-- (void)retryWrite:(NSStream *)stream
-{
-    [self stream:stream handleEvent:NSStreamEventHasSpaceAvailable];
-}
-
-- (void)stream:(NSStream *)theStream handleEvent:(NSStreamEvent)streamEvent
-{
-    if (self.isCancelled) {
-        [self close];
-        return;
-    }
-    
-    if (streamEvent & NSStreamEventHasSpaceAvailable)
-    {
-        if (self.inputStream.streamStatus < NSStreamStatusOpen)
-        {
-            // See comments in `retryWrite:` for details
-            [self performSelector:@selector(retryWrite:) withObject:theStream afterDelay:0.1];
-        }
-        else
-        {
-            [self writeDataToOutputStream];
-        }
-    }
-}
-
-- (void)writeDataToOutputStream
-{
-    while ([self.outputStream hasSpaceAvailable])
-    {
-        if (self.isCancelled) {
-            [self close];
-            return;
-        }
-        
-        if (self.outputBuffer.length > 0)
-        {
-            NSInteger bytesWrittenToOutputStream = [self.outputStream write:[self.outputBuffer mutableBytes] maxLength:self.outputBuffer.length];
-
-            if (bytesWrittenToOutputStream == -1)
-            {
-                // Failed to write from to output stream. The upload cannot be completed
-                BOXLog(@"BOXAPIMultipartToJSONOperation failed to write to the output stream. Aborting upload.");
-                NSError *streamWriteError = [self.outputStream streamError];
-                NSDictionary *userInfo = @{
-                    NSUnderlyingErrorKey : streamWriteError,
-                };
-                NSError *uploadError = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKStreamErrorWriteFailed userInfo:userInfo];
-                [self abortWithError:uploadError];
-
-                return; // Bail out due to error
-            }
-            else
-            {
-                self.bytesWritten += bytesWrittenToOutputStream;
-                [self performProgressCallback];
-
-                // truncate buffer by removing the consumed bytes from the front
-                [self.outputBuffer replaceBytesInRange:NSMakeRange(0, bytesWrittenToOutputStream) withBytes:NULL length:0];
-            }
-        }
-        else
-        {
-            // prime reading from the stream
-            if (self.currentPiece == nil)
-            {
-                if (self.pieceEnumerator == nil)
-                {
-                    self.pieceEnumerator = [self.formPieces objectEnumerator];
-                }
-                self.currentPiece = [self.pieceEnumerator nextObject];
-            }
-
-            // if there is no currentPiece by now, we have enumerated through all pieces,
-            // so close the stream. No more stream events will be received.
-            if (self.currentPiece == nil)
-            {
-                [self close];
-                return; // Upload finished, break out of loop
-            }
-
-            if ([self.currentPiece hasBytesAvailable])
-            {
-                self.outputBuffer.length = BOX_API_OUTPUT_STREAM_BUFFER_SIZE;
-                NSMutableData *buffer = self.outputBuffer;
-                NSError *streamReadError = nil;
-                NSInteger bytesReadFromPiece = [self.currentPiece read:&buffer maxLength:BOX_API_OUTPUT_STREAM_BUFFER_SIZE error:&streamReadError];
-
-                if (bytesReadFromPiece == -1)
-                {
-                    // Failed to read from an input stream. The upload cannot be completed
-                    BOXLog(@"BOXAPIMultipartToJSONOperation failed to read from a multipart piece. Aborting upload.");
-                    NSDictionary *userInfo = @{
-                        NSUnderlyingErrorKey : streamReadError,
-                    };
-                    NSError *uploadError = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKStreamErrorReadFailed userInfo:userInfo];
-                    [self abortWithError:uploadError];
-
-                    return; // Bail out due to error
-                }
-                else
-                {
-                    self.outputBuffer.length = bytesReadFromPiece;
-                }
-            }
-            else
-            {
-                self.currentPiece = [self.pieceEnumerator nextObject];
-            }
-        }
-    }
-}
-
 - (BOOL)canBeReenqueued
-{
-    return NO;
-}
-
-- (void)dealloc
-{
-    _outputStream.delegate = nil;
-}
-
-- (BOOL)shouldUseSessionTask
 {
     return NO;
 }

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
@@ -11,7 +11,7 @@
 #import "BOXOAuth2Session.h"
 
 #import "BOXContentSDKConstants.h"
-#import "BOXNSURLSessionManager.h"
+#import "BOXURLSessionManager.h"
 
 // Success and Failure callbacks
 //
@@ -87,7 +87,7 @@ typedef void (^BOXSessionTaskReplacedBlock)(NSURLSessionTask *oldSessionTask, NS
  * - performCompletionCallback
  *
  */
-@interface BOXAPIOperation : NSOperation <NSURLConnectionDataDelegate, BOXNSURLSessionTaskDelegate>
+@interface BOXAPIOperation : NSOperation <NSURLConnectionDataDelegate, BOXURLSessionTaskDelegate>
 
 /** @name Authorization */
 
@@ -237,7 +237,7 @@ typedef void (^BOXSessionTaskReplacedBlock)(NSURLSessionTask *oldSessionTask, NS
  */
 - (void)startURLConnection;
 
-#pragma mark - Process API call results BOXNSURLSessionTaskDelegate
+#pragma mark - Process API call results BOXURLSessionTaskDelegate
 /** @name Process API call results */
 
 /**

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
@@ -550,9 +550,9 @@ static BOOL BoxOperationStateTransitionIsValid(BOXAPIOperationState fromState, B
     [self finish];
 }
 
-#pragma mark - BOXNSURLSessionTaskDelegate
+#pragma mark - BOXURLSessionTaskDelegate
 
-- (void)finishURLSessionTaskWithResponse:(NSURLResponse *)response error:(NSError *)error
+- (void)sessionTask:(NSURLSessionTask *)sessionTask didFinishWithResponse:(NSURLResponse *)response error:(NSError *)error
 {
     [self finishURLSessionTaskWithData:nil response:response error:error];
 }

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
@@ -19,8 +19,8 @@
 
 - (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath;
 
-//initialize a request which will run in the background even if app terminates if tempUploadFilePath is provided
-- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath tempUploadFilePath:(NSString *)tempUploadFilePath;
+//initialize a request which will run in the background even if app terminates if uploadMultipartCopyFilePath is provided
+- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath;
 
 - (instancetype)initWithFileID:(NSString *)fileID data:(NSData *)data;
 - (instancetype)initWithFileID:(NSString *)fileID

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
@@ -18,6 +18,10 @@
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
 - (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath;
+
+//initialize a request which will run in the background even if app terminates if tempUploadFilePath is provided
+- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath tempUploadFilePath:(NSString *)tempUploadFilePath;
+
 - (instancetype)initWithFileID:(NSString *)fileID data:(NSData *)data;
 - (instancetype)initWithFileID:(NSString *)fileID
                        ALAsset:(ALAsset *)asset

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -15,7 +15,7 @@
 @interface BOXFileUploadNewVersionRequest ()
 
 @property (nonatomic, readwrite, strong) NSString *localFilePath;
-@property (nonatomic, readwrite, strong) NSString *tempUploadFilePath;
+@property (nonatomic, readwrite, strong) NSString *uploadMultipartCopyFilePath;
 @property (nonatomic, readwrite, strong) NSData *fileData;
 
 @end
@@ -32,11 +32,11 @@
     return self;
 }
 
-- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath tempUploadFilePath:(NSString *)tempUploadFilePath
+- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
 {
     self = [self initWithFileID:fileID localPath:localPath];
     if (self != nil) {
-        self.tempUploadFilePath = tempUploadFilePath;
+        self.uploadMultipartCopyFilePath = uploadMultipartCopyFilePath;
     }
     return self;
 }
@@ -83,7 +83,7 @@
                                                                                       session:self.queueManager.session];
     
     if ([self.localFilePath length] > 0 && [[NSFileManager defaultManager] fileExistsAtPath:self.localFilePath]) {
-        operation.tempUploadFilePath = self.tempUploadFilePath;
+        operation.uploadMultipartCopyFilePath = self.uploadMultipartCopyFilePath;
         [operation appendMultipartPieceWithFilePath:self.localFilePath
                                           fieldName:BOXAPIMultipartParameterFieldKeyFile
                                            filename:@""

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
@@ -23,6 +23,10 @@
 @property (nonatomic, readwrite, assign) BOOL enableCheckForCorruptionInTransit;
 
 - (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID;
+
+//initialize a request which will run in the background even if app terminates if tempUploadFilePath is provided
+- (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID tempUploadFilePath:(NSString *)tempUploadFilePath;
+
 - (instancetype)initWithName:(NSString *)fileName targetFolderID:(NSString *)folderID data:(NSData *)data;
 - (instancetype)initWithALAsset:(ALAsset *)asset assetsLibrary:(ALAssetsLibrary *)assetsLibrary targetForlderID:(NSString *)folderID;
 - (void)performRequestWithProgress:(BOXProgressBlock)progressBlock completion:(BOXFileBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
@@ -24,8 +24,8 @@
 
 - (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID;
 
-//initialize a request which will run in the background even if app terminates if tempUploadFilePath is provided
-- (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID tempUploadFilePath:(NSString *)tempUploadFilePath;
+//initialize a request which will run in the background even if app terminates if uploadMultipartCopyFilePath is provided
+- (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath;
 
 - (instancetype)initWithName:(NSString *)fileName targetFolderID:(NSString *)folderID data:(NSData *)data;
 - (instancetype)initWithALAsset:(ALAsset *)asset assetsLibrary:(ALAssetsLibrary *)assetsLibrary targetForlderID:(NSString *)folderID;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
@@ -18,7 +18,7 @@
 @interface BOXFileUploadRequest ()
 
 @property (nonatomic, readwrite, strong) NSString *localFilePath;
-@property (nonatomic, readwrite, strong) NSString *tempUploadFilePath;
+@property (nonatomic, readwrite, strong) NSString *uploadMultipartCopyFilePath;
 @property (nonatomic, readwrite, strong) NSData *fileData;
 
 @end
@@ -48,11 +48,11 @@
 
 - (instancetype)initWithPath:(NSString *)filePath
               targetFolderID:(NSString *)folderID
-          tempUploadFilePath:(NSString *)tempUploadFilePath
+ uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
 {
     self = [self initWithPath:filePath targetFolderID:folderID];
     if (self != nil) {
-        self.tempUploadFilePath = tempUploadFilePath;
+        self.uploadMultipartCopyFilePath = uploadMultipartCopyFilePath;
     }
     return self;
 }
@@ -126,7 +126,7 @@
                                               session:self.queueManager.session];
 
     if ([self.localFilePath length] > 0 && [[NSFileManager defaultManager] fileExistsAtPath:self.localFilePath]) {
-        operation.tempUploadFilePath = self.tempUploadFilePath;
+        operation.uploadMultipartCopyFilePath = self.uploadMultipartCopyFilePath;
 
         [operation appendMultipartPieceWithFilePath:self.localFilePath
                                           fieldName:BOXAPIMultipartParameterFieldKeyFile

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
@@ -18,6 +18,7 @@
 @interface BOXFileUploadRequest ()
 
 @property (nonatomic, readwrite, strong) NSString *localFilePath;
+@property (nonatomic, readwrite, strong) NSString *tempUploadFilePath;
 @property (nonatomic, readwrite, strong) NSData *fileData;
 
 @end
@@ -42,6 +43,17 @@
         _localFilePath = filePath;
     }
 
+    return self;
+}
+
+- (instancetype)initWithPath:(NSString *)filePath
+              targetFolderID:(NSString *)folderID
+          tempUploadFilePath:(NSString *)tempUploadFilePath
+{
+    self = [self initWithPath:filePath targetFolderID:folderID];
+    if (self != nil) {
+        self.tempUploadFilePath = tempUploadFilePath;
+    }
     return self;
 }
 
@@ -114,17 +126,12 @@
                                               session:self.queueManager.session];
 
     if ([self.localFilePath length] > 0 && [[NSFileManager defaultManager] fileExistsAtPath:self.localFilePath]) {
-        NSInputStream *inputStream = [[NSInputStream alloc] initWithFileAtPath:self.localFilePath];
+        operation.tempUploadFilePath = self.tempUploadFilePath;
 
-        NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:self.localFilePath
-                                                                                        error:nil];
-        unsigned long long contentLength = [fileAttributes fileSize];
-
-        [operation appendMultipartPieceWithInputStream:inputStream
-                                         contentLength:contentLength
-                                             fieldName:BOXAPIMultipartParameterFieldKeyFile
-                                              filename:fileName
-                                              MIMEType:nil];
+        [operation appendMultipartPieceWithFilePath:self.localFilePath
+                                          fieldName:BOXAPIMultipartParameterFieldKeyFile
+                                           filename:fileName
+                                           MIMEType:nil];
     } else if (self.fileData != nil) {
         [operation appendMultipartPieceWithData:self.fileData
                                       fieldName:BOXAPIMultipartParameterFieldKeyFile

--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
@@ -10,7 +10,7 @@
 #import "BOXAuthenticationPickerViewController.h"
 #import "BOXSampleAppSessionManager.h"
 
-@interface BOXSampleAppDelegate () <BOXNSURLSessionManagerDelegate>
+@interface BOXSampleAppDelegate () <BOXURLSessionManagerDelegate>
 
 @property (nonatomic, strong, readwrite) NSMutableDictionary *sessionIdToRequest;
 
@@ -21,7 +21,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 #warning Set the client ID and client secret that can be retrieved by creating an application at http://developers.box.com
-    [BOXContentClient setClientID:@"your_client_id" clientSecret:@"your_client_secret"];
+    [BOXContentClient setClientID:@"mr484mz72rq0gxvvbgc9a79q96kbws5l" clientSecret:@"E6jgm6foaRFKRTl5FB0MtcRZBCEM4UC8"];
     
     BOXAuthenticationPickerViewController *authenticationController = [[BOXAuthenticationPickerViewController alloc]init];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:authenticationController];
@@ -37,7 +37,7 @@
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        BOXNSURLSessionManager *manager = [BOXContentClient defaultClient].session.urlSessionManager;
+        BOXURLSessionManager *manager = [BOXContentClient defaultClient].session.urlSessionManager;
         [manager setUpWithDefaultDelegate:self];
     });
 }
@@ -79,7 +79,7 @@
 }
 
 - (void)downloadTask:(NSURLSessionDownloadTask *)downloadTask
-   totalBytesWritten:(int64_t)totalBytesWritten
+  didWriteTotalBytes:(int64_t)totalBytesWritten
 totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
     NSLog(@"sessionTaskId %lu, totalBytesWritten %lld, totalBytesExpectedToWrite %lld", (unsigned long)downloadTask.taskIdentifier, totalBytesWritten, totalBytesExpectedToWrite);
@@ -98,14 +98,14 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
     }
 }
 
-- (void)uploadTask:(NSURLSessionDataTask *)sessionTask
-    totalBytesSent:(int64_t)totalBytesSent
+- (void)sessionTask:(NSURLSessionTask *)sessionTask
+  didSendTotalBytes:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     NSLog(@"uploadTask sessionTaskId %lu", sessionTask.taskIdentifier);
 }
 
-- (void)finishURLSessionTask:(NSURLSessionTask *)sessionTask withResponse:(NSURLResponse *)response error:(NSError *)error
+- (void)sessionTask:(NSURLSessionTask *)sessionTask didFinishWithResponse:(NSURLResponse *)response error:(NSError *)error
 {
     //could be called to handle any session task whose delegate might have gone away like thumbnail requests if scrolled past them
     NSLog(@"sessionTaskId %lu, response %@, error %@", sessionTask.taskIdentifier, response, error);

--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
@@ -21,7 +21,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 #warning Set the client ID and client secret that can be retrieved by creating an application at http://developers.box.com
-    [BOXContentClient setClientID:@"mr484mz72rq0gxvvbgc9a79q96kbws5l" clientSecret:@"E6jgm6foaRFKRTl5FB0MtcRZBCEM4UC8"];
+    [BOXContentClient setClientID:@"your_client_id" clientSecret:@"your_client_secret"];
     
     BOXAuthenticationPickerViewController *authenticationController = [[BOXAuthenticationPickerViewController alloc]init];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:authenticationController];

--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
@@ -88,7 +88,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 
 - (void)downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
-    NSLog(@"sessionTaskId %lu location %@", (unsigned long)downloadTask.taskIdentifier, location);
+    NSLog(@"downloadTask sessionTaskId %lu location %@", (unsigned long)downloadTask.taskIdentifier, location);
     @synchronized (self.sessionIdToRequest) {
         if (self.sessionIdToRequest[@(downloadTask.taskIdentifier)] != nil) {
             BOXFileDownloadRequest *request = self.sessionIdToRequest[@(downloadTask.taskIdentifier)];
@@ -96,6 +96,13 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
             [self.sessionIdToRequest removeObjectForKey:@(downloadTask.taskIdentifier)];
         }
     }
+}
+
+- (void)uploadTask:(NSURLSessionDataTask *)sessionTask
+    totalBytesSent:(int64_t)totalBytesSent
+totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
+{
+    NSLog(@"uploadTask sessionTaskId %lu", sessionTask.taskIdentifier);
 }
 
 - (void)finishURLSessionTask:(NSURLSessionTask *)sessionTask withResponse:(NSURLResponse *)response error:(NSError *)error

--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleFolderViewController.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleFolderViewController.m
@@ -240,7 +240,7 @@
     // We did not find a file named similarly, we can upload normally the file.
     NSString *tempPath = background == NO ? nil : [path stringByAppendingString:@".temp"];
     if (indexOfFile == NSNotFound) {
-        BOXFileUploadRequest *uploadRequest = [self.client fileUploadRequestToFolderWithID:self.folderID fromLocalFilePath:path tempUploadFilePath:tempPath];
+        BOXFileUploadRequest *uploadRequest = [self.client fileUploadRequestInBackgroundToFolderWithID:self.folderID fromLocalFilePath:path uploadMultipartCopyFilePath:tempPath];
         if (background == NO) {
             self.nonBackgroundUploadRequest = uploadRequest;
         }
@@ -255,7 +255,7 @@
     // We already found the item. We will upload a new version of the file. 
     // Alternatively, we can also rename the file and upload it like a regular new file via a BOXFileUploadRequest
     else {
-        BOXFileUploadNewVersionRequest *newVersionRequest = [self.client fileUploadNewVersionRequestWithID:fileID fromLocalFilePath:path tempUploadFilePath:tempPath];
+        BOXFileUploadNewVersionRequest *newVersionRequest = [self.client fileUploadNewVersionRequestInBackgroundWithFileID:fileID fromLocalFilePath:path uploadMultipartCopyFilePath:tempPath];
         if (background == NO) {
             self.nonBackgroundUploadRequest = newVersionRequest;
         }


### PR DESCRIPTION
…URLSession

support background upload if given tempUploadFilePath
bringing in AFURLRequestSerialization  (from AFNetworking v3.1.0)(renamed to BOXURLRequestSerialization)
support non-background upload with NSURLSession
update BOXURLRequestSerialization to our need
add sample ap ui's button to upload in non-background or background mode
remove requirement for MIMEType in multipart upload
clean up multipart json operation