### PR TITLE
IOS-17850: (part2)

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
@@ -361,10 +361,21 @@
 - (BOOL)cacheBackgroundSessionIdFromExtension:(NSString *)backgroundSessionId error:(NSError **)outError;
 
 /**
- * Return currrently active background session IDs
-*/
-- (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
+ * Check if backgroundSessionID is associated with userID
+ *
+ * @param backgroundSessionID   Id to check
+ * @param userID    Id of user
+ *
+ * @return YES if associated, NO otherwise
+ */
+- (BOOL)isBackgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+         associatedWithUserID:(NSString * _Nonnull)userID;
 
+/**
+ * Return existing background session IDs
+ */
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 /**
  * Return all background session IDs created by the extensions
  * and reconnected to the app

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
@@ -142,7 +142,6 @@ backgroundSessionId:(NSString *)backgroundSessionId
                                                         associateID:associateId
                                                               error:error];
     }
-
     return success;
 }
 
@@ -732,7 +731,7 @@ backgroundSessionId:(NSString *)backgroundSessionId
     NSArray *associateIds = nil;
 
     BOOL isDir = NO;
-    
+
     if ([[NSFileManager defaultManager] fileExistsAtPath:dirPath isDirectory:&isDir] == YES && isDir == YES) {
         associateIds = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dirPath error:error];
     }
@@ -891,26 +890,19 @@ backgroundSessionId:(NSString *)backgroundSessionId
 }
 
 - (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
-                                                                 userId:(NSString * _Nonnull)userId
-                                                                  error:(NSError * _Nullable * _Nullable)error
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error
 {
     NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userId
                                                  backgroundSessionID:backgroundSessionId];
 
     BOOL isDir = NO;
-    NSMutableArray *associateIDs = nil;
+    NSArray *associateIDs = [NSArray new];
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] == YES && isDir == YES) {
-        NSArray *filePaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
-        if (filePaths.count > 0) {
-            associateIDs = [NSMutableArray new];
-            for (NSString *associateID in filePaths) {
-                [associateIDs addObject:associateID];
-            }
-        }
+        associateIDs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
     }
-
-    return [associateIDs copy];
+    return associateIDs;
 }
 
 // Create dir if not exists, users/$userId/$associateId/$backgroundSessionId-$sessionTaskId
@@ -936,7 +928,6 @@ backgroundSessionId:(NSString *)backgroundSessionId
     NSString *path = [self filePathOfBackgroundSessionIndexGivenUserID:userID
                                                    backgroundSessionID:backgroundSessionID
                                                            associateID:associateID];
-
     return [self createFile:path error:error];
 }
 
@@ -1133,20 +1124,40 @@ backgroundSessionId:(NSString *)backgroundSessionId
     return [dirPath stringByAppendingPathComponent:associateID];
 }
 
+
+- (NSString *)dirPathOfBackgroundSessionIndexGivenUserID:(NSString * _Nonnull)userID
+{
+    return [[self dirPathOfBackgroundSessionsIndex] stringByAppendingPathComponent:userID];
+}
+
 - (NSString *)dirPathOfBackgroundSessionIndexGivenUserID:(NSString * _Nonnull)userID
                                      backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
 {
-    NSString *dirPath = [[self dirPathOfBackgroundSessionsIndex] stringByAppendingPathComponent:userID];
+    NSString *dirPath = [self dirPathOfBackgroundSessionIndexGivenUserID:userID];
     return [dirPath stringByAppendingPathComponent:backgroundSessionID];
 }
 
-- (BOOL)isBackgroundSessionValidGivenUserID:(NSString * _Nonnull)userID
-                        backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+- (BOOL)isBackgroundSessionID:(NSString *)backgroundSessionID
+         associatedWithUserID:(NSString *)userID
 {
     BOOL isDir = NO;
     NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userID
                                                  backgroundSessionID:backgroundSessionID];
     return [[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] && isDir == YES;
+}
+
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error
+{
+    BOOL isDir = NO;
+    NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userID];
+    NSArray *backgroundSessionIDs = [NSArray new];
+
+    if ([[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] == YES && isDir == YES) {
+        backgroundSessionIDs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
+    }
+
+    return backgroundSessionIDs;
 }
 
 - (NSString *)filePathOfUserSessionTaskStartedForUserId:(NSString *)userId

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
@@ -299,10 +299,10 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 - (NSString *)backgroundSessionIdentifier;
 
 /**
- * Return currrently active background session IDs
-*/
-- (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
-
+ * Return existing background session IDs
+ */
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 /**
  * Return all background session IDs created by the extensions
  * and reconnected to the app

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -290,9 +290,10 @@ extern NSString *const BOXContentClientBackgroundTempFolder;
 + (nullable NSString *)backgroundSessionIdentifier;
 
 /**
- * Return currrently active background session IDs
-*/
-+ (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
+ * Return existing background session IDs
+ */
++ (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Return all background session IDs created by the extensions

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -495,9 +495,11 @@ static BOXContentClient *defaultInstance = nil;
     return [[BOXURLSessionManager sharedInstance] backgroundSessionIdentifier];
 }
 
-+ (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error
++ (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error
 {
-    return [[BOXURLSessionManager sharedInstance] onGoingBackgroundSessionIDsWithError:error];
+    return [[BOXURLSessionManager sharedInstance] backgroundSessionIDsOfUserID:userID
+                                                                         error:error];
 }
 
 + (NSArray <NSString *> *)backgroundSessionIDsReconnectedToAppWithError:(NSError **)error


### PR DESCRIPTION
- Return empty associateIDs/backgroundSessionIDs if their directories are not found, which could be expected after clean up
- Validate backgroundSessionID association with userID only if session has not yet cleaned up