### PR TITLE
Modify BOXMetadata model to support new API models.

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -371,6 +371,8 @@ extern NSString *const BOXAPIMetadataObjectKeyParent;
 extern NSString *const BOXAPIMetadataObjectKeyOperation;
 extern NSString *const BOXAPIMetadataObjectKeyPath;
 extern NSString *const BOXAPIMetadataObjectKeyValue;
+extern NSString *const BOXAPIMetadataObjectKeyVersion;
+extern NSString *const BOXAPIMetadataObjectKeyTypeVersion;
 
 // API Folder IDs
 extern NSString *const BOXAPIFolderIDRoot;

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
@@ -350,6 +350,8 @@ NSString *const BOXAPIMetadataObjectKeyParent = @"$parent";
 NSString *const BOXAPIMetadataObjectKeyOperation = @"op";
 NSString *const BOXAPIMetadataObjectKeyPath = @"path";
 NSString *const BOXAPIMetadataObjectKeyValue = @"value";
+NSString *const BOXAPIMetadataObjectKeyVersion = @"$version";
+NSString *const BOXAPIMetadataObjectKeyTypeVersion = @"$typeVersion";
 
 // API Folder IDs
 NSString *const BOXAPIFolderIDRoot = @"0";

--- a/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.h
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.h
@@ -29,6 +29,18 @@
 @property (nonatomic, readwrite, strong) NSString *scope;
 
 /**
+ * The current version of the metadata.
+ */
+@property (nonatomic, readwrite, strong) NSNumber *version;
+
+
+/**
+ * The current type version of the metadata.
+ */
+@property (nonatomic, readwrite, strong) NSNumber *typeVersion;
+
+
+/**
  * Custom defined information stored as key/value pairs.
  */
 @property (nonatomic, readwrite, strong) NSDictionary *info;

--- a/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.m
+++ b/BoxContentSDK/BoxContentSDK/Models/BOXMetadata.m
@@ -42,13 +42,22 @@
                                                   hasExpectedType:[NSString class]
                                                       nullAllowed:NO];
         
+        self.version = [NSJSONSerialization box_ensureObjectForKey:BOXAPIMetadataObjectKeyVersion
+                                                      inDictionary:JSONData
+                                                   hasExpectedType:[NSNumber class]
+                                                       nullAllowed:NO];
+        
+        self.typeVersion = [NSJSONSerialization box_ensureObjectForKey:BOXAPIMetadataObjectKeyTypeVersion
+                                                          inDictionary:JSONData
+                                                       hasExpectedType:[NSNumber class]
+                                                           nullAllowed:NO];
+        
         // Retrieving all custom metadata information (key/value pairs).
         NSMutableDictionary *info = [[NSMutableDictionary alloc] init];
         for (NSString *key in JSONData) {
             // Only default metadata keys have '$' at the beginning, so the ones that don't are custom metadata keys.
             if ([key characterAtIndex:0] != '$') {
-                NSString *value = [JSONData objectForKey:key];
-                [info setObject:value forKey:key];
+                [info setObject:[JSONData objectForKey:key] forKey:key];
             }
         }
         self.info = info;

--- a/BoxContentSDK/BoxContentSDKTests/enterprise_metadata.json
+++ b/BoxContentSDK/BoxContentSDKTests/enterprise_metadata.json
@@ -1,5 +1,5 @@
 {
-    "audience": "external",
+    "audience": ["internal", "internalEng"],
     "vertical": "healthcare",
     "documentType": "datasheet",
     "status": "active",
@@ -7,5 +7,7 @@
     "$parent": "file_6122548033",
     "$id": "fab04c3b-bf72-4726-80d1-d87f8cb87592",
     "$template": "marketingCollateral",
-    "$scope": "enterprise_42500"
+    "$scope": "enterprise_42500",
+    "$version": 1,
+    "$typeVersion": 2
 }

--- a/BoxContentSDK/BoxContentSDKTests/metadata.json
+++ b/BoxContentSDK/BoxContentSDKTests/metadata.json
@@ -8,4 +8,6 @@
     "case_type": "Employment Litigation",
     "assigned_attorney": "Francis Burke",
     "case_status": "in-progress"
+    "$version": 1,
+    "$typeVersion": 2
 }


### PR DESCRIPTION
Adding version and typeVersion fields to BOXMetadata, also added support for array<NSString> values for custom fields.