### PR TITLE
Resolve an issue with network calls not working in the sample app

### DIFF
--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAccountsViewController.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleAccountsViewController.m
@@ -40,6 +40,7 @@
         BOXContentClient *client = [BOXContentClient clientForUser:user];
         if (   ([client.session isKindOfClass:[BOXOAuth2Session class]] && !self.isAppUsers)
             || ([client.session isKindOfClass:[BOXAppUserSession class]] && self.isAppUsers)) {
+            [client.urlSessionManager setUpWithDefaultDelegate:((id<BOXURLSessionManagerDelegate>)[[UIApplication sharedApplication] delegate])];
             [users addObject:user];
         }
     }


### PR DESCRIPTION
Make sure the content client object obtained by the sample app has
initialized its URLSessionManager correctly.

This will likely go away as we move to a centralized session manager.