### PR TITLE
Updating sample app compatibility

### DIFF
--- a/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleFolderViewController.m
+++ b/BoxContentSDKSampleApp/BoxContentSDKSampleApp/BOXSampleFolderViewController.m
@@ -326,7 +326,6 @@
         if (background == NO) {
             self.nonBackgroundUploadRequest = uploadRequest;
         }
-        uploadRequest.enableCheckForCorruptionInTransit = YES;
         [uploadRequest performRequestWithProgress:^(long long totalBytesTransferred, long long totalBytesExpectedToTransfer) {
             progressBlock(totalBytesTransferred, totalBytesExpectedToTransfer);
         } completion:^(BOXFile *file, NSError *error) {
@@ -374,7 +373,6 @@
                 BOXFileUploadRequest *uploadRequest = [weakSelf.client fileUploadRequestToFolderWithID:weakSelf.folderID
                                                                                               fromData:imageData
                                                                                               fileName:filename];
-                uploadRequest.enableCheckForCorruptionInTransit = YES;
                 [uploadRequest performRequestWithProgress:nil completion:^(BOXFile *file, NSError *error) {
                 
                     if (error == nil) {

--- a/BoxContentSDKSampleApp/shareExtension/ShareViewController.m
+++ b/BoxContentSDKSampleApp/shareExtension/ShareViewController.m
@@ -53,7 +53,6 @@
     NSString *associateId = [BOXSampleAppSessionManager generateRandomStringWithLength:32];
 
     BOXFileUploadRequest *uploadRequest = [self.client fileUploadRequestInBackgroundToFolderWithID:BOXAPIFolderIDRoot fromLocalFilePath:path uploadMultipartCopyFilePath:tempPath associateId:associateId];
-    uploadRequest.enableCheckForCorruptionInTransit = YES;
 
     [uploadRequest performRequestWithProgress:^(long long totalBytesTransferred, long long totalBytesExpectedToTransfer) {
         BOXLog(@"totalBytesTransferred, totalBytesExpectedToTransfer: %lld, %lld", totalBytesTransferred, totalBytesExpectedToTransfer);


### PR DESCRIPTION
With the recent updates to the SDK, we're now enforcing SHA1 verification in file upload request header, instead of having it be optional.