### PR TITLE
Undo previous commit deprecating foreground uploads

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
@@ -131,8 +131,6 @@
  */
 - (BOXFileUploadRequest *)fileUploadRequestToFolderWithID:(NSString *)folderID
                                         fromLocalFilePath:(NSString *)localFilePath;
-__attribute__((deprecated("Foreground fileuploads will be removed. Please use fileUploadRequestInBackgroundToFolderWithID")));
-
 /**
  *  Generate a request to upload a local file to Box in background unless uploadMultipartCopyFilePath is not provided
  *
@@ -171,7 +169,6 @@ __attribute__((deprecated("Foreground fileuploads will be removed. Please use fi
  */
 - (BOXFileUploadNewVersionRequest *)fileUploadNewVersionRequestWithID:(NSString *)fileID
                                                     fromLocalFilePath:(NSString *)localFilePath;
-__attribute__((deprecated("Foreground fileuploads will be removed. Please use fileUploadNewVersionRequestInBackgroundWithFileID")));
 
 /**
  *  Generate a request to upload a new version of a file from a local file in the background


### PR DESCRIPTION
Due to performance implications on background uploads, we want to keep supporting foreground uploads for use-cases that dont need to be backgrounded