### PR TITLE
IOS-17740 - make access/refresh token updates and refreshes atomic

### DIFF
--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXAbstractSession.h
@@ -65,7 +65,8 @@ extern NSString *const BOXUserIDKey;
 
 /**
  * This token identifies a user on Box. This token is included in every request in the
- * Authorization header as a Bearer token. Access tokens expire 60 minutes from when they are issued.
+ * Authorization header as a Bearer token. Access tokens automatically expire after some
+ * duration of time controlled by the service, typically in the range of some few hours.
  *
  * accessToken is never stored by the SDK. If you choose to persist the access token, do so in
  * secure storage such as the Keychain.
@@ -76,7 +77,7 @@ extern NSString *const BOXUserIDKey;
  *
  * @see addAuthorizationParametersToRequest:
  */
-@property (nonatomic, readwrite, strong) NSString *accessToken;
+@property (atomic, readwrite, strong) NSString *accessToken;
 
 /**
  * When an access token is expected to expire. There is no guarantee the access token will be valid

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.h
@@ -82,7 +82,7 @@
 
 /**
  * This token may be exchanged for a new access token and refresh token. Refresh tokens expire
- * 14 days from when they are issued.
+ * some number days after they are issued, the timing of which is controlled by the service.
  *
  * refreshToken is never stored by the SDK. If you choose to persis the access token, do so in
  * secure storage such as the Keychain.
@@ -92,7 +92,7 @@
  *
  * @see performRefreshTokenGrant:
  */
-@property (nonatomic, readwrite, strong) NSString *refreshToken;
+@property (atomic, readwrite, strong) NSString *refreshToken;
 
 #pragma mark - Initialization
 /** @name Initialization */

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXOAuth2Session.m
@@ -235,6 +235,8 @@
                                                                                       BOXAuthTokenRequestClientIDKey : self.clientID,
                                                                                       BOXAuthTokenRequestClientSecretKey : self.clientSecret,
                                                                                       }];
+
+    // The following 2 POSTParams are undocumented features of the /token endpoint.
     if (accessTokenExpirationTimestamp) {
         [POSTParams setObject:accessTokenExpirationTimestamp forKey:BOXAuthTokenRequestAccessTokenExpiresAtKey];
     }

--- a/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
+++ b/BoxContentSDK/BoxContentSDK/OAuth2/BOXParallelOAuth2Session.m
@@ -105,4 +105,37 @@
     return isInvalidGrantError;
 }
 
+#pragma mark - Access/Refresh token consistency
+
+// Overrides below are to make atomic updating and storing access/refresh token pair.
+//
+// This is a fragile pattern, but doing better would require refactoring. Currently the BOXAbstractSession
+// owns the accessToken and BOXOAuth2Session owns the refreshToken. It's unclear why the OAuth class doesn't
+// also own the accessToekn, since the accessToken concept implies some for of authentication, while no
+// authentication is implied by the base BOXAbstractSession.
+
+- (void)storeCredentialsToKeychain
+{
+    @synchronized(self)
+    {
+        [super storeCredentialsToKeychain];
+    }
+}
+
+- (void)reassignTokensFromSession:(BOXOAuth2Session *)session
+{
+    @synchronized(self)
+    {
+        [super reassignTokensFromSession:session];
+    }
+}
+
+- (void)restoreCredentialsFromKeychainForUserWithID:(NSString *)userID
+{
+    @synchronized(self)
+    {
+        [super restoreCredentialsFromKeychainForUserWithID:userID];
+    }
+}
+
 @end


### PR DESCRIPTION
This is to avoid a refresh action updating those values while some
other operation is just reading the values. This is a somewhat
weak/fragile fix, and other access flows could be created in the
future. That's something to be wary of.