### PR TITLE
add content-md5 header for data uploads

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
@@ -131,6 +131,7 @@
  */
 - (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
                                         fromLocalFilePath:(NSString *)localFilePath;
+__attribute__((deprecated("Foreground fileuploads will be removed. Please use fileUploadRequestInBackgroundToFolderWithID")));
 
 /**
  *  Generate a request to upload a local file to Box in background unless uploadMultipartCopyFilePath is not provided
@@ -170,6 +171,7 @@
  */
 - (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
                                                     fromLocalFilePath:(NSString *)localFilePath;
+__attribute__((deprecated("Foreground fileuploads will be removed. Please use fileUploadNewVersionRequestInBackgroundWithFileID")));
 
 /**
  *  Generate a request to upload a new version of a file from a local file in the background

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -11,6 +11,7 @@
 #import "BOXAPIQueueManager.h"
 #import "BOXAbstractSession.h"
 #import "BOXDispatchHelper.h"
+#import "BOXHashHelper.h"
 
 @interface BOXFileUploadNewVersionRequest ()
 
@@ -83,6 +84,7 @@
                                       fieldName:BOXAPIMultipartParameterFieldKeyFile
                                        filename:@"" // Box API ignores the filename when uploading a new version.
                                        MIMEType:nil];
+        [operation.APIRequest setValue:[self fileSHA1] forHTTPHeaderField:BOXAPIHTTPHeaderContentMD5];
     }  else {
         BOXAssertFail(@"The File Upload Request was not given an existing file path to upload from or data to upload.");
     }
@@ -154,6 +156,21 @@
 - (BOXAPIItemType *)itemTypeForSharedLink
 {
     return BOXAPIItemTypeFile;
+}
+
+#pragma mark - Helper Methods
+
+- (NSString *)fileSHA1
+{
+    NSString *hash = nil;
+    
+    if (self.fileData != nil) {
+        hash = [BOXHashHelper sha1HashOfData:self.fileData];
+    } else {
+        BOXAssertFail(@"The File Upload Request was not given an existing file path or data to calculate the hash from.");
+    }
+    
+    return hash;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
@@ -12,10 +12,6 @@
 @property (nonatomic, readwrite, strong) NSDate *contentCreatedAt;
 @property (nonatomic, readwrite, strong) NSDate *contentModifiedAt;
 @property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
-// This setting uses the locally generated SHA1 hash of the file to ensure that the
-// file is not corrputed in transit. Settings this value to YES will result in a delay
-// before the upload actually begins as the hash is calculated. The default is NO.
-@property (nonatomic, readwrite, assign) BOOL enableCheckForCorruptionInTransit;
 
 - (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
@@ -127,13 +127,9 @@
                                       fieldName:BOXAPIMultipartParameterFieldKeyFile
                                        filename:fileName
                                        MIMEType:nil];
+        [operation.APIRequest setValue:[self fileSHA1] forHTTPHeaderField:BOXAPIHTTPHeaderContentMD5];
     } else {
         BOXAssertFail(@"The File Upload Request was not given an existing file path to upload from or data to upload.");
-    }
-
-    if (self.enableCheckForCorruptionInTransit) {
-        // Set up the Content-MD5 header
-        [operation.APIRequest setValue:[self fileSHA1] forHTTPHeaderField:BOXAPIHTTPHeaderContentMD5];
     }
 
     return operation;
@@ -209,9 +205,7 @@
 {
     NSString *hash = nil;
 
-    if ([self.localFilePath length] > 0 && [[NSFileManager defaultManager] fileExistsAtPath:self.localFilePath]) {
-        hash = [BOXHashHelper sha1HashOfFileAtPath:self.localFilePath];
-    } else if (self.fileData != nil) {
+    if (self.fileData != nil) {
         hash = [BOXHashHelper sha1HashOfData:self.fileData];
     } else {
         BOXAssertFail(@"The File Upload Request was not given an existing file path or data to calculate the hash from.");

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileUploadNewVersionRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileUploadNewVersionRequestTests.m
@@ -198,6 +198,8 @@
     XCTAssertTrue([expectedContentType isEqualToString:URLRequest.allHTTPHeaderFields[@"Content-Type"]]);
 
     XCTAssertEqualObjects(matchingEtag, URLRequest.allHTTPHeaderFields[@"If-Match"]);
+    XCTAssertEqualObjects([BOXHashHelper sha1HashOfData:[uploadData dataUsingEncoding:NSUTF8StringEncoding]], URLRequest.allHTTPHeaderFields[@"Content-MD5"]);
+
 }
 
 #pragma mark - Completion and Progress Blocks

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileUploadRequestTests.m
@@ -104,7 +104,6 @@
     request.fileName = fileNameOnServer;
     request.contentCreatedAt = contentCreatedAtDateOnServer;
     request.contentModifiedAt = contentModifiedAtDateOnServer;
-    request.enableCheckForCorruptionInTransit = YES;
     NSURLRequest *URLRequest = request.urlRequest;
     
     // URL
@@ -192,7 +191,6 @@
     request.fileName = fileNameOnServer;
     request.contentCreatedAt = contentCreatedAtDateOnServer;
     request.contentModifiedAt = contentModifiedAtDateOnServer;
-    request.enableCheckForCorruptionInTransit = YES;
     NSURLRequest *URLRequest = request.urlRequest;
     
     // URL


### PR DESCRIPTION
Add content-md5 for data uploads only


TBD 
   - Convert upload tasks to background upload (deprecate foreground tasks)
   - Calculate sha1 on copy at background temporary filepath
   - Add to header on completion handler
