### PR TITLE
Small refactor: Include representations by composition

### DIFF
--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -422,6 +422,8 @@
 		94D51FC3207D9347008341A7 /* BOXRepresentationInfoRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D51FC1207D9347008341A7 /* BOXRepresentationInfoRequest.m */; };
 		94D51FC4207EB9B1008341A7 /* BOXRepresentationInfoRequest.m in Headers */ = {isa = PBXBuildFile; fileRef = 94D51FC1207D9347008341A7 /* BOXRepresentationInfoRequest.m */; settings = {ATTRIBUTES = (Public, ); }; };
 		94F5E2CB2083B6E300334AEC /* BOXRepresentationInfoRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 94F5E2CA2083B6E300334AEC /* BOXRepresentationInfoRequestTests.m */; };
+		94F971222130B4DF00F50F8C /* BOXRepresentationsHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 94F971202130B4DF00F50F8C /* BOXRepresentationsHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94F971232130B4DF00F50F8C /* BOXRepresentationsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 94F971212130B4DF00F50F8C /* BOXRepresentationsHelper.m */; };
 		A59A40B31EA1771000BF4113 /* file_all_fields_representations.json in Resources */ = {isa = PBXBuildFile; fileRef = A59A40B21EA1771000BF4113 /* file_all_fields_representations.json */; };
 		C53EC2631A388E9F0007C8A7 /* BOXCommentAddRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C53EC2621A388E9F0007C8A7 /* BOXCommentAddRequestTests.m */; };
 		C53EC2991A389F2C0007C8A7 /* BOXCommentDeleteRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C53EC2981A389F2C0007C8A7 /* BOXCommentDeleteRequestTests.m */; };
@@ -797,6 +799,8 @@
 		94D51FC0207D9347008341A7 /* BOXRepresentationInfoRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BOXRepresentationInfoRequest.h; sourceTree = "<group>"; };
 		94D51FC1207D9347008341A7 /* BOXRepresentationInfoRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BOXRepresentationInfoRequest.m; sourceTree = "<group>"; };
 		94F5E2CA2083B6E300334AEC /* BOXRepresentationInfoRequestTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BOXRepresentationInfoRequestTests.m; sourceTree = "<group>"; };
+		94F971202130B4DF00F50F8C /* BOXRepresentationsHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BOXRepresentationsHelper.h; path = Helper/BOXRepresentationsHelper.h; sourceTree = "<group>"; };
+		94F971212130B4DF00F50F8C /* BOXRepresentationsHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BOXRepresentationsHelper.m; path = Helper/BOXRepresentationsHelper.m; sourceTree = "<group>"; };
 		A59A40B21EA1771000BF4113 /* file_all_fields_representations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = file_all_fields_representations.json; sourceTree = "<group>"; };
 		AA73ECFF1E36C1EE0010F6D8 /* BOXRecentItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BOXRecentItem.m; sourceTree = "<group>"; };
 		AA73ED001E36C1EE0010F6D8 /* BOXRecentItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BOXRecentItem.h; sourceTree = "<group>"; };
@@ -1512,6 +1516,8 @@
 				C562DB491A4831270002E510 /* BOXSharedLinkHeadersDefaultManager.m */,
 				6AA4256F1E39743800EF2677 /* BOXURLRequestSerialization.h */,
 				6AA425701E39743800EF2677 /* BOXURLRequestSerialization.m */,
+				94F971202130B4DF00F50F8C /* BOXRepresentationsHelper.h */,
+				94F971212130B4DF00F50F8C /* BOXRepresentationsHelper.m */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -1912,6 +1918,7 @@
 				599B1A2D1E4BE6DC00709C27 /* BOXRepresentation.h in Headers */,
 				599B1A2E1E4BE6DC00709C27 /* BOXRecentItem.h in Headers */,
 				599B1A2F1E4BE6DC00709C27 /* BOXStreamOperation.h in Headers */,
