### PR TITLE
IOS-17000 - Refactor to avoid 3 copies of the same 202 handling

### DIFF
--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.h
@@ -68,11 +68,17 @@
 - (void)prepareAPIRequest;
 
 /**
-  * Whether or not the operation request can be re-enqueued automatically.
-  * In certain cases, the Operations layer can try to re-execute (once) upon failure (e.g. token needed refreshing).
-  * Sub-classes should override to indicate whether they are re-enqueueable or not. If they are re-enqueueable
-  * the class also needs to support creating a copy of the Operation.
+  * Whether or not the operation request can be re-enqueued automatically because the access toekn expired.
+  * Sub-classes should override to indicate whether they are re-enqueueable or not in this case. If they are
+  * re-enqueueable the class also needs to support creating a copy of the Operation.
   */
-- (BOOL)canBeReenqueued;
+- (BOOL)canBeReenqueuedDueToTokenExpired;
+
+/**
+ * Whether or not the operation request can be re-enqueued automatically because of a 202 Accepted/Not-Ready response.
+ * Sub-classes should override to indicate whether they are re-enqueueable or not in this case. If they are
+ * re-enqueueable the class also needs to support creating a copy of the Operation.
+ */
+- (BOOL)canBeReenqueuedDueTo202NotReady;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIAuthenticatedOperation.m
@@ -12,6 +12,9 @@
 #import "BOXContentSDKErrors.h"
 #import "BOXAbstractSession.h"
 
+#define MAX_REENQUE_DELAY 15
+#define REENQUE_BASE_DELAY 0.2
+
 #define WWW_AUTHENTICATE_HEADER           (@"WWW-Authenticate")
 
 #define OAUTH2_INVALID_REQUEST_ERROR      (@"error=\"invalid_request\"")
@@ -57,7 +60,12 @@
     [self.session performRefreshTokenGrant:self.accessToken withCompletionBlock:nil];
 }
 
-- (BOOL)canBeReenqueued
+- (BOOL)canBeReenqueuedDueToTokenExpired
+{
+    return NO;
+}
+
+- (BOOL)canBeReenqueuedDueTo202NotReady
 {
     return NO;
 }
@@ -65,27 +73,61 @@
 - (void)processResponse:(NSURLResponse *)response
 {
     [super processResponse:response];
+    
+    [self handlePossible202NotReady];
+    [self handlePossibleTokenExpired];
+}
 
-    BOOL isOAuth2TokenExpired = [self isAccessTokenExpired];
-
-    if (isOAuth2TokenExpired)
+- (void)handlePossibleTokenExpired
+{
+    if ([self isAccessTokenExpired])
     {
+        BOXContentSDKAuthError errorCode;
+        
         [self handleExpiredAccessToken];
-
-        // re-enqueue operation in the same queue referred to by the OAuth2 session if possible.
-        if ([self canBeReenqueued] && self.timesReenqueued == 0)
+        
+        if ([self canBeReenqueuedDueToTokenExpired] && self.timesReenqueued == 0)
         {
-            self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued userInfo:nil];
-
-            BOXAPIAuthenticatedOperation *operationCopy = [self copy];
-            operationCopy.timesReenqueued = operationCopy.timesReenqueued + 1;
-            [self.session.queueManager enqueueOperation:operationCopy];
+            errorCode = BOXContentSDKAuthErrorAccessTokenExpiredOperationWillBeClonedAndReenqueued;
+            [self reenqueCopyOfOperation];
         }
         else
         {
-            self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued userInfo:nil];
+            errorCode = BOXContentSDKAuthErrorAccessTokenExpiredOperationCannotBeReenqueued;
         }
+        self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:errorCode userInfo:nil];
     }
