### PR TITLE
Login page fails to load after a device trust failure

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAuthorizationViewController.h
@@ -59,4 +59,15 @@
                   completionBlock:(void (^)(BOXAuthorizationViewController *authorizationViewController, BOXUser *user, NSError *error))completionBlock
                       cancelBlock:(void (^)(BOXAuthorizationViewController *authorizationViewController))cancelBlock;
 
+/**
+ * Helper method to be used when the BOXAuthorizationViewController needs to be dismissed
+ * externally. For example, an app presented the Authorization View Controller but needs
+ * to dismiss it without user action or any normal completion of the authorization process
+ * (because of an incoming event for example). Before dismissing, it must call prepare for
+ * dismissal.
+ * This method is already used internally in all of the expected cases such as the user
+ * cancelling and authorization completion (success and failure).
+ */
+- (void)prepareForDismissal;
+
 @end


### PR DESCRIPTION
The login view controller was not getting deallocated, because the
NSURLSession was holding a strong reference to it as the delegate.