+				94F971222130B4DF00F50F8C /* BOXRepresentationsHelper.h in Headers */,
 				599B1A301E4BE6DC00709C27 /* BOXAPIAuthenticatedOperation.h in Headers */,
 				599B1A311E4BE6DC00709C27 /* BOXAPIDataOperation.h in Headers */,
 				599B1A321E4BE6DC00709C27 /* BOXAPIJSONOperation.h in Headers */,
@@ -2352,6 +2359,7 @@
 				599B19631E4BE67600709C27 /* BOXOAuth2Session.m in Sources */,
 				599B19641E4BE67600709C27 /* BOXParallelOAuth2Session.m in Sources */,
 				94D51FC3207D9347008341A7 /* BOXRepresentationInfoRequest.m in Sources */,
+				94F971232130B4DF00F50F8C /* BOXRepresentationsHelper.m in Sources */,
 				599B19651E4BE67600709C27 /* BOXAbstractSession.m in Sources */,
 				599B19661E4BE67600709C27 /* BOXAppUserSession.m in Sources */,
 				599B19671E4BE67600709C27 /* BOXDispatchHelper.m in Sources */,

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -515,3 +515,33 @@ typedef NS_ENUM(NSUInteger, BOXAvatarType) {
     BOXAvatarTypeLarge
 };
 
+/**
+ Representations are digital assets created for files stored in Box. To request representations information for
+ a file, set the options for each type.
+ 
+ - BOXRepresentationRequestOriginal:                        Request original content url with file information request
+ Reference the reponse field 'authenticated_download_url' to download original content when file
+ has download permissions are owner, co-owner, editor, viewer uploader, viewer
+ - BOXRepresentationRequestAllRepresentations:              If permissions allow retrieve representations for thumbnails, preview representations for the given file
+ - BOXRepresentationRequestHighDefinitionVideo:             Request video representions if available for the given file
+ - BOXRepresentationRequestThumbnailRepresentation:         Request thumbnail representions if available for the given file
+ - BOXRepresentationRequestLargeThumbnailRepresentation:    Request large thumbnail representions are available for the given file
+ - BOXRepresentationRequestPDFRepresentation:               Request PDF representions if available for the given file
+ - BOXRepresentationRequestJPGRepresentation:               Request JPG representions if available for the given file
+ - BOXRepresentationRequestMP3Representation:               Request PNG representions if available for the given file
+ - BOXRepresentationRequestMP4Representation:               Request MP4 representions if available for the given file
+ - BOXRepresentationRequesteExtractedTextRepresentation:    Request extracted text if unformatted text is contained in a document (non-image)
+ */
+typedef NS_ENUM(NSUInteger, BOXRepresentationRequestOptions) {
+    BOXRepresentationRequestOriginal,
+    BOXRepresentationRequestAllRepresentations,
+    BOXRepresentationRequestHighDefinitionVideo,
+    BOXRepresentationRequestThumbnailRepresentation,
+    BOXRepresentationRequestLargeThumbnailRepresentation,
+    BOXRepresentationRequestPDFRepresentation,
+    BOXRepresentationRequestJPGRepresentation,
+    BOXRepresentationRequestMP3Representation,
+    BOXRepresentationRequestMP4Representation,
+    BOXRepresentationRequesteExtractedTextRepresentation
+};
+

--- a/BoxContentSDK/BoxContentSDK/Helper/BOXRepresentationsHelper.h
+++ b/BoxContentSDK/BoxContentSDK/Helper/BOXRepresentationsHelper.h
@@ -1,0 +1,21 @@
+//
+//  BOXRepresentationsHelper.h
+//  BoxContentSDK
+//
+//  Created by Prithvi Jutur on 8/24/18.
+//  Copyright © 2018 Box. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "BOXContentSDKConstants.h"
+
+@protocol RepresentationsRequesting
+- (void)setRepresentationRequestOptions:(NSArray*) representationOptions;
+@end
+
+@interface BOXRepresentationsHelper : NSObject
+
+- (void)setRepresentationRequestOptions:(NSArray*) representationOptions;
+- (NSString *)formatRepresentationRequestHeader;
+- (NSString *) getRepresentationsFieldString;
+@end

