### PR TITLE
Add new cache function that does not depend on a box-ios-sdk request

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Protocols/BOXContentCacheClientProtocol.h
+++ b/BoxContentSDK/BoxContentSDK/Protocols/BOXContentCacheClientProtocol.h
@@ -121,6 +121,8 @@
 
 #pragma mark - Files
 
+- (void)cacheBoxFile:(BOXFile *)file;
+
 - (void)cacheFileRequest:(BOXFileRequest *)request
                 withFile:(BOXFile *)file
                    error:(NSError *)error;


### PR DESCRIPTION
We have other requests that return files and it makes sense to provide a caching interface that is not tied into a request type