### PR TITLE
Adds 1024, 2048 thumbnail sizes

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -486,7 +486,9 @@ typedef NS_ENUM(NSUInteger, BOXThumbnailSize) {
     BOXThumbnailSize32 = 32,
     BOXThumbnailSize64 = 64,
     BOXThumbnailSize128 = 128,
-    BOXThumbnailSize256 = 256
+    BOXThumbnailSize256 = 256,
+    BOXThumbnailSize1024 = 1024,
+    BOXThumbnailSize2048 = 2048,
 };
 
 typedef NS_ENUM(NSUInteger, BOXAvatarType) {


### PR DESCRIPTION
Rest API allows you to request 1024x1024 and 2048x2048 thumbnail sizes. The SDK limits to max 256.

https://developer.box.com/v2.0/reference#fetching-a-thumbnail-representation

This adds 1024, 2048 thumbnail sizes options.