--- a/BoxContentSDK/BoxContentSDK/Helper/BOXRepresentationsHelper.m
+++ b/BoxContentSDK/BoxContentSDK/Helper/BOXRepresentationsHelper.m
@@ -1,0 +1,99 @@
+//
+//  BOXRepresentationsHelper.m
+//  BoxContentSDK
+//
+//  Created by Prithvi Jutur on 8/24/18.
+//  Copyright © 2018 Box. All rights reserved.
+//
+
+#import "BOXRepresentationsHelper.h"
+
+@interface BOXRepresentationsHelper()
+@property (nonatomic, readwrite, strong) NSMutableOrderedSet *representationsRequested;
+@end
+
+@implementation BOXRepresentationsHelper
+
+- (void)setRepresentationRequestOptions:(NSArray *)representationOptions
+{
+    self.representationsRequested = [[NSMutableOrderedSet alloc] initWithArray:representationOptions];
+}
+
+- (NSString *) getRepresentationsFieldString {
+    NSString *fieldString = @"";
+    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestOriginal)]) {
+        [self.representationsRequested removeObject:@(BOXRepresentationRequestOriginal)];
+        fieldString = [fieldString stringByAppendingFormat:@",%@", BOXAPIObjectKeyAuthenticatedDownloadURL];
+    }
+    if ([self.representationsRequested count] > 0) {
+        // Include information for the original content URL in any request for file representations
+        fieldString = [fieldString stringByAppendingFormat:@",%@", BOXAPIObjectKeyRepresentations];
+    }
+    return fieldString;
+}
+
+- (NSString *)formatRepresentationRequestHeader
+{
+    // Only process valid API options.
+    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestOriginal)]) {
+        [self.representationsRequested removeObject:@(BOXRepresentationRequestOriginal)];
+    }
+    
+    if ([self.representationsRequested count] == 0) {
+        return nil;
+    }
+    
+    __block NSString *representationFields = @"";
+    
+    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestAllRepresentations)]) {
+        representationFields = @"[jpg?dimensions=320x320&paged=false][jpg?dimensions=1024x1024&paged=false][pdf,hls,mp4,mp3,jpg]";
+        [self.representationsRequested removeObject:@(BOXRepresentationRequestAllRepresentations)];
+    }
+    if ([self.representationsRequested count] == 0) {
+        return representationFields;
+    }
+    
+    representationFields = [representationFields stringByAppendingString:@"["];
+    
+    __block NSString *delimiter = @"],[";
+    
+    [self.representationsRequested enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        if (idx == [self.representationsRequested count]) {
+            representationFields = [representationFields stringByReplacingCharactersInRange:NSMakeRange([representationFields length]-1, 1) withString:@"]"];
+            
+            *stop = YES;
+        } else {
+            if (idx == [self.representationsRequested  count] - 1) {
+                delimiter = @"]";
+            }
+            BOXRepresentationRequestOptions representationOption = (BOXRepresentationRequestOptions) [obj integerValue];
+            if (representationOption == BOXRepresentationRequestHighDefinitionVideo) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeHLS, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestMP3Representation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeMP3, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestMP4Representation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeMP4, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestThumbnailRepresentation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensionsJPG320, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestLargeThumbnailRepresentation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensions1024, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestPDFRepresentation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypePDF, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequestJPGRepresentation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensions1024, delimiter]];
+            }
+            if (representationOption == BOXRepresentationRequesteExtractedTextRepresentation) {
+                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeExtractedText, delimiter]];
+            }
+        }
+    }];
+    
+    return representationFields;
+}
+@end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
@@ -4,46 +4,11 @@
 //
 
 #import "BOXRequestWithSharedLinkHeader.h"
