### PR TITLE
IOS-17005 - fix linking of the ContentSDKTestFramework

### DIFF
--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -2861,6 +2861,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.box.BoxContentSDKTestFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -2911,6 +2912,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.box.BoxContentSDKTestFramework;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Needed to add the -ObjC linking option. I learned then when attempting
to use the ContentSDKTestFramework from another target (BoxToolkitTests)
and a test hit a runtime error when trying to use OCMock. And the runtime
error actually gave a super useful error syaing to try to -ObjC error!