### PR TITLE
Curly brackets need to be encoded as they are explicitly disallowed in URL (RFC 1738)

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSString+BOXContentSDKAdditions.m
@@ -125,7 +125,7 @@ long long const BOX_TERABYTE = BOX_GIGABYTE * 1024;
 
 - (NSString *)box_stringByAddingURLPercentEscapes
 {
-    NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]"] invertedSet];
+    NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]{}"] invertedSet];
     return [self stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 


### PR DESCRIPTION
Internal ticket: IOS-14153