+#import "BOXRepresentationsHelper.h"
 
-
-/**
- Representations are digital assets created for files stored in Box. To request representations information for
- a file, set the options for each type.
- 
- - BOXRepresentationRequestOriginal:                        Request original content url with file information request
-                                                            Reference the reponse field 'authenticated_download_url' to download original content when file
-                                                            has download permissions are owner, co-owner, editor, viewer uploader, viewer
- - BOXRepresentationRequestAllRepresentations:              If permissions allow retrieve representations for thumbnails, preview representations for the given file
- - BOXRepresentationRequestHighDefinitionVideo:             Request video representions if available for the given file
- - BOXRepresentationRequestThumbnailRepresentation:         Request thumbnail representions if available for the given file
- - BOXRepresentationRequestLargeThumbnailRepresentation:    Request large thumbnail representions are available for the given file
- - BOXRepresentationRequestPDFRepresentation:               Request PDF representions if available for the given file
- - BOXRepresentationRequestJPGRepresentation:               Request JPG representions if available for the given file
- - BOXRepresentationRequestMP3Representation:               Request PNG representions if available for the given file
- - BOXRepresentationRequestMP4Representation:               Request MP4 representions if available for the given file
- - BOXRepresentationRequesteExtractedTextRepresentation:    Request extracted text if unformatted text is contained in a document (non-image)
- */
-typedef NS_ENUM(NSUInteger, BOXRepresentationRequestOptions) {
-    BOXRepresentationRequestOriginal,
-    BOXRepresentationRequestAllRepresentations,
-    BOXRepresentationRequestHighDefinitionVideo,
-    BOXRepresentationRequestThumbnailRepresentation,
-    BOXRepresentationRequestLargeThumbnailRepresentation,
-    BOXRepresentationRequestPDFRepresentation,
-    BOXRepresentationRequestJPGRepresentation,
-    BOXRepresentationRequestMP3Representation,
-    BOXRepresentationRequestMP4Representation,
-    BOXRepresentationRequesteExtractedTextRepresentation
-} NS_ENUM_AVAILABLE_IOS(10_0);
-
-@interface BOXFileRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileRequest : BOXRequestWithSharedLinkHeader <RepresentationsRequesting>
 
 @property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
-
-/**
- Ordered list of representation types, returns first representation type supported by the specified file type
- */
-@property (nonatomic, readwrite, assign) BOOL matchSupportedRepresentation;
 
 @property (nonatomic, readwrite, strong) NSArray *notMatchingEtags; //If-None-Match: Array of strings representing etag values
 
@@ -76,10 +41,10 @@ typedef NS_ENUM(NSUInteger, BOXRepresentationRequestOptions) {
                        refreshed:(BOXFileBlock)refreshBlock;
 
 /**
+ Returns an array of representations requested if existing
  Setting a representation or Array of options will include availability for that file when request representation information
+ Use BOXRepresentationRequestAllRepresentations to return small and large thumbnail and best preview
  */
 - (void)setRepresentationRequestOptions:(NSArray *)representationOptions;
-
-- (NSString *)formatRepresentationRequestHeader;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
@@ -16,12 +16,7 @@
 
 @property (nonatomic, readwrite, strong) NSString *fileID;
 @property (nonatomic, readwrite, assign) BOOL isTrashed;
-
-/**
- Setting a representation or list option will include availability of file with request representation information
- */
-@property (nonatomic, readwrite, strong) NSMutableOrderedSet *representationsRequested;
-
+@property (nonatomic, readonly, strong) BOXRepresentationsHelper* repsHelper;
 
 - (BOOL)shouldPerformBackgroundOperation;
 
@@ -39,6 +34,7 @@
     if (self = [super init]) {
         _fileID = fileID;
         _isTrashed = isTrashed;
+        _repsHelper = [BOXRepresentationsHelper new];
     }
 
     return self;
@@ -65,16 +61,9 @@
         fieldString = [self fullFileFieldsParameterString];
     }
     
