### PR TITLE
add sharedLink Header String to comment request headers

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Helper/BOXSharedLinkHeadersHelper.m
+++ b/BoxContentSDK/BoxContentSDK/Helper/BOXSharedLinkHeadersHelper.m
@@ -55,16 +55,18 @@
 
 - (void)storeHeadersFromAncestorsIfNecessaryForItemWithID:(NSString *)itemID itemType:(NSString *)itemType ancestors:(NSArray *)ancestors
 {
-    // Go from the direct parent to the most remote ancestor.
-    for (NSInteger i = ancestors.count - 1; i >= 0; i --) {
-        BOXFolderMini *folder = ancestors[i];
+    if ([self.delegate sharedLinkForItemWithID:itemID itemType:itemType userID:self.userID] == nil) {
+        // Go from the direct parent to the most remote ancestor.
+        for (NSInteger i = ancestors.count - 1; i >= 0; i --) {
+            BOXFolderMini *folder = ancestors[i];
             
-        NSString *link = [self.delegate sharedLinkForItemWithID:folder.modelID itemType:folder.type userID:self.userID];
-        // We found a link in one of the ancestors of the file, we need to store this file that now would need the headers of its ancestors in any API request
-        if (link) {
-            NSString *password = [self.delegate passwordForSharedItemWithID:folder.modelID itemType:folder.type userID:self.userID];
-            [self.delegate storeSharedLink:link forItemWithIDKey:itemID itemTypeKey:itemType password:password userIDKey:self.userID];
-            break;
+            NSString *link = [self.delegate sharedLinkForItemWithID:folder.modelID itemType:folder.type userID:self.userID];
+            // We found a link in one of the ancestors of the file, we need to store this file that now would need the headers of its ancestors in any API request
+            if (link) {
+                NSString *password = [self.delegate passwordForSharedItemWithID:folder.modelID itemType:folder.type userID:self.userID];
+                [self.delegate storeSharedLink:link forItemWithIDKey:itemID itemTypeKey:itemType password:password userIDKey:self.userID];
+                break;
+            }
         }
     }
 }

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.h
@@ -3,11 +3,11 @@
 //  BoxContentSDK
 //
 
-#import "BOXRequest.h"
+#import "BOXRequestWithSharedLinkHeader.h"
 
 @class BOXItem;
 
-@interface BOXCommentAddRequest : BOXRequest
+@interface BOXCommentAddRequest : BOXRequestWithSharedLinkHeader
 
 @property (nonatomic, readwrite, strong) NSString *taggedMessage;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXCommentAddRequest.m
@@ -9,6 +9,7 @@
 #import "BOXItem.h"
 #import "BOXComment.h"
 #import "BOXDispatchHelper.h"
+#import "BOXSharedLinkHeadersHelper.h"
 
 @interface BOXCommentAddRequest ()
 
@@ -78,6 +79,8 @@
                                 bodyDictionary:bodyDictionary
                               JSONSuccessBlock:nil
                                   failureBlock:nil];
+
+        [self addSharedLinkHeaderToRequest:operation.APIRequest];
     }
     
     return operation;
@@ -90,6 +93,11 @@
 
     commentAddOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
         BOXComment *comment = [[BOXComment alloc] initWithJSON:JSONDictionary];
+
+        // Noop. Passing nil for ancestors since we don't have the information right now.
+        [self.sharedLinkHeadersHelper storeHeadersFromAncestorsIfNecessaryForItemWithID:comment.item.modelID
+                                                                               itemType:comment.item.type
+                                                                              ancestors:nil];
 
         if ([self.cacheClient respondsToSelector:@selector(cacheAddCommentRequest:withComment:error:)]) {
             [self.cacheClient cacheAddCommentRequest:self
@@ -116,6 +124,17 @@
         }
     };
     [self performRequest];
+}
+
+#pragma mark - BOXRequestWithSharedLinkHeader methods
+- (NSString *)itemIDForSharedLink
+{
+    return self.modelID;
+}
+
+- (BOXAPIItemType *)itemTypeForSharedLink
+{
+    return self.modelType;
 }
 
 @end


### PR DESCRIPTION
This header is required on all comment requests that attempt to post comments on shared links.