### PR TITLE
IOS-17522 - remove unnecessary code, which elims a race condition

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -21,11 +21,6 @@
 // output stream from this NSData when space becomes availble
 @property (nonatomic, readwrite, strong) NSMutableData *receivedDataBuffer;
 
-// The output stream may trigger the has space available callback when no data
-// is buffered. Use this BOOL to keep track of this state and manually invoke
-// the callback if necessary
-@property (nonatomic, readwrite, assign) BOOL outputStreamHasSpaceAvailable;
-
 @property (nonatomic, readwrite, assign) unsigned long long bytesReceived;
 
 - (void)writeDataToOutputStream;
@@ -51,7 +46,6 @@
 
 @synthesize outputStream = _outputStream;
 @synthesize receivedDataBuffer = _receivedDataBuffer;
-@synthesize outputStreamHasSpaceAvailable = _outputStreamHasSpaceAvailable;
 @synthesize bytesReceived = _bytesReceived;
 
 - (id)initWithURL:(NSURL *)URL HTTPMethod:(NSString *)HTTPMethod body:(NSDictionary *)body queryParams:(NSDictionary *)queryParams session:(BOXAbstractSession *)session
@@ -62,7 +56,6 @@
     {
         _outputStream = [NSOutputStream outputStreamToMemory];
         _receivedDataBuffer = [NSMutableData dataWithCapacity:0];
-        _outputStreamHasSpaceAvailable = YES; // attempt to write to the output stream as soon as we receive data
         _bytesReceived = 0;
         self.allowResume = NO;
 
@@ -303,15 +296,7 @@
             [self.receivedDataBuffer appendData:data];
         }
 
-        // If the output stream does have space available, trigger the writeDataToOutputStream
-        // handler so the data is consumed by the output stream. This state would occur if
-        // an NSStreamEventHasSpaceAvailable event was received but receivedDataBuffer was
-        // empty.
-        if (self.outputStreamHasSpaceAvailable)
-        {
-            self.outputStreamHasSpaceAvailable = NO;
-            [self writeDataToOutputStream];
-        }
+        [self writeDataToOutputStream];
     }
 }
 
@@ -339,7 +324,6 @@
         {
             if (self.receivedDataBuffer.length == 0)
             {
-                self.outputStreamHasSpaceAvailable = YES;
                 return; // bail out because we have nothing to write
             }
 


### PR DESCRIPTION
The `outputStreamHasSpaceAvailable` state was an optimization to
avoid acquring a mutex and calling NSOutputStream.hasSpaceAvailable.
Logic using `outputStreamHasSpaceAvailable` wasn't properly contained
within a mutex, so it was open to race conditions. I don't suspect
this race condition was actually triggering this bug (that will
come in another commit). But this change simplifies the code and
removes a race condition.