### PR TITLE
Resolve issue with auth failing in the sample app

### DIFF
--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAccountsViewController.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAccountsViewController.m
@@ -53,7 +53,10 @@
 {
     // Create a new client for the account we want to add.
     BOXContentClient *client = [BOXContentClient clientForNewSession];
-    
+
+    BOXURLSessionManager *manager = client.session.urlSessionManager;
+    [manager setUpWithDefaultDelegate:((id<BOXURLSessionManagerDelegate>)[[UIApplication sharedApplication] delegate])];
+
     if (self.isAppUsers) {
         [client setAccessTokenDelegate:self];
     }

--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAppDelegate.m
@@ -30,22 +30,13 @@
     self.window.rootViewController = navController;
     [self.window makeKeyAndVisible];
     self.sessionIdToRequest = [[NSMutableDictionary alloc] init];
-    [self setUpSessionManager];
 
     return YES;
 }
 
-- (void)setUpSessionManager
-{
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        BOXURLSessionManager *manager = [BOXContentClient defaultClient].session.urlSessionManager;
-        [manager setUpWithDefaultDelegate:self];
-    });
-}
-
 - (void)recoverDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
+    //FIXME: NOTE the sample app does NOT use the default client, need to grab the current active client.
     BOXContentClient *client = [BOXContentClient defaultClient];
     BOXSampleAppSessionManager *appSessionManager = [BOXSampleAppSessionManager defaultManager];
     BOXSampleAppSessionInfo *info = [appSessionManager getSessionTaskInfo:downloadTask.taskIdentifier];
@@ -146,7 +137,9 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 - (void)application:(UIApplication *)application handleEventsForBackgroundURLSession:(NSString *)identifier completionHandler:(void (^)())completionHandler
 {
     NSLog(@"handleEventsForBackgroundURLSession identifier %@", identifier);
-    [self setUpSessionManager];
+    //FIXME: Need to get the BOXContentClient for the currently logged in user and set up its URL session manager
+//    BOXURLSessionManager *manager = client.session.urlSessionManager;
+//    [manager setUpWithDefaultDelegate:self];
     completionHandler();
 }
 


### PR DESCRIPTION
The problem stemmed from using the default client instead of the instance
of BOXContentClient currently in-use by the sample app (which supports
multiple accounts and thus client objects).
Also fixes a problem with the configuration of the BOXURLSessionManager
repeatedly for each instance of BOXContentClient