### PR TITLE
IOS-17410 removed unusued md5HashOfFileAtPath method

### DIFF
--- a/BoxContentSDK/BoxContentSDK/External/HashHelper/BOXHashHelper.h
+++ b/BoxContentSDK/BoxContentSDK/External/HashHelper/BOXHashHelper.h
@@ -22,7 +22,6 @@
 
 @interface BOXHashHelper : NSObject
 
-+ (NSString *)md5HashOfFileAtPath:(NSString *)filePath;
 + (NSString *)sha1HashOfFileAtPath:(NSString *)filePath;
 + (NSString *)sha512HashOfFileAtPath:(NSString *)filePath;
 

--- a/BoxContentSDK/BoxContentSDK/External/HashHelper/BOXHashHelper.m
+++ b/BoxContentSDK/BoxContentSDK/External/HashHelper/BOXHashHelper.m
@@ -107,12 +107,6 @@ typedef struct _FileHashComputationContext {
     return result;
 }
 
-+ (NSString *)md5HashOfFileAtPath:(NSString *)filePath {
-    FileHashComputationContext context;
-    FileHashComputationContextInitialize(context, MD5);
-    return [self hashOfFileAtPath:filePath withComputationContext:&context];
-}
-
 + (NSString *)sha1HashOfFileAtPath:(NSString *)filePath {
     FileHashComputationContext context;
     FileHashComputationContextInitialize(context, SHA1);


### PR DESCRIPTION
Removed a method which was flagged by Data Theorem for using md5. 