### PR TITLE
Remove incorrect location for handling temporary upload path cleanup

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Protocols/BOXContentCacheClientProtocol.h
+++ b/BoxContentSDK/BoxContentSDK/Protocols/BOXContentCacheClientProtocol.h
@@ -154,11 +154,6 @@
                                 withFile:(BOXFile *)file
                                    error:(NSError *)error;
 
-- (void)cacheFileUploadNewVersionRequest:(BOXFileUploadNewVersionRequest *)request
-                                withFile:(BOXFile *)file
-                             tmpFilePath:(NSString *)tmpFilePath
-                                   error:(NSError *)error;
-
 #pragma mark - Folders
 
 - (void)cacheFolderRequest:(BOXFolderRequest *)request

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -120,9 +120,7 @@
         //if the app crashes before we could cache the response data
         BOXFile *file = JSONDictionary == nil ? nil : [[BOXFile alloc] initWithJSON:JSONDictionary];
         
-        if ([self.cacheClient respondsToSelector:@selector(cacheFileUploadNewVersionRequest:withFile:tmpFilePath:error:)]) {
-           [self.cacheClient cacheFileUploadNewVersionRequest:self withFile:file tmpFilePath:self.localFilePath error:nil];
-        } else if ([self.cacheClient respondsToSelector:@selector(cacheFileUploadNewVersionRequest:withFile:error:)]) {
+        if ([self.cacheClient respondsToSelector:@selector(cacheFileUploadNewVersionRequest:withFile:error:)]) {
             [self.cacheClient cacheFileUploadNewVersionRequest:self withFile:file error:nil];
         }
         


### PR DESCRIPTION
The cache layer should not be cleaning up the upload asset location when it
is not deterministically the layer where it was created. It's the caller of
the Content Client that creates the upload file and thus owns the responsibility
for cleaning it up, etc.