### PR TITLE
Release memory each time we're finished with a chunk

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLRequestSerialization.m
@@ -449,7 +449,7 @@ forHTTPHeaderField:(NSString *)field
         bodyStream.contentProcessor = streamingHashHelper;
         [streamingHashHelper open];
         const NSUInteger chunkSize = 1024 * 8;
-        while ([inputStream hasBytesAvailable] && [outputStream hasSpaceAvailable]) {
+        while ([inputStream hasBytesAvailable] && [outputStream hasSpaceAvailable]) { @autoreleasepool {
             uint8_t buffer[chunkSize];
 
             NSInteger bytesRead = [inputStream read:buffer maxLength:chunkSize];
@@ -467,7 +467,7 @@ forHTTPHeaderField:(NSString *)field
             if (bytesRead == 0 && bytesWritten == 0) {
                 break;
             }
-        }
+        } }
 
         [outputStream close];
         [inputStream close];


### PR DESCRIPTION
We're using an autoreleased data object as part of preparing the file for upload, so we need to clean it up each time round the loop, or we end up loading the entire contents of the file into memory at once.