-    // The original content url is retrieved from the download_url. Include BOXRepresentationRequestOriginal
-    // The download url is added to the BoxFile representations array, retrieved by type value BOXRepresentationRequestOriginal.
-    // You can download the file has owner, co-owner, editor, viewer uploader, viewer permissions.
-    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestOriginal)]) {
-        [self.representationsRequested removeObject:@(BOXRepresentationRequestOriginal)];
-        fieldString = [fieldString stringByAppendingFormat:@",%@", BOXAPIObjectKeyAuthenticatedDownloadURL];
-    }
-    if ([self.representationsRequested count] > 0) {
-        // Include information for the original content URL in any request for file representations
-        fieldString = [fieldString stringByAppendingFormat:@",%@", BOXAPIObjectKeyRepresentations];
+    NSString *repsFieldString = [self.repsHelper getRepresentationsFieldString];
+    if(repsFieldString.length > 0) {
+        fieldString = [fieldString stringByAppendingFormat:@",%@", repsFieldString];
     }
     
     if (fieldString.length > 0) {
@@ -113,7 +102,7 @@
         }
     }
     
-    NSString *representationFields = [self formatRepresentationRequestHeader];
+    NSString *representationFields = [self.repsHelper formatRepresentationRequestHeader];
     
     if (representationFields.length > 0) {
         [fileOperation.APIRequest addValue:representationFields
@@ -224,6 +213,10 @@
     [self performRequestWithCompletion:refreshBlock];
 }
 
+- (void)setRepresentationRequestOptions:(NSArray *)representationOptions {
+    [self.repsHelper setRepresentationRequestOptions:representationOptions];
+}
+
 #pragma mark - Superclass overidden methods
 
 - (NSString *)itemIDForSharedLink
@@ -243,77 +236,6 @@
     return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
-- (void)setRepresentationRequestOptions:(NSArray *)representationOptions
-{
-    self.representationsRequested = [[NSMutableOrderedSet alloc] initWithArray:representationOptions];
-}
 
-- (NSString *)formatRepresentationRequestHeader
-{
-    // Only process valid API options.
-    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestOriginal)]) {
-        [self.representationsRequested removeObject:@(BOXRepresentationRequestOriginal)];
-    }
-    
-    if ([self.representationsRequested count] == 0) {
-        return nil;
-    }
-    
-    __block NSString *representationFields = @"";
-    
-    if ([self.representationsRequested containsObject:@(BOXRepresentationRequestAllRepresentations)]) {
-        representationFields = @"[jpg?dimensions=320x320&paged=false][jpg?dimensions=1024x1024&paged=false][pdf,hls,mp4,mp3,jpg]";
-        [self.representationsRequested removeObject:@(BOXRepresentationRequestAllRepresentations)];
-    }
-    if ([self.representationsRequested count] == 0) {
-        return representationFields;
-    }
-    
-    representationFields = [representationFields stringByAppendingString:@"["];
-    
-    __block NSString *delimiter = @"],[";
-    if (self.matchSupportedRepresentation == YES) {
-        delimiter = @",";
-    }
-    
-    [self.representationsRequested enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        if (idx == [self.representationsRequested count]) {
-            representationFields = [representationFields stringByReplacingCharactersInRange:NSMakeRange([representationFields length]-1, 1) withString:@"]"];
-            
-            *stop = YES;
-        } else {
-            if (idx == [self.representationsRequested  count] - 1) {
-                delimiter = @"]";
-            }
-            BOXRepresentationRequestOptions representationOption = (BOXRepresentationRequestOptions) [obj integerValue];
-            if (representationOption == BOXRepresentationRequestHighDefinitionVideo) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeHLS, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestMP3Representation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeMP3, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestMP4Representation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeMP4, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestThumbnailRepresentation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensionsJPG320, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestLargeThumbnailRepresentation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensions1024, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestPDFRepresentation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypePDF, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequestJPGRepresentation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@?dimensions=%@&paged=false%@", BOXRepresentationTypeJPG, BOXRepresentationImageDimensions1024, delimiter]];
-            }
-            if (representationOption == BOXRepresentationRequesteExtractedTextRepresentation) {
-                representationFields = [representationFields stringByAppendingString:[NSString stringWithFormat:@"%@%@", BOXRepresentationTypeExtractedText, delimiter]];
-            }
-        }
-    }];
-    
-    return representationFields;
-}
 
 @end

