### PR TITLE
IOS-17614 - Fix a memory corruption issue in BOXAPIDataOperation

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
@@ -13,11 +13,7 @@
 /**
  * BOXAPIAuthenticatedOperation is an abstract base class for all API operations that
  * require authentication with Box. Because this class is abstract, you should not instantiate
- * it directly. Instead, use one of its subclasses:
- *
- * - BOXAPIJSONOperation
- * - BOXAPIMultipartToJSONOperation
- * - BOXAPIDataOperation
+ * it directly. Instead, use one of its subclasses.
  *
  * This class encapsulates logic for handling expired access tokens. If an access token is found
  * to be expired, instances will request an attempt to refresh access tokens and will attempt
@@ -27,9 +23,7 @@
  * ================
  * ...
  *
- * @warning Only members of the class BOXAPIJSONOperation may be reenqueued. Neither
- * BOXAPIMultipartToJSONOperation nor BOXAPIDataOperation instances may be reenqueued because they
- * contain properties that cannot be copied (subclasses of NSStream).
+ * @warning Concrete subclasses that are reenqueueable (see `canBeReenqueued:` below) also need to  conform to NSCopying.
  */
 @interface BOXAPIAuthenticatedOperation : BOXAPIOperation
 
@@ -76,7 +70,8 @@
 /**
   * Whether or not the operation request can be re-enqueued automatically.
   * In certain cases, the Operations layer can try to re-execute (once) upon failure (e.g. token needed refreshing).
-  * Sub-classes should override to indicate whether they are re-enqueueable or not.
+  * Sub-classes should override to indicate whether they are re-enqueueable or not. If they are re-enqueueable
+  * the class also needs to support creating a copy of the Operation.
   */
 - (BOOL)canBeReenqueued;
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
@@ -8,7 +8,6 @@
 
 #import "BOXAPIAuthenticatedOperation.h"
 
-#import "BOXAPIJSONOperation.h"
 #import "BOXLog.h"
 #import "BOXContentSDKErrors.h"
 #import "BOXAbstractSession.h"
@@ -78,7 +77,7 @@
         {
             self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued userInfo:nil];
 
-            BOXAPIJSONOperation *operationCopy = [self copy];
+            BOXAPIAuthenticatedOperation *operationCopy = [self copy];
             operationCopy.timesReenqueued = operationCopy.timesReenqueued + 1;
             [self.session.queueManager enqueueOperation:operationCopy];
         }

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.h
@@ -39,15 +39,10 @@ typedef void (^BOXAPIDataProgressBlock)(long long expectedTotalBytes, unsigned l
  * **Note**: expectedTotalBytes may be `NSURLResponseUnknownLength` if the operation is unable to
  * determine the Content-Length of the download.
  *
- * @warning Because BOXAPIDataOperation holds references to `NSStream`s, it cannot be copied. Because it
- * cannot be copied, BOXAPIDataOperation instances cannot be automatically retried by the SDK in the event
- * of an expired access token. In this case, the operation will fail with error code
- * `BoxContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued`.
- *
  * BOXAPIDataOperation supports both foreground and background downloads
  * By default, download is foreground unless associateId and destinationPath properties are provided
  */
-@interface BOXAPIDataOperation : BOXAPIAuthenticatedOperation <NSStreamDelegate, BOXURLSessionDownloadTaskDelegate>
+@interface BOXAPIDataOperation : BOXAPIAuthenticatedOperation <NSStreamDelegate, BOXURLSessionDownloadTaskDelegate, NSCopying>
 
 /** @name Streams */
 

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -362,7 +362,6 @@
 {
     BOXAPIDataOperation *operationCopy = [self copy];
     operationCopy.timesReenqueued++;
-    self.outputStream = nil;
     [self.session.queueManager enqueueOperation:operationCopy];
     [self finish];
 }
@@ -385,8 +384,9 @@
                                                                                           body:bodyCopy
                                                                                    queryParams:queryStringParametersCopy
                                                                                  session:self.session];
+    self.outputStream.delegate = nil;
     operationCopy.outputStream = self.outputStream;
-    operationCopy.outputStream.delegate = nil;
+    self.outputStream = nil;
     operationCopy.timesReenqueued = self.timesReenqueued;
     operationCopy.successBlock = [self.successBlock copy];
     operationCopy.failureBlock = [self.failureBlock copy];

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.h
@@ -14,12 +14,10 @@
 typedef void (^BOXAPIStreamProgressBlock)(NSData *data, long long expectedTotalBytes);
 
 /**
- * BOXAPIDataOperation is a concrete subclass of BOXAPIAuthenticatedOperation.
- * This operation receives binary data from the Box API which may be in the form
- * of downloads or thumbnails.
+ * BOXStreamOperation is a concrete subclass of BOXAPIAuthenticatedOperation.
  *
  * API calls to Box may fail with a 202 Accepted with an
- * empty body on Downloads of files and thumbnails.
+ * empty body on Downloads.
  * This indicates that a file has successfully been uploaded but
  * is not yet available for download or has not yet been converted
  * to the requested thumbnail representation. In these cases, retry
@@ -35,13 +33,8 @@ typedef void (^BOXAPIStreamProgressBlock)(NSData *data, long long expectedTotalB
  *
  * **Note**: expectedTotalBytes may be `NSURLResponseUnknownLength` if the operation is unable to
  * determine the Content-Length of the download.
- *
- * @warning Because BOXAPIDataOperation holds references to `NSStream`s, it cannot be copied. Because it
- * cannot be copied, BOXAPIDataOperation instances cannot be automatically retried by the SDK in the event
- * of an expired access token. In this case, the operation will fail with error code
- * `BoxContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued`.
  */
-@interface BOXStreamOperation : BOXAPIAuthenticatedOperation
+@interface BOXStreamOperation : BOXAPIAuthenticatedOperation <NSCopying>
 
 
 /** @name Callbacks */

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.h
@@ -10,7 +10,7 @@
 
 typedef void (^BOXAPIHeaderSuccessBlock)(NSURLRequest *request, NSHTTPURLResponse *response);
 typedef void (^BOXAPIHeaderFailureBlock)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error);
-@interface BOXAPIHeadOperation : BOXAPIAuthenticatedOperation
+@interface BOXAPIHeadOperation : BOXAPIAuthenticatedOperation <NSCopying>
 
 @property (nonatomic, readwrite, strong) BOXAPIHeaderSuccessBlock successBlock;
 @property (nonatomic, readwrite, strong) BOXAPIHeaderFailureBlock failureBlock;


### PR DESCRIPTION
It's likely that this fix, which appears to fix the a big source of
flakiness in running our test suite, will also fix the top crashing
bug in our product (see IOS-17522).

BOXAPIDataOperation instances *were* being "copied", which resulted
in 2 instances retaining a reference to the same underlying NSOutputStream.
This lead to a variety of crashes when one Op closed the Stream
while the other Op was attempting to use it.

This fix is somewhat distasteful as copying an BOXAPIDataOperation instance
now modifies the instance being copying (nil'ing out the output stream
reference).

There is much wrong with BOXAuthenticatedOperation and it's subclasses.
Including fuzzy contracts, lots of duplicated code, contradictory comments & code. 
None of that is addressed here to keep the fix small/focused on an attempt to 
fix the #1 crashed in our product.