### PR TITLE
Adding intermediate response handling to BOXAPIMultipartToJSONOperati…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
@@ -50,6 +50,17 @@ static NSString * BOXAPIMultipartContentTypeHeader(void)
  */
 @implementation BOXAPIMultipartToJSONOperation
 
+- (id)initWithURL:(NSURL *)URL HTTPMethod:(NSString *)HTTPMethod body:(NSDictionary *)body queryParams:(NSDictionary *)queryParams session:(BOXAbstractSession *)session
+{
+    self = [super initWithURL:URL HTTPMethod:HTTPMethod body:body queryParams:queryParams session:session];
+    if (self != nil) {
+        // Initialize the responseData object to mutable data
+        self.responseData = [NSMutableData data];
+    }
+    
+    return self;
+}
+
 #pragma mark - Append data to upload operation
 
 - (void)appendMultipartPieceWithData:(NSData *)data fieldName:(NSString *)fieldName filename:(NSString *)filename MIMEType:(NSString *)MIMEType
@@ -124,15 +135,6 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     if (self.progressBlock) {
         self.progressBlock(totalBytesExpectedToSend, totalBytesSent);
-    }
-}
-
-- (void)sessionTask:(NSURLSessionTask *)sessionTask processIntermediateData:(NSData *)data
-{
-    @synchronized (self) {
-        if (data != nil) {
-            [self processResponseData:data];
-        }
     }
 }
 


### PR DESCRIPTION
…on which supports urlsession tasks transferring data in parts. Supports variable length data responses for file requests. Our current example is file information returned via file upload request, certain field requests will extend the data size causing url session to return data in sections. We append the data and wait until task completion before serializing the data.