### PR TITLE
Lowering BoxContentSDKFramework target to 11.0 for CI test execution

### DIFF
--- a/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
+++ b/BoxContentSDK/BoxContentSDK.xcodeproj/project.pbxproj
@@ -2857,7 +2857,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/BoxContentSDKTestFramework/Libraries/**";
 				INFOPLIST_FILE = BoxContentSDKTestFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2908,7 +2908,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/BoxContentSDKTestFramework/Libraries/**";
 				INFOPLIST_FILE = BoxContentSDKTestFramework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Discovered the unit tests were executed in sim iOS 11.0. The content sdk framework had the wrong min target set.