+}
+
+- (void)handlePossible202NotReady
+{
+    if (self.error.code == BOXContentSDKAPIErrorAccepted && [self canBeReenqueuedDueTo202NotReady]) {
+        // If we get a 202, it means the content is not yet ready on Box's servers.
+        // Re-enqueue after a certain amount of time.
+        double delay = [self reenqueDelay];
+        dispatch_queue_t currentQueue = [[NSOperationQueue currentQueue] underlyingQueue];
+        if (currentQueue == nil) {
+            currentQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+        }
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), currentQueue, ^{
+            [self reenqueCopyOfOperation];
+            [self finish];
+        });
+    }
+}
+
+- (double)reenqueDelay
+{
+    // Delay grows each time the request is re-enqueued.
+    double delay = MIN(pow((1 + REENQUE_BASE_DELAY), self.timesReenqueued) - 1, MAX_REENQUE_DELAY);
+    return delay;
+}
+
+- (void)reenqueCopyOfOperation
+{
+    BOXAPIAuthenticatedOperation *operationCopy = [self copy];
+    operationCopy.timesReenqueued++;
+    [self.session.queueManager enqueueOperation:operationCopy];
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -12,9 +12,6 @@
 #import "BOXLog.h"
 #import "BOXAbstractSession.h"
 
-#define MAX_REENQUE_DELAY 15
-#define REENQUE_BASE_DELAY 0.2
-
 @interface BOXAPIDataOperation ()
 
 // Buffer data received from the connection in an NSData. Write to the
@@ -264,18 +261,8 @@
     [super sessionTask:sessionTask processIntermediateResponse:response];
 
     self.HTTPResponse = (NSHTTPURLResponse *)response;
-    if (self.HTTPResponse.statusCode == BOXContentSDKAPIErrorAccepted) {
-        // If we get a 202, it means the content is not yet ready on Box's servers.
-        // Re-enqueue after a certain amount of time.
-        double delay = [self reenqueDelay];
-        dispatch_queue_t currentQueue = [[NSOperationQueue currentQueue] underlyingQueue];
-        if (currentQueue == nil) {
-            currentQueue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
-        }
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), currentQueue, ^{
-            [self reenqueOperationDueTo202Response];
-        });
-    } else {
+
+    if (self.HTTPResponse.statusCode != BOXContentSDKAPIErrorAccepted) {
         [self.outputStream open];
     }
 }
@@ -358,21 +345,6 @@
 
 #pragma mark - Reenque helpers
 
-- (void)reenqueOperationDueTo202Response
-{
-    BOXAPIDataOperation *operationCopy = [self copy];
-    operationCopy.timesReenqueued++;
-    [self.session.queueManager enqueueOperation:operationCopy];
-    [self finish];
-}
-
-- (double)reenqueDelay
-{
-    // Delay grows each time the request is re-enqueued.
-    double delay = MIN(pow((1 + REENQUE_BASE_DELAY), self.timesReenqueued) - 1, MAX_REENQUE_DELAY);
-    return delay;
-}
-
 - (id)copyWithZone:(NSZone *)zone
 {
     NSURL *URLCopy = [self.baseRequestURL copy];
@@ -395,9 +367,14 @@
     return operationCopy;
 }
 
-- (BOOL)canBeReenqueued
+- (BOOL)canBeReenqueuedDueToTokenExpired
 {
     return self.shouldStartImmediately == NO;
+}
+
+- (BOOL)canBeReenqueuedDueTo202NotReady
+{
+    return YES;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIDataOperation.m
@@ -374,7 +374,7 @@
 
 - (BOOL)canBeReenqueuedDueTo202NotReady
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIJSONOperation.m
@@ -159,7 +159,7 @@
     self.failure = nil;
 }
 
-- (BOOL)canBeReenqueued
+- (BOOL)canBeReenqueuedDueToTokenExpired
 {
     return self.shouldStartImmediately == NO;
 }

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIMultipartToJSONOperation.m
@@ -211,7 +211,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
     [self.sessionTask cancel];
 }
 
