### PR TITLE
IOS-15945: Fix an issue where file accessed from a shared link cannot be previewed (because it fails to trigger preview generation)

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.h
@@ -22,6 +22,7 @@
 @class BOXPreflightCheckRequest;
 @class BOXFileRepresentationDownloadRequest;
 @class BOXRepresentation;
+@class BOXRepresentationInfoRequest;
 
 @interface BOXContentClient (File)
 
@@ -388,6 +389,15 @@
 - (BOXFileRepresentationDownloadRequest *)fileRepresentationDownloadRequestWithID:(NSString *)fileID
                                                                    toOutputStream:(NSOutputStream *)outputStream
                                                                    representation:(BOXRepresentation *)representation;
-
+/**
+ *  Generate a request to get representation information for a file
+ *
+ *  @param fileID          File ID.
+ *  @param representation  BOXRepresentation to get information on
+ *
+ *  @return A request that can be customized and then executed.
+ */
+- (BOXRepresentationInfoRequest *)fileRepresentationInfoRequestWithFileID:(NSString *)fileID
+                                                           representation:(BOXRepresentation *)representation;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
@@ -20,6 +20,7 @@
 #import "BOXPreflightCheckRequest.h"
 #import "BOXFileUploadNewVersionRequest.h"
 #import "BOXFileRepresentationDownloadRequest.h"
+#import "BOXRepresentationInfoRequest.h"
 
 @implementation BOXContentClient (File)
 
@@ -320,6 +321,15 @@
     BOXFileRepresentationDownloadRequest *request = [[BOXFileRepresentationDownloadRequest alloc] initWithOutputStream:outputStream
                                                                                                                 fileID:fileID
                                                                                                         representation:representation];
+    [self prepareRequest:request];
+    return request;
+}
+
+- (BOXRepresentationInfoRequest *)fileRepresentationInfoRequestWithFileID:(NSString *)fileID
+                                                           representation:(BOXRepresentation *)representation
+{
+    BOXRepresentationInfoRequest *request = [[BOXRepresentationInfoRequest alloc] initWithFileID:fileID
+                                                                                  representation:representation];
     [self prepareRequest:request];
     return request;
 }

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.h
@@ -9,7 +9,9 @@
 #import <BoxContentSDK/BoxContentSDK.h>
 @class BOXRepresentation;
 
-@interface BOXRepresentationInfoRequest : BOXRequest
-- (instancetype)initWithRepresentation:(BOXRepresentation *) representation;
+@interface BOXRepresentationInfoRequest : BOXRequestWithSharedLinkHeader
+
+- (instancetype)initWithFileID:(NSString *)fileID
+                representation:(BOXRepresentation *)representation;
 - (void)performRequestWithCompletion:(BOXRepresentationInfoBlock)completionBlock;
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.m
@@ -21,7 +21,8 @@
 @implementation BOXRepresentationInfoRequest
 
 - (instancetype)initWithFileID:(NSString *)fileID
-                representation:(BOXRepresentation *)representation {
+                representation:(BOXRepresentation *)representation
+{
     self = [super init];
     if (self != nil) {
         _fileID = fileID;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRepresentationInfoRequest.m
@@ -15,13 +15,16 @@
 
 @interface BOXRepresentationInfoRequest ()
 @property (nonatomic, readwrite, strong) BOXRepresentation *representation;
+@property (nonatomic, readwrite, strong) NSString *fileID;
 @end
 
 @implementation BOXRepresentationInfoRequest
 
-- (instancetype)initWithRepresentation:(BOXRepresentation *) representation {
+- (instancetype)initWithFileID:(NSString *)fileID
+                representation:(BOXRepresentation *)representation {
     self = [super init];
     if (self != nil) {
+        _fileID = fileID;
         _representation = representation;
     }
     return self;
@@ -29,15 +32,17 @@
 
 - (BOXAPIOperation *)createOperation
 {
-    return [self JSONOperationWithURL:self.representation.infoURL
+    BOXAPIJSONOperation *JSONOperation = [self JSONOperationWithURL:self.representation.infoURL
                                                          HTTPMethod:BOXAPIHTTPMethodGET
                                               queryStringParameters:nil
                                                      bodyDictionary:nil
                                                    JSONSuccessBlock:nil
                                                        failureBlock:nil];
+    [self addSharedLinkHeaderToRequest:JSONOperation.APIRequest];
+    return JSONOperation;
 }
 
-- (void) performRequestWithCompletion:(BOXRepresentationInfoBlock)completionBlock
+- (void)performRequestWithCompletion:(BOXRepresentationInfoBlock)completionBlock
 {
     if (completionBlock) {
         BOOL isMainThread = [NSThread isMainThread];
@@ -46,7 +51,7 @@
         metadataOperation.success = ^(NSURLRequest *request, NSHTTPURLResponse *response, NSDictionary *JSONDictionary) {
             [BOXDispatchHelper callCompletionBlock:^{
                 BOXRepresentation *metadata = [[BOXRepresentation alloc] initWithJSON:JSONDictionary];
-                    completionBlock(metadata, nil);
+                completionBlock(metadata, nil);
             } onMainThread:isMainThread];
         };
 
@@ -57,6 +62,18 @@
         };
         [self performRequest];
     }
+}
+
+#pragma mark - Superclass overidden methods
+
+- (NSString *)itemIDForSharedLink
+{
+    return self.fileID;
+}
+
+- (BOXAPIItemType *)itemTypeForSharedLink
+{
+    return BOXAPIItemTypeFile;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDKTests/BOXRepresentationInfoRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXRepresentationInfoRequestTests.m
@@ -15,6 +15,7 @@
 
 @implementation BOXRepresentationInfoRequestTests
 NSString *const testInfoUrl = @"https://dl.boxcloud.com/api/2.0/internal_files/12345/versions/12345/representations/jpg_2048x2048/content/";
+NSString *const testFileID = @"12345";
 
 - (BOXRepresentation *)testRepresentation
 {
@@ -25,7 +26,7 @@ NSString *const testInfoUrl = @"https://dl.boxcloud.com/api/2.0/internal_files/1
 
 #pragma mark - URLRequest
 - (void)test_that_basic_request_has_expected_URLRequest {
-    BOXRepresentationInfoRequest *request = [[BOXRepresentationInfoRequest alloc] initWithRepresentation:[self testRepresentation]];
+    BOXRepresentationInfoRequest *request = [[BOXRepresentationInfoRequest alloc] initWithFileID:testFileID representation:[self testRepresentation]];
     NSURLRequest *URLRequest = request.urlRequest;
     
     XCTAssertEqualObjects(testInfoUrl, URLRequest.URL.absoluteString);
@@ -36,7 +37,7 @@ NSString *const testInfoUrl = @"https://dl.boxcloud.com/api/2.0/internal_files/1
 
 - (void)test_that_expected_items_are_returned_for_representationInfo_request
 {
-    BOXRepresentationInfoRequest *request = [[BOXRepresentationInfoRequest alloc] initWithRepresentation:[self testRepresentation]];
+    BOXRepresentationInfoRequest *request = [[BOXRepresentationInfoRequest alloc] initWithFileID:testFileID representation:[self testRepresentation]];
     NSData *cannedData = [self cannedResponseDataWithName:@"representations_info"];
     NSHTTPURLResponse *response = [self cannedURLResponseWithStatusCode:200 responseData:cannedData];
     [self setCannedURLResponse:response cannedResponseData:cannedData forRequest:request];


### PR DESCRIPTION
To trigger preview generation, we uses representation info request, which needs shared link header to get authorized in this case.