### PR TITLE
IOS-14005 - Migrate Recents API request to use 'next_marker' since 'm…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -217,9 +217,13 @@ extern NSString *const BOXAPIParameterKeyMaxHeight;
 extern NSString *const BOXAPIParameterKeyAvatarType;
 
 // Recent Items Parameter Keys
-extern NSString *const BOXAPIParameterKeyMarker;
 extern NSString *const BOXAPIParameterKeyNextMarker;
 extern NSString *const BOXAPIParameterKeyListType;
+
+/*!
+ * @deprecated Use BOXAPIParameterKeyNextMarker instead for Recents API.
+ */
+extern NSString *const BOXAPIParameterKeyMarker;
 
 // Metadata Parameter Key
 extern NSString *const BOXAPIParameterKeyTemplate;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRecentItemsRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRecentItemsRequest.m
@@ -41,7 +41,7 @@
     }
 
     if (self.nextMarker != nil) {
-        queryParameters[BOXAPIParameterKeyMarker] = self.nextMarker;
+        queryParameters[BOXAPIParameterKeyNextMarker] = self.nextMarker;
     }
 
     if (self.listType != nil) {


### PR DESCRIPTION
…arker' will be deprecated.