### PR TITLE
Don't assert on query parameters

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Categories/NSURL+BOXURLHelper.m
+++ b/BoxContentSDK/BoxContentSDK/Categories/NSURL+BOXURLHelper.m
@@ -27,8 +27,6 @@
         keyValuePairComponents = [keyValuePair componentsSeparatedByString:@"="];
         if (keyValuePairComponents.count == 2) {
             params[keyValuePairComponents[0]] = [keyValuePairComponents[1] stringByRemovingPercentEncoding];
-        } else {
-            BOXAssertFail(@"Inconsistent information in keyValuePair=%@", keyValuePair);
         }
     }
 


### PR DESCRIPTION
This would assert in debug mode on certain unexpected query parameters, but this isn't particularly useful, and is causing problems in practice during development.