### PR TITLE
Use deprecation attribute instead of Headerdoc comment for marker par…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -222,9 +222,7 @@ extern NSString *const BOXAPIParameterKeyAvatarType;
 extern NSString *const BOXAPIParameterKeyNextMarker;
 extern NSString *const BOXAPIParameterKeyListType;
 
-/*!
- * @deprecated Use BOXAPIParameterKeyNextMarker instead for Recents API.
- */
+__attribute__((deprecated("BOXAPIParameterKeyMarker is deprecated - please use BOXAPIParameterKeyNextMarker instead")))
 extern NSString *const BOXAPIParameterKeyMarker;
 
 // Metadata Parameter Key


### PR DESCRIPTION
…amter

The previous format was generating a warning. Using `__attribute__` allows for warnings in code completion.