### PR TITLE
IOS-17522 - clear receivedDataBuffer when outputStream is cleared

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -212,6 +212,7 @@
 
 - (void)dealloc
 {
+    self.receivedDataBuffer = nil;
     if (self.outputStream) {
         self.outputStream.delegate = nil;
         [self.outputStream close];


### PR DESCRIPTION
IOS-17522 shows writeDataToOutputStream accessing freed memory. This is an
attempt to avoid that. This fix is speculative in that I haven't been able
to repro the same crash. I have confirmed that writeDataToOutputStream
will gracefully fail if it executed with receivedDataBuffer==nil.