### PR TITLE
IOS-17361: support immediate API request execution

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -86,6 +86,12 @@ extern NSString *const BOXContentClientBackgroundTempFolder;
 @property (nonatomic, nullable, readwrite, copy) NSDictionary *fetchTokenBlockInfo;
 
 /**
+ *  Used to set background requests' shouldPerformRequestImmediately provided those requests prepared
+ *  using BOXContentClient. E.g.: BOXFileRequest returned by fileInfoRequestWithID:associateID:
+ */
+@property (nonatomic, readwrite, assign) BOOL shouldBackgroundRequestsPerformImmediately;
+
+/**
  *  The list of Box users that have established a session through the SDK.
  *
  *  @return array of BOXUserMini model objects

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -397,7 +397,7 @@
 
 - (BOOL)canBeReenqueued
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
@@ -161,7 +161,7 @@
 
 - (BOOL)canBeReenqueued
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.h
@@ -169,6 +169,14 @@ typedef void (^BOXAPIDataFailureBlock)(NSURLRequest *request, NSHTTPURLResponse 
 @property (nonatomic, readwrite, copy) NSString *associateId;
 
 /**
+ * If true, operation's start will execute immediately on the current thread and not be put on a network thread. This also removes
+ *  the automatic re-enqueuing of a failed operation, thus, provides the caller further control in handling of failed operations.
+ * If false, operation's start will be put on a network thread.
+ * Default to false.
+ */
+@property (nonatomic, readwrite, assign) BOOL shouldStartImmediately;
+
+/**
  * Do not call this. It is used internally.
  */
 - (void)finish;

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
@@ -241,7 +241,7 @@
 
 - (BOOL)canBeReenqueued
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.m
@@ -131,7 +131,7 @@
 
 - (BOOL)canBeReenqueued
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
@@ -92,6 +92,12 @@ Please refer to specific requests for additional required properties to perform 
 @property (nonatomic, readwrite, strong) NSString *SDKIdentifier;
 @property (nonatomic, readwrite, strong) NSString *SDKVersion;
 
+/**
+ * If true, when performRequest is called, its API request will be started immediately instead of being put onto a network queue.
+ * This also means no automatic retry.
+ */
+@property (nonatomic, readwrite, assign) BOOL shouldPerformRequestImmediately;
+
 - (void)performRequest;
 - (void)cancel;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.m
@@ -65,7 +65,12 @@
 - (void)performRequest
 {
     [self.operation.APIRequest setValue:[self userAgent] forHTTPHeaderField:@"User-Agent"];
-    [self.queueManager enqueueOperation:self.operation];
+    if (self.shouldPerformRequestImmediately == YES) {
+        self.operation.shouldStartImmediately = YES;
+        [self.operation start];
+    } else {
+        [self.queueManager enqueueOperation:self.operation];
+    }
 }
 
 - (void)cancel


### PR DESCRIPTION
Pre-requisite: PR https://github.com/box/box-ios-sdk/pull/649

Currently, executing request will enqueue an API Operation to a network queue for execution.

Adding support for immediate API request execution allows the network request to be executed immediately without waiting on the queue. This is useful for cases where the caller needs control of timing of network request execution.

- Add BOXRequest's shouldPerformRequestImmediately option: to allow API network request to start immediately instead of being put onto a network queue
- Add BoxContentClient's shouldBackgroundRequestsPerformImmediately option: to support marking all background requests' API network requests to be executed immediately instead of being put onto a network queue