### PR TITLE
Remove invalid entry in proj file for NSString+BOXURLHelper

### DIFF
--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -102,7 +102,6 @@
 		599B196D1E4BE67600709C27 /* NSError+BOXContentSDKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C59605541CC5917E0096DD59 /* NSError+BOXContentSDKAdditions.m */; };
 		599B196E1E4BE67600709C27 /* NSJSONSerialization+BOXContentSDKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C59605561CC5917E0096DD59 /* NSJSONSerialization+BOXContentSDKAdditions.m */; };
 		599B196F1E4BE67600709C27 /* NSString+BOXContentSDKAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C59605581CC5917E0096DD59 /* NSString+BOXContentSDKAdditions.m */; };
-		599B19701E4BE67600709C27 /* NSString+BOXURLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = E4FAD97D172CE2C50052AD11 /* NSString+BOXURLHelper.m */; };
 		599B19711E4BE67600709C27 /* NSURL+BOXURLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = E4FAD97F172CE2C50052AD11 /* NSURL+BOXURLHelper.m */; };
 		599B19721E4BE67600709C27 /* BOXContentClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 15958DEB1A1432AB00AEBCEE /* BOXContentClient.m */; };
 		599B19731E4BE67600709C27 /* BOXContentClient+Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 15958E581A1445A300AEBCEE /* BOXContentClient+Authentication.m */; };
@@ -247,7 +246,6 @@
 		599B1A001E4BE6DC00709C27 /* NSError+BOXContentSDKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C59605531CC5917E0096DD59 /* NSError+BOXContentSDKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		599B1A011E4BE6DC00709C27 /* NSJSONSerialization+BOXContentSDKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C59605551CC5917E0096DD59 /* NSJSONSerialization+BOXContentSDKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		599B1A021E4BE6DC00709C27 /* NSString+BOXContentSDKAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C59605571CC5917E0096DD59 /* NSString+BOXContentSDKAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		599B1A031E4BE6DC00709C27 /* NSString+BOXURLHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E4FAD97C172CE2C50052AD11 /* NSString+BOXURLHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		599B1A041E4BE6DC00709C27 /* NSURL+BOXURLHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E4FAD97E172CE2C50052AD11 /* NSURL+BOXURLHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		599B1A051E4BE6DC00709C27 /* BOXContentClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 15958DEA1A1432AB00AEBCEE /* BOXContentClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		599B1A061E4BE6DC00709C27 /* BOXContentClient+Authentication.h in Headers */ = {isa = PBXBuildFile; fileRef = 15958E571A1445A300AEBCEE /* BOXContentClient+Authentication.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1755,7 +1753,6 @@
 				599B1A001E4BE6DC00709C27 /* NSError+BOXContentSDKAdditions.h in Headers */,
 				599B1A011E4BE6DC00709C27 /* NSJSONSerialization+BOXContentSDKAdditions.h in Headers */,
 				599B1A021E4BE6DC00709C27 /* NSString+BOXContentSDKAdditions.h in Headers */,
-				599B1A031E4BE6DC00709C27 /* NSString+BOXURLHelper.h in Headers */,
 				599B1A041E4BE6DC00709C27 /* NSURL+BOXURLHelper.h in Headers */,
 				599B1A051E4BE6DC00709C27 /* BOXContentClient.h in Headers */,
 				599B1A061E4BE6DC00709C27 /* BOXContentClient+Authentication.h in Headers */,
@@ -2191,7 +2188,6 @@
 				599B196D1E4BE67600709C27 /* NSError+BOXContentSDKAdditions.m in Sources */,
 				599B196E1E4BE67600709C27 /* NSJSONSerialization+BOXContentSDKAdditions.m in Sources */,
 				599B196F1E4BE67600709C27 /* NSString+BOXContentSDKAdditions.m in Sources */,
-				599B19701E4BE67600709C27 /* NSString+BOXURLHelper.m in Sources */,
 				599B19711E4BE67600709C27 /* NSURL+BOXURLHelper.m in Sources */,
 				599B19721E4BE67600709C27 /* BOXContentClient.m in Sources */,
 				599B19731E4BE67600709C27 /* BOXContentClient+Authentication.m in Sources */,


### PR DESCRIPTION
- This class was removed in https://github.com/box/box-ios-sdk/pull/392
- Having this entry can seem to cause problems when making subsequent proj file changes.