### PR TITLE
IOS-16748 - add missing tests for Collaborations Request code

### DIFF
--- a/BoxContentSDK/BoxContentSDKTests/BOXFileCollaborationsRequestTests.m
+++ b/BoxContentSDK/BoxContentSDKTests/BOXFileCollaborationsRequestTests.m
@@ -13,19 +13,80 @@
 
 @end
 
+NSString *const someFileID = @"123";
+
 @implementation BOXFileCollaborationsRequestTests
 
-- (void)test_request_has_expected_URLRequest
+- (void)assert_request_url:(BOXFileCollaborationsRequest *)request box_id:(NSString *)box_id
 {
-    NSString *fileID = @"123";
-    
-    BOXFileCollaborationsRequest *request = [[BOXFileCollaborationsRequest alloc] initWithFileID:fileID];
+    [self assert_request_url:request box_id:box_id limit:100 next_marker:nil];
+}
+
+- (void)assert_request_url:(BOXFileCollaborationsRequest *)request box_id:(NSString *)box_id limit:(int)limit
+{
+    [self assert_request_url:request box_id:box_id limit:limit next_marker:nil];
+}
+
+- (void)assert_request_url:(BOXFileCollaborationsRequest *)request box_id:(NSString *)box_id next_marker:(NSString *)marker
+{
+    [self assert_request_url:request box_id:box_id limit:100 next_marker:marker];
+}
+
+- (void)assert_request_url:(BOXFileCollaborationsRequest *)request box_id:(NSString *)box_id limit:(int)limit next_marker:(NSString *)marker
+{
     NSURLRequest *URLRequest = request.urlRequest;
-    
+
     // URL assertions
-    NSURL *expectedURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@/files/%@/collaborations?limit=100", [BOXContentClient APIBaseURL], fileID]];
+    NSMutableString *rawURL = [NSMutableString stringWithFormat:@"%@/files/%@/collaborations?limit=%d", [BOXContentClient APIBaseURL], box_id, limit];
+    
+    if (marker) {
+        [rawURL appendFormat:@"&marker=%@", marker];
+    }
+    
+    NSURL *expectedURL = [NSURL URLWithString:rawURL];
     XCTAssertEqualObjects(expectedURL, URLRequest.URL);
     XCTAssertEqualObjects(@"GET", URLRequest.HTTPMethod);
 }
+
+- (void)test_request_has_expected_URLRequest
+{
+    // code under test
+    BOXFileCollaborationsRequest *request = [[BOXFileCollaborationsRequest alloc] initWithFileID:someFileID];
+    
+    // validate
+    [self assert_request_url:request box_id:someFileID];
+}
+
+- (void)test_request_with_limit_has_expected_URLRequest
+{
+    // code under test
+    BOXFileCollaborationsRequest *request = [[BOXFileCollaborationsRequest alloc] initWithFileID:someFileID];
+    request.limit = 53;
+    
+    // validate
+    [self assert_request_url:request box_id:someFileID limit:53];
+}
+
+- (void)test_request_with_next_marker_has_expected_URLRequest
+{
+    // code under test
+    BOXFileCollaborationsRequest *request = [[BOXFileCollaborationsRequest alloc] initWithFileID:someFileID];
+    request.nextMarker = @"some_marker";
+
+    // validate
+    [self assert_request_url:request box_id:someFileID next_marker:@"some_marker"];
+}
+
+- (void)test_request_with_limit_and_next_marker_has_expected_URLRequest
+{
+    // code under test
+    BOXFileCollaborationsRequest *request = [[BOXFileCollaborationsRequest alloc] initWithFileID:someFileID];
+    request.nextMarker = @"another_marker";
+    request.limit = 1000;
+    
+    // validate
+    [self assert_request_url:request box_id:someFileID limit:1000 next_marker:@"another_marker"];
+}
+
 
 @end


### PR DESCRIPTION
Add a bit of missing test coverage - namely how the `limit` and
'next_marker` attributes are placed in the URL.

The class BOXFileCollaborationsRequest has more missing coverage,
namely the processing of the HTTP response. That isn't dealt with here.