### PR TITLE
change sha1 calculation to happen async to completing file download

### DIFF
--- a/BoxContentSDK/BoxContentSDKTests/BOXFileRepresentationDownloadRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileRepresentationDownloadRequestTests.m
@@ -106,7 +106,7 @@
 
 #pragma mark - Error Handling
 
-- (void)test_that_download_data_integrity_check_triggers_error
+- (void)test_that_download_data_integrity_check_triggers_notification
 {
     NSString *fileID = @"123";
     NSURL *temporaryDirectoryURL = [NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES];
@@ -124,9 +124,10 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     request.sha1Hash = @"Some Incorrect Sha1";
     [request performRequestWithProgress:nil completion:^(NSError *error) {
-        XCTAssertNotNil(error);
+        XCTAssertNil(error);
         [expectation fulfill];
     }];
+    [self expectationForNotification:BOXFileDownloadCorruptedNotification object:nil handler:nil];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     [[NSFileManager defaultManager] removeItemAtURL:localFileURL error:nil];


### PR DESCRIPTION
After running time profiler on sha1 calculation, it appears that there is a significant slowdown in marking large downloads as complete. While tolerable, we want to still delegate handling these rare cases to SDK consumers to deal with it as needed. (Either invalidating the cache or recording metrics). The tradeoff here is between adding increased download times for everyone Vs catching the rare data integrity error