### PR TITLE
Be tolerant of null values for user created/modified dates.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Models/BOXUser.m
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXUser.m
@@ -53,14 +53,16 @@
     if (self = [super initWithJSON:JSONResponse])
     {
         self.createdDate = [NSDate box_dateWithISO8601String:[NSJSONSerialization box_ensureObjectForKey:BOXAPIObjectKeyCreatedAt
-                                                                                       inDictionary:JSONResponse
-                                                                                    hasExpectedType:[NSString class]
-                                                                                        nullAllowed:NO]];
+                                                                                            inDictionary:JSONResponse
+                                                                                         hasExpectedType:[NSString class]
+                                                                                             nullAllowed:YES
+                                                                                       suppressNullAsNil:YES]];
         
         self.modifiedDate = [NSDate box_dateWithISO8601String:[NSJSONSerialization box_ensureObjectForKey:BOXAPIObjectKeyModifiedAt
-                                                                                       inDictionary:JSONResponse
-                                                                                    hasExpectedType:[NSString class]
-                                                                                        nullAllowed:NO]];
+                                                                                             inDictionary:JSONResponse
+                                                                                          hasExpectedType:[NSString class]
+                                                                                              nullAllowed:YES
+                                                                                        suppressNullAsNil:YES]];
         
         self.language = [NSJSONSerialization box_ensureObjectForKey:BOXAPIObjectKeyLanguage
                                                        inDictionary:JSONResponse


### PR DESCRIPTION
We would get those values from the API for special cases such as 'prior collboarator'
and 'anonomyous user'.