-- (BOOL)canBeReenqueued
+- (BOOL)canBeReenqueuedDueToTokenExpired
 {
     return NO;
 }

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXAPIOperation.m
@@ -565,46 +565,20 @@ static BOOL BoxOperationStateTransitionIsValid(BOXAPIOperationState fromState, B
         switch (self.HTTPResponse.statusCode)
         {
             case BOXContentSDKAPIErrorAccepted:
-                errorCode = BOXContentSDKAPIErrorAccepted;
-                break;
             case BOXContentSDKAPIErrorBadRequest:
-                errorCode = BOXContentSDKAPIErrorBadRequest;
-                break;
             case BOXContentSDKAPIErrorUnauthorized:
-                errorCode = BOXContentSDKAPIErrorUnauthorized;
-                break;
             case BOXContentSDKAPIErrorForbidden:
-                errorCode = BOXContentSDKAPIErrorForbidden;
-                break;
             case BOXContentSDKAPIErrorNotFound:
-                errorCode = BOXContentSDKAPIErrorNotFound;
-                break;
             case BOXContentSDKAPIErrorMethodNotAllowed:
-                errorCode = BOXContentSDKAPIErrorMethodNotAllowed;
-                break;
             case BOXContentSDKAPIErrorConflict:
-                errorCode = BOXContentSDKAPIErrorConflict;
-                break;
             case BOXContentSDKAPIErrorPreconditionFailed:
-                errorCode = BOXContentSDKAPIErrorPreconditionFailed;
-                break;
             case BOXContentSDKAPIErrorRequestEntityTooLarge:
-                errorCode = BOXContentSDKAPIErrorRequestEntityTooLarge;
-                break;
             case BOXContentSDKAPIErrorPreconditionRequired:
-                errorCode = BOXContentSDKAPIErrorPreconditionRequired;
-                break;
             case BOXContentSDKAPIErrorTooManyRequests:
-                errorCode = BOXContentSDKAPIErrorTooManyRequests;
-                break;
             case BOXContentSDKAPIErrorInternalServerError:
-                errorCode = BOXContentSDKAPIErrorInternalServerError;
-                break;
             case BOXContentSDKAPIErrorInsufficientStorage:
-                errorCode = BOXContentSDKAPIErrorInsufficientStorage;
+                errorCode = self.HTTPResponse.statusCode;
                 break;
-            default:
-                errorCode = BOXContentSDKAPIErrorUnknownStatusCode;
         }
 
         self.error = [[NSError alloc] initWithDomain:BOXContentSDKErrorDomain code:errorCode userInfo:nil];

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
@@ -206,7 +206,7 @@
 
 - (BOOL)canBeReenqueuedDueTo202NotReady
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Operations/BOXStreamOperation.m
@@ -12,9 +12,6 @@
 #import "BOXAPIOperation_Private.h"
 #import "BOXAbstractSession.h"
 
-#define MAX_REENQUE_DELAY 15
-#define REENQUE_BASE_DELAY 0.2
-
 @interface BOXStreamOperation () <BOXURLSessionDownloadTaskDelegate>
 
 // Buffer data received. Write to the output stream from this data object when space becomes available.
@@ -154,31 +151,11 @@
     NSString *contentRange = [response.allHeaderFields objectForKey:@"Content-Range"];
     NSString *contentLength = [[contentRange componentsSeparatedByString:@"/"] objectAtIndex:1];
     return [contentLength longLongValue];
-//    return [self.HTTPResponse expectedContentLength];
 }
 
 #pragma mark - BOXURLSessionTaskDelegate
 //NOTE: Currently not implementing BOXURLSessionDownloadTaskDelegate methods on purpose.
 // For the stream, only the direct data and response handling is required.
-
-- (void)sessionTask:(NSURLSessionTask *)sessionTask processIntermediateResponse:(NSURLResponse *)response
-{
-    [super sessionTask:sessionTask processIntermediateResponse:response];
-    
-    if (self.error != nil &&
-        self.error.code == BOXContentSDKAPIErrorAccepted) {
-        // If we get a 202, it means the content is not yet ready on Box's servers.
-        // Re-enqueue after a certain amount of time.
-        double delay = [self reenqueDelay];
-        dispatch_queue_t currentQueue = [[NSOperationQueue currentQueue] underlyingQueue];
-        if (currentQueue == nil) {
-            currentQueue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
-        }
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), currentQueue, ^{
-            [self reenqueOperationDueTo202Response];
-        });
-    }
-}
 
 // Override this delegate method from the default BOXAPIOperation implementation
 // (may not even be implemented in the first place as it is optional).
@@ -203,23 +180,6 @@
     }
 }
 
-#pragma mark - Reenque helpers
-
-- (void)reenqueOperationDueTo202Response
-{
-    BOXStreamOperation *operationCopy = [self copy];
-    operationCopy.timesReenqueued++;
-    [self.session.queueManager enqueueOperation:operationCopy];
-    [self finish];
-}
-
-- (double)reenqueDelay
-{
-    // Delay grows each time the request is re-enqueued.
-    double delay = MIN(pow((1 + REENQUE_BASE_DELAY), self.timesReenqueued) - 1, MAX_REENQUE_DELAY);
-    return delay;
-}
-
 - (id)copyWithZone:(NSZone *)zone
 {
     NSURL *URLCopy = [self.baseRequestURL copy];
@@ -239,9 +199,14 @@
     return operationCopy;
 }
 
-- (BOOL)canBeReenqueued
+- (BOOL)canBeReenqueuedDueToTokenExpired
 {
     return self.shouldStartImmediately == NO;
+}
+
+- (BOOL)canBeReenqueuedDueTo202NotReady
+{
+    return YES;
 }
 
 @end

--- a/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.m
+++ b/BoxContentSDK/BoxContentSDK/Requests/BOXAPIHeadOperation.m
@@ -100,7 +100,7 @@
 
 - (BOOL)canBeReenqueuedDueTo202NotReady
 {
-    return YES;
+    return self.shouldStartImmediately == NO;
 }
 
 @end


### PR DESCRIPTION
3 sibling Operation classes each had it's own chunk of code to deal
with 202 responses. This code was basically identical.

A bit of refactoring in these classes along with
the base classes BOXAPIDataOperation and BOXAPIAuthenticatedOperation
now has this rety logic centralized, right next to the similar logic
for the token expired error.