### PR TITLE
IOS-17361: (part 2) add BOXBackgroundRequestProtocol to be conformed …

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Bookmark.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Bookmark.m
@@ -69,8 +69,7 @@
 - (BOXBookmarkUpdateRequest *)bookmarkUpdateRequestWithID:(NSString *)bookmarkID
                                               associateID:(NSString *)associateID
 {
-    BOXBookmarkUpdateRequest *request = [[BOXBookmarkUpdateRequest alloc] initWithBookmarkID:bookmarkID];
-    request.associateID = associateID;
+    BOXBookmarkUpdateRequest *request = [[BOXBookmarkUpdateRequest alloc] initWithBookmarkID:bookmarkID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Collection.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Collection.m
@@ -60,7 +60,7 @@
 {
     BOXItemSetCollectionsRequest *request = [[BOXItemSetCollectionsRequest alloc] initFileSetCollectionsRequestForFileWithID:fileID
                                                                                                                collectionIDs:collectionIDs
-                                                                                                                 associateId:associateId];
+                                                                                                                 associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     
     [self prepareRequest:request];
@@ -82,7 +82,7 @@
 {
     BOXItemSetCollectionsRequest *request = [[BOXItemSetCollectionsRequest alloc] initFolderSetCollectionsRequestForFolderWithID:folderID
                                                                                                                    collectionIDs:collectionIDs
-                                                                                                                     associateId:associateId];
+                                                                                                                     associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     
     [self prepareRequest:request];
@@ -104,7 +104,7 @@
 {
     BOXItemSetCollectionsRequest *request = [[BOXItemSetCollectionsRequest alloc] initBookmarkSetCollectionsRequestForBookmarkWithID:bookmarkID
                                                                                                                        collectionIDs:collectionIDs
-                                                                                                                         associateId:associateId];
+                                                                                                                         associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     
     [self prepareRequest:request];

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+File.m
@@ -35,8 +35,7 @@
 - (BOXFileRequest *)fileInfoRequestWithID:(NSString *)fileID
                               associateID:(NSString *)associateID
 {
-    BOXFileRequest *request = [[BOXFileRequest alloc] initWithFileID:fileID];
-    request.associateID = associateID;
+    BOXFileRequest *request = [[BOXFileRequest alloc] initWithFileID:fileID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -63,8 +62,7 @@
 
 - (BOXFileUpdateRequest *)fileUpdateRequestWithID:(NSString *)fileID
                                       associateID:(NSString *)associateID {
-    BOXFileUpdateRequest *request = [[BOXFileUpdateRequest alloc] initWithFileID:fileID];
-    request.associateID = associateID;
+    BOXFileUpdateRequest *request = [[BOXFileUpdateRequest alloc] initWithFileID:fileID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -102,8 +100,7 @@
 - (BOXFileDeleteRequest *)fileDeleteRequestWithID:(NSString *)fileID
                                       associateID:(NSString *)associateID
 {
-    BOXFileDeleteRequest *request = [[BOXFileDeleteRequest alloc] initWithFileID:fileID];
-    request.associateId = associateID;
+    BOXFileDeleteRequest *request = [[BOXFileDeleteRequest alloc] initWithFileID:fileID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -123,7 +120,7 @@
                                       toLocalFilePath:(NSString *)localFilePath
                                           associateId:(NSString *)associateId
 {
-    BOXFileDownloadRequest *request = [[BOXFileDownloadRequest alloc] initWithLocalDestination:localFilePath fileID:fileID associateId:associateId];
+    BOXFileDownloadRequest *request = [[BOXFileDownloadRequest alloc] initWithLocalDestination:localFilePath fileID:fileID associateID:associateId];
     [self prepareRequest:request];
 
     return request;
@@ -168,7 +165,7 @@
                                           uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
                                                           associateId:(NSString *)associateId
 {
-    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID uploadMultipartCopyFilePath:uploadMultipartCopyFilePath associateId:associateId];
+    BOXFileUploadRequest *request = [[BOXFileUploadRequest alloc] initWithPath:localFilePath targetFolderID:folderID uploadMultipartCopyFilePath:uploadMultipartCopyFilePath associateID:associateId];
     [self prepareRequest:request];
 
     return request;
@@ -195,7 +192,7 @@
                                                       uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
                                                                       associateId:(NSString *)associateId
 {
-    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath uploadMultipartCopyFilePath:uploadMultipartCopyFilePath associateId:associateId];
+    BOXFileUploadNewVersionRequest *request = [[BOXFileUploadNewVersionRequest alloc] initWithFileID:fileID localPath:localFilePath uploadMultipartCopyFilePath:uploadMultipartCopyFilePath associateID:associateId];
     [self prepareRequest:request];
 
     return request;
@@ -243,8 +240,7 @@
 - (BOXFileRequest *)trashedFileInfoRequestWithID:(NSString *)fileID
                                      associateID:(NSString *)associateID
 {
-    BOXFileRequest *request = [[BOXFileRequest alloc] initWithFileID:fileID isTrashed:YES];
-    request.associateID = associateID;
+    BOXFileRequest *request = [[BOXFileRequest alloc] initWithFileID:fileID isTrashed:YES associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -263,8 +259,7 @@
 - (BOXFileDeleteRequest *)trashedFileDeleteFromTrashRequestWithID:(NSString *)fileID
                                                       associateID:(NSString *)associateID
 {
-    BOXFileDeleteRequest *request = [[BOXFileDeleteRequest alloc] initWithFileID:fileID isTrashed:YES];
-    request.associateId = associateID;
+    BOXFileDeleteRequest *request = [[BOXFileDeleteRequest alloc] initWithFileID:fileID isTrashed:YES associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -282,8 +277,7 @@
 - (BOXTrashedFileRestoreRequest *)trashedFileRestoreRequestWithID:(NSString *)fileID
                                                       associateID:(NSString *)associateID
 {
-    BOXTrashedFileRestoreRequest *request = [[BOXTrashedFileRestoreRequest alloc] initWithFileID:fileID];
-    request.associateId = associateID;
+    BOXTrashedFileRestoreRequest *request = [[BOXTrashedFileRestoreRequest alloc] initWithFileID:fileID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -309,7 +303,7 @@
     BOXFileRepresentationDownloadRequest *request = [[BOXFileRepresentationDownloadRequest alloc] initWithLocalDestination:localFilePath
                                                                                                                     fileID:fileID
                                                                                                             representation:representation
-                                                                                                               associateId:associateID];
+                                                                                                               associateID:associateID];
     [self prepareRequest:request];
     return request;
 }

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Folder.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient+Folder.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   associateId:(nullable NSString *)associateId
 {
     BOXFolderRequest *request = nil;
-    request = [[BOXFolderRequest alloc] initWithFolderID:folderID associateId:associateId];
+    request = [[BOXFolderRequest alloc] initWithFolderID:folderID associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     
     [self prepareRequest:request];
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     BOXFolderCreateRequest *request = [[BOXFolderCreateRequest alloc] initWithFolderName:folderName
                                                                           parentFolderID:parentFolderID
-                                                                             associateId:associateId];
+                                                                             associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     
     [self prepareRequest:request];
@@ -88,8 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOXFolderUpdateRequest *)folderUpdateRequestWithID:(NSString *)folderID
                                           associateID:(nullable NSString *)associateID
 {
-    BOXFolderUpdateRequest *request = [[BOXFolderUpdateRequest alloc] initWithFolderID:folderID];
-    request.associateId = associateID;
+    BOXFolderUpdateRequest *request = [[BOXFolderUpdateRequest alloc] initWithFolderID:folderID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -128,9 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
                                           associateId:(nullable NSString *)associateId;
 {
     BOXFolderDeleteRequest *request = nil;
-    request = [[BOXFolderDeleteRequest alloc] initWithFolderID:folderID];
+    request = [[BOXFolderDeleteRequest alloc] initWithFolderID:folderID associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
-    request.associateId = associateId;
     [self prepareRequest:request];
     
     return request;
@@ -188,8 +186,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOXFolderRequest *)trashedFolderInfoRequestWithID:(NSString *)folderID
                                          associateID:(nullable NSString *)associateID
 {
-    BOXFolderRequest *request = [[BOXFolderRequest alloc] initWithFolderID:folderID isTrashed:YES];
-    request.associateId = associateID;
+    BOXFolderRequest *request = [[BOXFolderRequest alloc] initWithFolderID:folderID isTrashed:YES associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -210,8 +207,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                           associateId:(nullable NSString *)associateId;
 {
     BOXFolderDeleteRequest *request = [[BOXFolderDeleteRequest alloc] initWithFolderID:folderID
-                                                                             isTrashed:YES];
-    request.associateId = associateId;
+                                                                             isTrashed:YES
+                                                                           associateID:associateId];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     
@@ -237,8 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOXTrashedFolderRestoreRequest *)trashedFolderRestoreRequestWithID:(NSString *)folderID
                                                           associateID:(nullable NSString *)associateID
 {
-    BOXTrashedFolderRestoreRequest *request = [[BOXTrashedFolderRestoreRequest alloc] initWithFolderID:folderID];
-    request.associateId = associateID;
+    BOXTrashedFolderRestoreRequest *request = [[BOXTrashedFolderRestoreRequest alloc] initWithFolderID:folderID associateID:associateID];
     request.requestDirectoryPath = self.tempCacheDir;
     [self prepareRequest:request];
     

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXBookmarkUpdateRequest : BOXRequestWithSharedLinkHeader
+@interface BOXBookmarkUpdateRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readonly, strong) NSString *bookmarkID;
 @property (nonatomic, readwrite, strong) NSURL *URL;
@@ -24,18 +24,14 @@
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
 /**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, strong) NSString *associateID;
-
-/**
  Caller provided directory path for the result payload of the background operation to be written to.
  This is a required value for performing the request in the background.
  */
 @property (nonatomic, readwrite, strong) NSString *requestDirectoryPath;
 
 - (instancetype)initWithBookmarkID:(NSString *)bookmarkID;
+
+- (instancetype)initWithBookmarkID:(NSString *)bookmarkID associateID:(NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXBookmarkBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXBookmarkUpdateRequest.m
@@ -14,6 +14,7 @@
 @property (nonatomic, readwrite, strong) NSString *bookmarkID;
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanDownload;
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanPreview;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -25,6 +26,13 @@
         _bookmarkID = bookmarkID;
     }
     
+    return self;
+}
+
+- (instancetype)initWithBookmarkID:(NSString *)bookmarkID associateID:(NSString *)associateID
+{
+    self = [self initWithBookmarkID:bookmarkID];
+    self.associateID = associateID;
     return self;
 }
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileDeleteRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileDeleteRequest.h
@@ -5,15 +5,9 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFileDeleteRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileDeleteRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, strong) NSString *associateId;
-
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
  */
@@ -26,11 +20,13 @@
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
 - (instancetype)initWithFileID:(NSString *)fileID;
-- (instancetype)initWithFileID:(NSString *)fileID isTrashed:(BOOL)isTrashed;
+- (instancetype)initWithFileID:(NSString *)fileID
+                   associateID:(NSString *)associateID;
 
+- (instancetype)initWithFileID:(NSString *)fileID isTrashed:(BOOL)isTrashed;
 - (instancetype)initWithFileID:(NSString *)fileID
                      isTrashed:(BOOL)isTrashed
-                   associateId:(NSString *)associateId;
+                   associateID:(NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXErrorBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileDeleteRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileDeleteRequest.m
@@ -15,6 +15,8 @@
 
 @property (nonatomic, readwrite, strong) NSString *fileID;
 
+@property (nonatomic, readwrite, copy) NSString *associateID;
+
 /// Properties related to Background tasks
 
 /**
@@ -33,6 +35,14 @@
     return [self initWithFileID:fileID isTrashed:NO];
 }
 
+- (instancetype)initWithFileID:(NSString *)fileID
+                   associateID:(NSString *)associateID
+{
+    self = [self initWithFileID:fileID];
+    self.associateID = associateID;
+    return self;
+}
+
 - (instancetype)initWithFileID:(NSString *)fileID isTrashed:(BOOL)isTrashed
 {
     if (self = [super init]) {
@@ -45,12 +55,12 @@
 
 - (instancetype)initWithFileID:(NSString *)fileID
                      isTrashed:(BOOL)isTrashed
-                   associateId:(NSString *)associateId
+                   associateID:(NSString *)associateID
 {
     if (self = [super init]) {
         _fileID = fileID;
         _isTrashed = isTrashed;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     return self;
 }
@@ -75,10 +85,10 @@
                                                          bodyDictionary:nil
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         return dataOperation;
@@ -188,7 +198,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileDownloadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileDownloadRequest.h
@@ -6,7 +6,7 @@
 #import "BOXRequestWithSharedLinkHeader.h"
 #import "BOXAPIOperation.h"
 
-@interface BOXFileDownloadRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileDownloadRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 // This is not the etag of a particular version of the file, nor the sequential version number,
 // it is the ID of the version representation gotten from /files/<fileID>/versions
@@ -29,7 +29,7 @@
  */
 - (instancetype)initWithLocalDestination:(NSString *)destinationPath
                                   fileID:(NSString *)fileID
-                             associateId:(NSString *)associateId;
+                             associateID:(NSString *)associateID;
 
 /**
  * request will download file into outputStream, and the file download cannot continue

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileDownloadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileDownloadRequest.m
@@ -14,7 +14,7 @@
 @property (nonatomic, readonly, strong) NSString *destinationPath;
 @property (nonatomic, readonly, strong) NSOutputStream *outputStream;
 @property (nonatomic, readonly, strong) NSString *fileID;
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 @end
 
 @implementation BOXFileDownloadRequest
@@ -33,10 +33,10 @@
 
 - (instancetype)initWithLocalDestination:(NSString *)destinationPath
                                   fileID:(NSString *)fileID
-                             associateId:(NSString *)associateId
+                             associateID:(NSString *)associateID
 {
     self = [self initWithLocalDestination:destinationPath fileID:fileID];
-    self.associateId = associateId;
+    self.associateID = associateID;
     return self;
 }
 
@@ -79,14 +79,14 @@
                                                      bodyDictionary:nil
                                                        successBlock:nil
                                                        failureBlock:nil
-                                                        associateId:self.associateId];
+                                                        associateId:self.associateID];
 
     dataOperation.modelID = self.fileID;
     
     BOXAssert(self.outputStream != nil || self.destinationPath != nil, @"An output stream or destination file path must be specified.");
     BOXAssert(!(self.outputStream != nil && self.destinationPath != nil), @"You cannot specify both an outputStream and a destination file path.");
 
-    if (self.destinationPath != nil && self.associateId != nil) {
+    if (self.destinationPath != nil && self.associateID != nil) {
         dataOperation.destinationPath = self.destinationPath;
     } else if (self.outputStream != nil) {
         dataOperation.outputStream = self.outputStream;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRepresentationDownloadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRepresentationDownloadRequest.h
@@ -10,7 +10,7 @@
 
 @class BOXRepresentation;
 
-@interface BOXFileRepresentationDownloadRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileRepresentationDownloadRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 // This is not the etag of a particular version of the file, nor the sequential version number,
 // it is the ID of the version representation gotten from /files/<fileID>/versions
@@ -54,7 +54,7 @@
 - (instancetype)initWithLocalDestination:(NSString *)destinationPath
                                   fileID:(NSString *)fileID
                           representation:(BOXRepresentation *)representation
-                             associateId:(NSString *)associateId;
+                             associateID:(NSString *)associateID;
 
 /**
  * request will download file into outputStream, and the file download cannot continue

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRepresentationDownloadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRepresentationDownloadRequest.m
@@ -21,7 +21,7 @@
 @property (nonatomic, readonly, strong) NSOutputStream *outputStream;
 @property (nonatomic, readonly, strong) NSString *fileID;
 @property (nonatomic, readwrite, strong) BOXRepresentation *representation;
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -45,10 +45,10 @@
 - (instancetype)initWithLocalDestination:(NSString *)destinationPath
                                   fileID:(NSString *)fileID
                           representation:(BOXRepresentation *)representation
-                             associateId:(NSString *)associateId
+                             associateID:(NSString *)associateID
 {
     self = [self initWithLocalDestination:destinationPath fileID:fileID representation:representation];
-    self.associateId = associateId;
+    self.associateID = associateID;
     return self;
 }
 
@@ -83,13 +83,13 @@
                                                      bodyDictionary:nil
                                                        successBlock:nil
                                                        failureBlock:nil
-                                                        associateId:self.associateId];
+                                                        associateId:self.associateID];
     
     BOXAssert(self.representation != nil, @"A representation must be specified.");
     BOXAssert(self.outputStream != nil || self.destinationPath != nil, @"An output stream or destination file path must be specified.");
     BOXAssert(!(self.outputStream != nil && self.destinationPath != nil), @"You cannot specify both an outputStream and a destination file path.");
     
-    if (self.destinationPath != nil && self.associateId != nil) {
+    if (self.destinationPath != nil && self.associateID != nil) {
         dataOperation.destinationPath = self.destinationPath;
     } else if (self.outputStream != nil) {
         dataOperation.outputStream = self.outputStream;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFileRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
 
@@ -14,11 +14,6 @@
 @property (nonatomic, readonly, strong) NSString *fileID;
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, strong) NSString *associateID;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -36,7 +31,14 @@
 - (instancetype)initWithFileID:(NSString *)fileID;
 
 - (instancetype)initWithFileID:(NSString *)fileID
+                   associateID:(NSString *)associateID;
+
+- (instancetype)initWithFileID:(NSString *)fileID
                      isTrashed:(BOOL)isTrashed;
+
+- (instancetype)initWithFileID:(NSString *)fileID
+                     isTrashed:(BOOL)isTrashed
+                   associateID:(NSString *)associateID;
 
 //Perform API request and any cache update only if refreshBlock is not nil
 - (void)performRequestWithCompletion:(BOXFileBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileRequest.m
@@ -16,6 +16,7 @@
 
 @property (nonatomic, readwrite, strong) NSString *fileID;
 @property (nonatomic, readwrite, assign) BOOL isTrashed;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 - (BOOL)shouldPerformBackgroundOperation;
 
@@ -28,6 +29,13 @@
     return [self initWithFileID:fileID isTrashed:NO];
 }
 
+- (instancetype)initWithFileID:(NSString *)fileID associateID:(NSString *)associateID
+{
+    self = [self initWithFileID:fileID];
+    self.associateID = associateID;
+    return self;
+}
+
 - (instancetype)initWithFileID:(NSString *)fileID isTrashed:(BOOL)isTrashed
 {    
     if (self = [super init]) {
@@ -35,6 +43,13 @@
         _isTrashed = isTrashed;
     }
 
+    return self;
+}
+
+- (instancetype)initWithFileID:(NSString *)fileID isTrashed:(BOOL)isTrashed associateID:(NSString *)associateID
+{
+    self = [self initWithFileID:fileID isTrashed:isTrashed];
+    self.associateID = associateID;
     return self;
 }
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFileUpdateRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileUpdateRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readonly, strong) NSString *fileID;
 @property (nonatomic, readwrite, strong) NSString *fileName;
@@ -22,11 +22,6 @@
 @property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, strong) NSString *associateID;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -35,6 +30,7 @@
 @property (nonatomic, readwrite, strong) NSString *requestDirectoryPath;
 
 - (instancetype)initWithFileID:(NSString *)fileID;
+- (instancetype)initWithFileID:(NSString *)fileID associateID:(NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXFileBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUpdateRequest.m
@@ -14,6 +14,7 @@
 @property (nonatomic, readwrite, strong) NSString *fileID;
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanDownload;
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanPreview;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 @end
 
 @implementation BOXFileUpdateRequest
@@ -24,6 +25,13 @@
         _fileID = fileID;
     }
 
+    return self;
+}
+
+- (instancetype)initWithFileID:(NSString *)fileID associateID:(NSString *)associateID
+{
+    self = [self initWithFileID:fileID];
+    self.associateID = associateID;
     return self;
 }
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFileUploadNewVersionRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileUploadNewVersionRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readonly, strong) NSString *fileID;
 @property (nonatomic, readwrite, assign) BOOL requestAllFileFields;
@@ -15,7 +15,7 @@
 - (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath;
 
 //initialize a request which will run in the background even if app terminates if uploadMultipartCopyFilePath is provided
-- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateId:(NSString *)associateId;
+- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateID:(NSString *)associateID;
 
 - (instancetype)initWithFileID:(NSString *)fileID data:(NSData *)data;
 - (void)performRequestWithProgress:(BOXProgressBlock)progressBlock completion:(BOXFileBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadNewVersionRequest.m
@@ -17,7 +17,7 @@
 
 @property (nonatomic, readwrite, strong) NSString *localFilePath;
 @property (nonatomic, readwrite, strong) NSString *uploadMultipartCopyFilePath;
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 @property (nonatomic, readwrite, strong) NSData *fileData;
 
 @end
@@ -34,12 +34,12 @@
     return self;
 }
 
-- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateId:(NSString *)associateId
+- (instancetype)initWithFileID:(NSString *)fileID localPath:(NSString *)localPath uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateID:(NSString *)associateID
 {
     self = [self initWithFileID:fileID localPath:localPath];
     if (self != nil) {
         self.uploadMultipartCopyFilePath = uploadMultipartCopyFilePath;
-        self.associateId = associateId;
+        self.associateID = associateID;
     }
     return self;
 }
@@ -78,7 +78,7 @@
         }
 
         operation.uploadMultipartCopyFilePath = self.uploadMultipartCopyFilePath;
-        operation.associateId = self.associateId;
+        operation.associateId = self.associateID;
         [operation appendMultipartPieceWithFilePath:self.localFilePath
                                           fieldName:BOXAPIMultipartParameterFieldKeyFile
                                            filename:@""

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFileUploadRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFileUploadRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readwrite, strong) NSString *fileName;
 @property (nonatomic, readonly, strong) NSString *folderID;
@@ -16,7 +16,7 @@
 - (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID;
 
 //initialize a request which will run in the background even if app terminates if uploadMultipartCopyFilePath is provided
-- (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateId:(NSString *)associateId;
+- (instancetype)initWithPath:(NSString *)filePath targetFolderID:(NSString *)folderID uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath associateID:(NSString *)associateID;
 
 - (instancetype)initWithName:(NSString *)fileName targetFolderID:(NSString *)folderID data:(NSData *)data;
 - (void)performRequestWithProgress:(BOXProgressBlock)progressBlock completion:(BOXFileBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFileUploadRequest.m
@@ -18,7 +18,7 @@
 
 @property (nonatomic, readwrite, strong) NSString *localFilePath;
 @property (nonatomic, readwrite, strong) NSString *uploadMultipartCopyFilePath;
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 @property (nonatomic, readwrite, strong) NSData *fileData;
 
 @end
@@ -49,12 +49,12 @@
 - (instancetype)initWithPath:(NSString *)filePath
               targetFolderID:(NSString *)folderID
  uploadMultipartCopyFilePath:(NSString *)uploadMultipartCopyFilePath
-                 associateId:(NSString *)associateId
+                 associateID:(NSString *)associateID
 {
     self = [self initWithPath:filePath targetFolderID:folderID];
     if (self != nil) {
         self.uploadMultipartCopyFilePath = uploadMultipartCopyFilePath;
-        self.associateId = associateId;
+        self.associateID = associateID;
     }
     return self;
 }
@@ -120,7 +120,7 @@
             [operation.APIRequest setValue:[self fileSHA1] forHTTPHeaderField:BOXAPIHTTPHeaderContentMD5];
         }
         operation.uploadMultipartCopyFilePath = self.uploadMultipartCopyFilePath;
-        operation.associateId = self.associateId;
+        operation.associateId = self.associateID;
         [operation appendMultipartPieceWithFilePath:self.localFilePath
                                           fieldName:BOXAPIMultipartParameterFieldKeyFile
                                            filename:fileName

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderCreateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderCreateRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFolderCreateRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFolderCreateRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readwrite, strong) NSString *folderName;
 @property (nonatomic, readwrite, strong) NSString *parentFolderID;
@@ -21,7 +21,7 @@
 
 - (instancetype)initWithFolderName:(NSString *)folderName
                     parentFolderID:(NSString *)parentFolderID
-                       associateId:(nullable NSString *)associateId;
+                       associateID:(nullable NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXFolderBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderCreateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderCreateRequest.m
@@ -24,7 +24,7 @@
 /**
  Caller provided unique ID to execute the request as a NSURLSession background task
  */
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -34,18 +34,18 @@
 {
     return [self initWithFolderName:folderName
                        parentFolderID:parentFolderID
-                    associateId:nil];
+                    associateID:nil];
 }
 
 - (instancetype)initWithFolderName:(NSString *)folderName
                     parentFolderID:(NSString *)parentFolderID
-                       associateId:(nullable NSString *)associateId
+                       associateID:(nullable NSString *)associateID
 
 {
     if (self = [super init]) {
         _folderName = folderName;
         _parentFolderID = parentFolderID;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     
     return self;
@@ -74,10 +74,10 @@
                                                          bodyDictionary:bodyDictionary
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         return dataOperation;
@@ -195,7 +195,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-	return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+	return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderDeleteRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderDeleteRequest.h
@@ -5,14 +5,9 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFolderDeleteRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFolderDeleteRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, strong) NSString *associateId;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -27,11 +22,14 @@
 @property (nonatomic, readwrite, strong) NSString *matchingEtag;
 
 - (instancetype)initWithFolderID:(NSString *)folderID;
+- (instancetype)initWithFolderID:(NSString *)folderID
+                     associateID:(NSString *)associateID;
+
 - (instancetype)initWithFolderID:(NSString *)folderID isTrashed:(BOOL)isTrashed;
 
 - (instancetype)initWithFolderID:(NSString *)folderID
-                     isTrashed:(BOOL)isTrashed
-                   associateId:(NSString *)associateId;
+                       isTrashed:(BOOL)isTrashed
+                     associateID:(NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXErrorBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderDeleteRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderDeleteRequest.m
@@ -10,6 +10,7 @@
 
 @interface BOXFolderDeleteRequest ()
 @property (nonatomic, readwrite, assign) BOOL isTrashed;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 /// Properties related to Background tasks
 
@@ -29,21 +30,29 @@
     return [self initWithFolderID:folderID isTrashed:NO];
 }
 
+- (instancetype)initWithFolderID:(NSString *)folderID
+                     associateID:(NSString *)associateID
+{
+    self = [self initWithFolderID:folderID];
+    self.associateID = associateID;
+    return self;
+}
+
 - (instancetype)initWithFolderID:(NSString *)folderID isTrashed:(BOOL)isTrashed
 {
-    return [self initWithFolderID:folderID isTrashed:isTrashed associateId:nil];
+    return [self initWithFolderID:folderID isTrashed:isTrashed associateID:nil];
 }
 
 - (instancetype)initWithFolderID:(NSString *)folderID
                        isTrashed:(BOOL)isTrashed
-                     associateId:(NSString *)associateId
+                     associateID:(NSString *)associateID
 {
     self = [super init];
     if (self != nil) {
         _folderID = folderID;
         _recursive = YES;
         _isTrashed = isTrashed;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     
     return self;
@@ -75,10 +84,10 @@
                                                          bodyDictionary:nil
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         if ([self.matchingEtag length] > 0) {
@@ -192,7 +201,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.h
@@ -5,7 +5,7 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFolderRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFolderRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 /*
  By default BOXFileRequest will only fetch a predefined set of fields. Use |requestAllFolderFields| to
@@ -17,11 +17,6 @@
 @property (nonatomic, readonly, strong) NSString *folderID;
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, copy) NSString *associateId;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -31,8 +26,11 @@
 
 - (instancetype)initWithFolderID:(NSString *)folderID;
 - (instancetype)initWithFolderID:(NSString *)folderID
-                     associateId:(NSString *)associateId;
+                     associateID:(NSString *)associateID;
 - (instancetype)initWithFolderID:(NSString *)folderID isTrashed:(BOOL)isTrashed;
+- (instancetype)initWithFolderID:(NSString *)folderID
+                       isTrashed:(BOOL)isTrashed
+                     associateID:(NSString *)associateID;
 
 //Perform API request and any cache update only if refreshBlock is not nil
 - (void)performRequestWithCompletion:(BOXFolderBlock)completionBlock;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderRequest.m
@@ -19,6 +19,8 @@
 
 /// Properties related to Background tasks
 
+@property (nonatomic, readwrite, copy) NSString *associateID;
+
 /**
  Check if the request can executre on background. Requires valid associateId and requestDirectoryPath
  
@@ -32,28 +34,28 @@
 
 - (instancetype)initWithFolderID:(NSString *)folderID
 {
-    return [self initWithFolderID:folderID associateId:nil];
+    return [self initWithFolderID:folderID associateID:nil];
 }
 
 - (instancetype)initWithFolderID:(NSString *)folderID
-                     associateId:(NSString *)associateId
+                     associateID:(NSString *)associateID
 {
-    return [self initWithFolderID:folderID isTrashed:NO associateId: associateId];
+    return [self initWithFolderID:folderID isTrashed:NO associateID:associateID];
 }
 
 - (instancetype)initWithFolderID:(NSString *)folderID isTrashed:(BOOL)isTrashed
 {
-    return [self initWithFolderID:folderID isTrashed:isTrashed associateId: nil];
+    return [self initWithFolderID:folderID isTrashed:isTrashed associateID:nil];
 }
 
 - (instancetype)initWithFolderID:(NSString *)folderID
                        isTrashed:(BOOL)isTrashed
-                     associateId:(NSString *)associateId
+                     associateID:(NSString *)associateID
 {
     if (self = [super init]) {
         _folderID = folderID;
         _isTrashed = isTrashed;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     
     return self;
@@ -89,10 +91,10 @@
                                                          bodyDictionary:nil
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         if ([self.notMatchingEtags count] > 0) {
@@ -248,7 +250,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.h
@@ -5,17 +5,12 @@
 
 #import "BOXRequestWithSharedLinkHeader.h"
 
-@interface BOXFolderUpdateRequest : BOXRequestWithSharedLinkHeader
+@interface BOXFolderUpdateRequest : BOXRequestWithSharedLinkHeader <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readonly, strong) NSString *folderID;
 @property (nonatomic, readwrite, strong) NSString *folderName;
 @property (nonatomic, readwrite, strong) NSString *folderDescription;
 @property (nonatomic, readwrite, strong) NSString *parentID;
-
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task
- */
-@property (nonatomic, readwrite, copy) NSString *associateId;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -38,6 +33,7 @@
 @property (nonatomic, readwrite, assign) BOOL requestAllFolderFields;
 
 - (instancetype)initWithFolderID:(NSString *)folderID;
+- (instancetype)initWithFolderID:(NSString *)folderID associateID:(NSString *)associateID;
 - (void)performRequestWithCompletion:(BOXFolderBlock)completionBlock;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXFolderUpdateRequest.m
@@ -14,6 +14,7 @@
 
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanDownload;
 @property (nonatomic, readwrite, assign) BOOL shouldUseSharedLinkCanPreview;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -24,6 +25,14 @@
     if (self = [super init]) {
         _folderID = folderID;
     }
+    return self;
+}
+
+
+- (instancetype)initWithFolderID:(NSString *)folderID associateID:(NSString *)associateID
+{
+    self = [self initWithFolderID:folderID];
+    self.associateID = associateID;
     return self;
 }
 
@@ -131,10 +140,10 @@
                                                          bodyDictionary:bodyDictionary
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         folderUpdateOperation = dataOperation;
     } else {
@@ -263,7 +272,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXItemSetCollectionsRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXItemSetCollectionsRequest.h
@@ -9,7 +9,7 @@
  * This request associates a BOXItem to a list of collections. The return value is the updated BOXItem.
  */
 
-@interface BOXItemSetCollectionsRequest : BOXRequest
+@interface BOXItemSetCollectionsRequest : BOXRequest <BOXBackgroundRequestProtocol>
 
 @property (nonatomic, readonly, strong) NSString *itemID;
 @property (nonatomic, readonly, strong) NSArray *collectionIDs;
@@ -25,21 +25,21 @@
 
 - (instancetype)initFileSetCollectionsRequestForFileWithID:(NSString *)fileID
                                              collectionIDs:(NSArray *)collectionIDs
-                                               associateId:(NSString *)associateId;
+                                               associateID:(NSString *)associateID;
 
 - (instancetype)initFolderSetCollectionsRequestForFolderWithID:(NSString *)folderID
                                                  collectionIDs:(NSArray *)collectionIDs;
 
 - (instancetype)initFolderSetCollectionsRequestForFolderWithID:(NSString *)folderID
                                                  collectionIDs:(NSArray *)collectionIDs
-                                                   associateId:(NSString *)associateId;
+                                                   associateID:(NSString *)associateID;
 
 - (instancetype)initBookmarkSetCollectionsRequestForBookmarkWithID:(NSString *)bookmarkID
                                                      collectionIDs:(NSArray *)collectionIDs;
 
 - (instancetype)initBookmarkSetCollectionsRequestForBookmarkWithID:(NSString *)bookmarkID
                                                      collectionIDs:(NSArray *)collectionIDs
-                                                       associateId:(NSString *)associateId;
+                                                       associateID:(NSString *)associateID;
 
 - (void)performRequestWithCompletion:(BOXItemBlock)completionBlock;
 

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXItemSetCollectionsRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXItemSetCollectionsRequest.m
@@ -30,7 +30,7 @@
 /**
  Caller provided unique ID to execute the request as a NSURLSession background task
  */
-@property (nonatomic, readwrite, copy) NSString *associateId;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -43,19 +43,19 @@
     return [self initWithItemID:itemID
                        resource:BOXAPIResourceFiles
                   collectionIDs:collectionIDs
-                    associateId:nil];
+                    associateID:nil];
 }
 
 - (instancetype)initWithItemID:(NSString *)itemID
                       resource:(NSString *)resource
                  collectionIDs:(NSArray *)collectionIDs
-                   associateId:(NSString *)associateId
+                   associateID:(NSString *)associateID
 {
     if (self = [super init]) {
         _itemID = itemID;
         _resource = resource;
         _collectionIDs = collectionIDs;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     return self;
 }
@@ -65,17 +65,17 @@
 {
     return [self initFileSetCollectionsRequestForFileWithID:fileID
                                               collectionIDs:collectionIDs
-                                                associateId:nil];
+                                                associateID:nil];
 }
 
 - (instancetype)initFileSetCollectionsRequestForFileWithID:(NSString *)fileID
                                              collectionIDs:(NSArray *)collectionIDs
-                                               associateId:(NSString *)associateId
+                                               associateID:(NSString *)associateID
 {
     return [self initWithItemID:fileID
                        resource:BOXAPIResourceFiles
                   collectionIDs:collectionIDs
-                    associateId:associateId];
+                    associateID:associateID];
 }
 
 - (instancetype)initFolderSetCollectionsRequestForFolderWithID:(NSString *)folderID
@@ -83,17 +83,17 @@
 {
     return [self initFolderSetCollectionsRequestForFolderWithID:folderID
                                               collectionIDs:collectionIDs
-                                                associateId:nil];
+                                                associateID:nil];
 }
 
 - (instancetype)initFolderSetCollectionsRequestForFolderWithID:(NSString *)folderID
                                                  collectionIDs:(NSArray *)collectionIDs
-                                                   associateId:(NSString *)associateId
+                                                   associateID:(NSString *)associateID
 {
     return [self initWithItemID:folderID
                        resource:BOXAPIResourceFolders
                   collectionIDs:collectionIDs
-                    associateId:associateId];
+                    associateID:associateID];
 }
 
 - (instancetype)initBookmarkSetCollectionsRequestForBookmarkWithID:(NSString *)bookmarkID
@@ -101,17 +101,17 @@
 {
     return [self initBookmarkSetCollectionsRequestForBookmarkWithID:bookmarkID
                                                   collectionIDs:collectionIDs
-                                                    associateId:nil];
+                                                    associateID:nil];
 }
 
 - (instancetype)initBookmarkSetCollectionsRequestForBookmarkWithID:(NSString *)bookmarkID
                                                      collectionIDs:(NSArray *)collectionIDs
-                                                       associateId:(NSString *)associateId
+                                                       associateID:(NSString *)associateID
 {
     return [self initWithItemID:bookmarkID
                        resource:BOXAPIResourceBookmarks
                   collectionIDs:collectionIDs
-                    associateId:associateId];
+                    associateID:associateID];
 }
 
 - (BOXAPIOperation *)createOperation
@@ -149,10 +149,10 @@
                                                          bodyDictionary:bodyDictionary
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
 
         return dataOperation;
@@ -258,7 +258,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXRequest.h
@@ -70,6 +70,17 @@ typedef void (^BOXMetadataTemplatesBlock) (NSArray <BOXMetadataTemplate *>*metad
 
 typedef void (^BOXRepresentationInfoBlock)(BOXRepresentation *representation, NSError *error);
 
+@protocol BOXBackgroundRequestProtocol
+
+/**
+Caller provided unique ID to execute the request as a NSURLSession background task.
+This is a required value for performing the request in the background.
+Please refer to specific requests for additional required properties to perform as background task.
+*/
+- (NSString *)associateID;
+
+@end
+
 @interface BOXRequest : NSObject
 
 @property (nonatomic, readwrite, strong) NSString *baseURL;

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFileRestoreRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFileRestoreRequest.h
@@ -5,14 +5,9 @@
 
 #import "BOXRequest.h"
 
-@interface BOXTrashedFileRestoreRequest : BOXRequest
+@interface BOXTrashedFileRestoreRequest : BOXRequest <BOXBackgroundRequestProtocol>
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, copy) NSString *associateId;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -27,6 +22,8 @@
 @property (nonatomic, readwrite, strong) NSString *parentFolderID;
 
 - (instancetype)initWithFileID:(NSString *)fileID;
+- (instancetype)initWithFileID:(NSString *)fileID
+                   associateID:(NSString *)associateID;
 - (void)performRequestWithCompletion:(BOXFileBlock)completionBlock;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFileRestoreRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFileRestoreRequest.m
@@ -12,6 +12,7 @@
 @interface BOXTrashedFileRestoreRequest ()
 
 @property (nonatomic, readwrite, strong) NSString *fileID;
+@property (nonatomic, readwrite, copy) NSString *associateID;
 
 @end
 
@@ -27,11 +28,11 @@
 }
 
 - (instancetype)initWithFileID:(NSString *)fileID
-                   associateId:(NSString *)associateId
+                   associateID:(NSString *)associateID
 {
     if (self = [super init]) {
         _fileID = fileID;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     return self;
 }
@@ -58,10 +59,10 @@
                                                          bodyDictionary:bodyDictionary
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         return dataOperation;
@@ -164,7 +165,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFolderRestoreRequest.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFolderRestoreRequest.h
@@ -5,14 +5,9 @@
 
 #import "BOXRequest.h"
 
-@interface BOXTrashedFolderRestoreRequest : BOXRequest
+@interface BOXTrashedFolderRestoreRequest : BOXRequest <BOXBackgroundRequestProtocol>
 
 // NOTE: Both the associateID and requestDirectoryPath values are required for performing the request in the background.
-/**
- Caller provided unique ID to execute the request as a NSURLSession background task.
- This is a required value for performing the request in the background.
- */
-@property (nonatomic, readwrite, copy) NSString *associateId;
 
 /**
  Caller provided directory path for the result payload of the background operation to be written to.
@@ -27,6 +22,7 @@
 @property (nonatomic, readwrite, strong) NSString *parentFolderID;
 
 - (instancetype)initWithFolderID:(NSString *)folderID;
+- (instancetype)initWithFolderID:(NSString *)folderID associateID:(NSString *)associateID;
 - (void)performRequestWithCompletion:(BOXFolderBlock)completionBlock;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFolderRestoreRequest.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXTrashedFolderRestoreRequest.m
@@ -9,6 +9,10 @@
 #import "BOXFolder.h"
 #import "BOXDispatchHelper.h"
 
+@interface BOXTrashedFolderRestoreRequest()
+@property (nonatomic, readwrite, copy) NSString *associateID;
+@end
+
 @implementation BOXTrashedFolderRestoreRequest
 
 - (instancetype)initWithFolderID:(NSString *)folderID
@@ -21,11 +25,11 @@
 }
 
 - (instancetype)initWithFolderID:(NSString *)folderID
-                     associateId:(NSString *)associateId
+                     associateID:(NSString *)associateID
 {
     if (self = [super init]) {
         _folderID = folderID;
-        _associateId = associateId;
+        _associateID = associateID;
     }
     
     return self;
@@ -53,10 +57,10 @@
                                                          bodyDictionary:bodyDictionary
                                                            successBlock:nil
                                                            failureBlock:nil
-                                                            associateId:self.associateId];
+                                                            associateId:self.associateID];
         
         NSString *requestDirectory = self.requestDirectoryPath;
-        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateId];
+        NSString *destinationPath = [requestDirectory stringByAppendingPathComponent:self.associateID];
         dataOperation.destinationPath = destinationPath;
         
         return dataOperation;
@@ -159,7 +163,7 @@
 
 - (BOOL)shouldPerformBackgroundOperation
 {
-    return (self.associateId.length > 0 && self.requestDirectoryPath.length > 0);
+    return (self.associateID.length > 0 && self.requestDirectoryPath.length > 0);
 }
 
 @end


### PR DESCRIPTION
…by BOXRequest which supports background mode

Changes affect BOXRequest and its subclasses
- Renaming of `associateId` property to `associateID`
- Making `associateID` a readonly property from the interface
- Adding initializer interfaces which takes `associateID`