### PR TITLE
Removing the set representation option method that used va_list param…

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
@@ -84,7 +84,7 @@ typedef NS_OPTIONS(NSUInteger, BOXRepresentationRequestOptions) {
  */
 - (void)setRepresentationRequestOptions:(BOXRepresentationRequestOptions)representationOptions, ...;
 
-- (void)setRepresentationRequestOptions:(BOXRepresentationRequestOptions)representationOptions args:(va_list)args;
+- (void)setRepresentationRequestOptionsWithSet:(NSSet *)representationOptionsSet;
 
 - (NSString *)formatRepresentationRequestHeader;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
@@ -265,21 +265,9 @@
     self.representationsRequested = [[NSMutableOrderedSet alloc] initWithArray:arguments];
 }
 
-// Swift compatable va_list version of the method
-- (void)setRepresentationRequestOptions:(BOXRepresentationRequestOptions)representationOptions args:(va_list)argumentList
+- (void)setRepresentationRequestOptionsWithSet:(NSSet *)representationOptionsSet
 {
-    NSMutableArray *arguments=[[NSMutableArray alloc]init];
-    BOXRepresentationRequestOptions eachObject;
-    if (representationOptions) {
-        [arguments addObject: [NSNumber numberWithUnsignedInteger:representationOptions]];
-        while ((eachObject = va_arg(argumentList, BOXRepresentationRequestOptions))) {
-            if (eachObject > 0) {
-                [arguments addObject: [NSNumber numberWithUnsignedInteger:eachObject]];
-            }
-        }
-    }
-    
-    self.representationsRequested = [[NSMutableOrderedSet alloc] initWithArray:arguments];
+    self.representationsRequested = [[NSMutableOrderedSet alloc] initWithSet:representationOptionsSet];
 }
 
 - (NSString *)formatRepresentationRequestHeader


### PR DESCRIPTION
…eters to support the swift bridge, changing the method to an NSSet parameter. For consitentcy we should follow up migrating the objc set represetation option method as well.