### PR TITLE
Support for early access to the operation and session task from a request

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
@@ -130,6 +130,12 @@ typedef void (^BOXAPIDataFailureBlock)(NSURLRequest *request, NSHTTPURLResponse 
  */
 @property (nonatomic, readwrite, strong) NSMutableURLRequest *APIRequest;
 
+/**
+ * The URL Session Task.
+ */
+
+@property (nonatomic, readonly, strong) NSURLSessionTask *sessionTask;
+
 /** @name Request response properties */
 
 /**
@@ -229,6 +235,16 @@ typedef void (^BOXAPIDataFailureBlock)(NSURLRequest *request, NSHTTPURLResponse 
  * For example, BOXAPIAuthenticatedOperation signs requests with an Authorization header
  */
 - (void)prepareAPIRequest;
+
+//NOTE: Only meant to be used in cases where access to the operation and its URL Session Task
+// is needed before actually performing the operation. In that case, the preparation of the URL
+// request and session task which is usually done right before making the network request
+// (including population the API auth headers, etc) is done earlier, so it is expected that
+// the operation will be enqueued immediately after and not held onto for a long time.
+// Specifically it is the authentication token, which has a one hour lifespan, that gets
+// associated with the operation. Thus, if a long delay is expected between setup and
+// execution, it is not recommended to use this method.
+- (void)prepareOperation;
 
 #pragma mark - Process API call results BOXURLSessionTaskDelegate
 /** @name Process API call results */

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
@@ -78,6 +78,13 @@
     return nil;
 }
 
+
+- (void)prepareOperation
+{
+    [self.operation.APIRequest setValue:[self userAgent] forHTTPHeaderField:@"User-Agent"];
+    [self.operation prepareOperation];
+}
+
 #pragma mark - Convenience Methods
 
 - (NSURL *)URLWithResource:(NSString *)resource

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest_Private.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest_Private.h
@@ -73,6 +73,16 @@
 
 - (BOXAPIOperation *)createOperation;
 
+//NOTE: Only meant to be used in cases where access to the operation and its URL Session Task
+// is needed before actually performing the operation. In that case, the preparation of the URL
+// request and session task which is usually done right before making the network request
+// (including population the API auth headers, etc) is done earlier, so it is expected that
+// the operation will be enqueued immediately after and not held onto for a long time.
+// Specifically it is the authentication token, which has a one hour lifespan, that gets
+// associated with the operation. Thus, if a long delay is expected between setup and
+// execution, it is not recommended to use this method.
+- (void)prepareOperation;
+
 - (NSString *)fullFileFieldsParameterString;
 - (NSString *)fullFolderFieldsParameterString;
 - (NSString *)fullBookmarkFieldsParameterString;


### PR DESCRIPTION
Introducing a 'prepare' method for requests and operations, such that the
underlying session task could be accessed before an operation is enqueued
and contain the complete information.