--- a/BoxContentSDK/BoxContentSDKTests/BOXFileRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileRequestTests.m
@@ -15,6 +15,7 @@
 #import "UIDevice+BOXContentSDKAdditions.h"
 
 @interface BOXFileRequestTests : BOXRequestTestCase
+
 @end
 
 @implementation BOXFileRequestTests
@@ -125,67 +126,62 @@
     
     // Check x-reps-hint header original file request
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestOriginal)]];
-    NSString *actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    BOXAPIOperation *fileRequestOperation = [fileRequest createOperation];
+    NSString *actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     XCTAssertEqualObjects(nil, actualXRepsHint);
     
     // Check x-reps-hint header with multi-options file request
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestJPGRepresentation), @(BOXRepresentationRequestMP3Representation), @(BOXRepresentationRequestMP4Representation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     NSString *expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=1024x1024&paged=false],[mp3],[mp4]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header original file request with other option
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestOriginal)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     XCTAssertEqualObjects(nil, actualXRepsHint);
     
     // Check x-reps-hint header default original file request with other option
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestOriginal), @(BOXRepresentationRequestThumbnailRepresentation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=320x320&paged=false]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header thumbnail request
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestThumbnailRepresentation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=320x320&paged=false]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header group reps request for all options
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestJPGRepresentation), @(BOXRepresentationRequestMP3Representation), @(BOXRepresentationRequestMP4Representation), @(BOXRepresentationRequestMP4Representation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=1024x1024&paged=false],[mp3],[mp4]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header mp3 request
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestMP3Representation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     expectedHeaderXRepsHint = [NSString stringWithFormat:@"[mp3]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header is no option due to persmissions set '0', representation is ignored.
     [fileRequest setRepresentationRequestOptions:@[@(0)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     XCTAssertEqualObjects(nil, actualXRepsHint);
-    
-    // Match representations option request
-    fileRequest.matchSupportedRepresentation = YES;
-    
-    // Check x-reps-hint header first reps matched request for all options
-    [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestJPGRepresentation),@(BOXRepresentationRequestMP3Representation), @(BOXRepresentationRequestMP4Representation), @(BOXRepresentationRequestMP4Representation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
-    expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=1024x1024&paged=false,mp3,mp4]"];
-    XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
     
     // Check x-reps-hint header verify single rep in match option
     [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestHighDefinitionVideo)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
+    fileRequestOperation = [fileRequest createOperation];
+    actualXRepsHint = [[fileRequestOperation.APIRequest allHTTPHeaderFields] valueForKey:BOXAPIHTTPHeaderXRepHints];
     expectedHeaderXRepsHint = [NSString stringWithFormat:@"[hls]"];
-    XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
-    
-    [fileRequest setRepresentationRequestOptions:@[@(BOXRepresentationRequestLargeThumbnailRepresentation)]];
-    actualXRepsHint = [fileRequest formatRepresentationRequestHeader];
-    expectedHeaderXRepsHint = [NSString stringWithFormat:@"[jpg?dimensions=1024x1024&paged=false]"];
     XCTAssertEqualObjects(expectedHeaderXRepsHint, actualXRepsHint);
 }
 


### PR DESCRIPTION
Just moving around code mostly and removed also a couple of unused/deprecated public methods. 