### PR TITLE
Fix an issue that could result in incomplete files

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -188,8 +188,8 @@
 
 - (void)finish
 {
-    [super finish];
     [self close];
+    [super finish];
 }
 
 - (void)dealloc


### PR DESCRIPTION
Downloaded files could end up starting with a bunch of 0 bytes
instead of the actual data due to a timing issue. This change
to the correct order of operations resolves the problem.