### PR TITLE
IOS 17850: cache the map of background session ID and its associateIDs under backgroundSessionsIndex

### DIFF
--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.h
@@ -487,6 +487,7 @@ extern NSString *const BOXAPIEnterpriseEventTypeItemUnsync;
 extern NSString *const BOXURLSessionTaskCacheDirectoryName;
 extern NSString *const BOXURLSessionTaskCacheOnGoingSessionTasksDirectoryName;
 extern NSString *const BOXURLSessionTaskCacheUsersDirectoryName;
+extern NSString *const BOXURLSessionTaskCacheBackgroundSessionsIndexDirectoryName;
 extern NSString *const BOXURLSessionTaskCacheExtensionSessionsDirectoryName;
 extern NSString *const BOXURLSessionTaskCacheDestinationFilePath;
 extern NSString *const BOXURLSessionTaskCacheResumeData;

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKConstants.m
@@ -464,6 +464,7 @@ NSString *const BOXAPIEnterpriseEventTypeItemUnsync = @"ITEM_UNSYNC";
 NSString *const BOXURLSessionTaskCacheDirectoryName = @"BOXURLSessionCache";
 NSString *const BOXURLSessionTaskCacheOnGoingSessionTasksDirectoryName = @"onGoingSessionTasks";
 NSString *const BOXURLSessionTaskCacheUsersDirectoryName = @"users";
+NSString *const BOXURLSessionTaskCacheBackgroundSessionsIndexDirectoryName = @"backgroundSessionsIndex";
 NSString *const BOXURLSessionTaskCacheExtensionSessionsDirectoryName = @"extensionSessions";
 NSString *const BOXURLSessionTaskCacheDestinationFilePath = @"destinationFilePath";
 NSString *const BOXURLSessionTaskCacheResumeData = @"resumeData";

--- a/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
+++ b/BoxContentSDK/BoxContentSDK/BOXContentSDKErrors.h
@@ -90,7 +90,10 @@ typedef NS_ENUM(NSUInteger, BOXContentSDKURLSessionError) {
     BOXContentSDKURLSessionFailToReconnectBecauseBackgroundSessionIsNotSupported = 50009,
     BOXContentSDKURLSessionFailToCreateSessionTask = 50010,
     BOXContentSDKURLSessionInvalidSessionTask = 50011,
-    BOXContentSDKURLSessionInvalidBackgroundSession = 50012
+    BOXContentSDKURLSessionInvalidBackgroundSession = 50012,
+    BOXContentSDKURLSessionCannotCleanUpCurrentBackgroundSession = 50013,
+    BOXContentSDKURLSessionCannotCleanUpBackgroundSessionWithActiveTasks = 50014,
+    BOXContentSDKURLSessionCannotCleanUpBackgroundSessionWithTasks = 50015
 };
 
 typedef NS_ENUM(NSUInteger, BOXContentSDKDataContentError) {

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
@@ -327,8 +327,8 @@
  *
  * @return YES if successfully cleaned up, NO if failed
  */
-- (BOOL)cleanUpExtensionBackgrounSessionIdIfExists:(NSString * _Nonnull)backgroundSessionId
-                                             error:(NSError * _Nullable * _Nullable)error;
+- (BOOL)cleanUpExtensionBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                      error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Clean up users/$userId directory if empty. Expected to be used at logout

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
@@ -320,6 +320,17 @@
                                            error:(NSError * _Nullable * _Nullable)error;
 
 /**
+ * Clean up background session ID from IDs reconnected from extension
+ *
+ * @param backgroundSessionId   Id to clean
+ * @param error error if fail to complete
+ *
+ * @return YES if successfully cleaned up, NO if failed
+ */
+- (BOOL)cleanUpExtensionBackgrounSessionIdIfExists:(NSString * _Nonnull)backgroundSessionId
+                                             error:(NSError * _Nullable * _Nullable)error;
+
+/**
  * Clean up users/$userId directory if empty. Expected to be used at logout
  * after cleaning up on user's session tasks
  *

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
@@ -361,10 +361,21 @@
 - (BOOL)cacheBackgroundSessionIdFromExtension:(NSString *)backgroundSessionId error:(NSError **)outError;
 
 /**
- * Return currrently active background session IDs
-*/
-- (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
+ * Check if backgroundSessionID is associated with userID
+ *
+ * @param backgroundSessionID   Id to check
+ * @param userID    Id of user
+ *
+ * @return YES if associated, NO otherwise
+ */
+- (BOOL)isBackgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+         associatedWithUserID:(NSString * _Nonnull)userID;
 
+/**
+ * Return existing background session IDs
+ */
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 /**
  * Return all background session IDs created by the extensions
  * and reconnected to the app

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.h
@@ -67,6 +67,9 @@
  * 2. To keep track of whose user and its associateId the session task belongs to, we save backgroundSessionId and sessionTaskId
  * as a file name under sub-directory users/$userId/$associateId/info with format $backgroundSessionId-$sessionTaskId
  *
+ * We also record a map of background session ID to its associateIDs at backgroundSessionsIndex/$userID/$backgroundSessionID/$associateID
+ * which provides a quick look up of associateIDs given a background session ID.
+ *
  * 3. Once session tasks complete, their cached info under onGoingSessionTasks/$backgroundSessionId/$sessionTaskId dir
  * will be moved into users/$userId/$associateId/completed dir
  *
@@ -281,6 +284,17 @@
 - (BOOL)isSessionTaskCompletedForUserId:(NSString *)userId associateId:(NSString *)associateId;
 
 /**
+ * Check if a background session is valid, i.e. exists for a userId
+ *
+ * @param userID            Id of user
+ * @param backgroundSessionID       Id of background session
+ *
+ * @return YES if valid, NO if not
+ */
+- (BOOL)isBackgroundSessionValidGivenUserID:(NSString * _Nonnull)userID
+                        backgroundSessionID:(NSString * _Nonnull)backgroundSessionID;
+
+/**
  * Clean up on-going session tasks' cached info of backgroundSessionId.
  * This does not clean up info relating to user and completed cached info, which
  * can be done using deleteCachedInfoForUserId:associateId:error
@@ -291,6 +305,19 @@
  * @return YES if succeeded, NO if failed
  */
 - (BOOL)cleanUpOnGoingCachedInfoOfBackgroundSessionId:(NSString *)backgroundSessionId error:(NSError **)error;
+
+/**
+ * Clean up background session index of a given background session
+ *
+ * @param userID    Id of user
+ * @param backgroundSessionID   Id of the background session
+ * @param error                 error if fail to complete
+ *
+ * @return YES if succeeded, NO if failed
+*/
+- (BOOL)cleanUpBackgroundSessionIndexGivenUserID:(NSString * _Nonnull)userID
+                             backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+                                           error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Clean up users/$userId directory if empty. Expected to be used at logout
@@ -374,6 +401,8 @@
  *
  * @return NSArray of associateIds, nil if error
  */
-- (NSArray <NSString *> *)associateIdsOfBackgroundSessionId:(NSString *)backgroundSessionId userId:(NSString *)userId error:(NSError **)error;
+- (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error;
 
 @end

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
@@ -744,13 +744,7 @@ backgroundSessionId:(NSString *)backgroundSessionId
 - (BOOL)cleanUpOnGoingCachedInfoOfBackgroundSessionId:(NSString *)backgroundSessionId error:(NSError **)error
 {
     NSString *dirPath = [self dirPathOfSessionTaskWithBackgroundSessionId:backgroundSessionId];
-    BOOL success = [self deleteDirectory:dirPath error:error];
-    
-    if (success == YES) {
-        success = [self cleanUpExtensionBackgrounSessionIdIfExists:backgroundSessionId error:error];
-    }
-    
-    return success;
+    return [self deleteDirectory:dirPath error:error];
 }
 
 - (BOOL)cacheBackgroundSessionId:(NSString *)backgroundSessionId
@@ -850,7 +844,8 @@ backgroundSessionId:(NSString *)backgroundSessionId
 }
 
 // Delete file extensionSessions/$backgroundSessionId if backgroundSessionId is from extension
-- (BOOL)cleanUpExtensionBackgrounSessionIdIfExists:(NSString *)backgroundSessionId error:(NSError **)outError
+- (BOOL)cleanUpExtensionBackgrounSessionIdIfExists:(NSString * _Nonnull)backgroundSessionId
+                                             error:(NSError * _Nullable * _Nullable)outError
 {
     NSString *filePath = [self filePathOfExtensionBackgroundSessionId:backgroundSessionId];
     BOOL success = YES;

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
@@ -844,8 +844,8 @@ backgroundSessionId:(NSString *)backgroundSessionId
 }
 
 // Delete file extensionSessions/$backgroundSessionId if backgroundSessionId is from extension
-- (BOOL)cleanUpExtensionBackgrounSessionIdIfExists:(NSString * _Nonnull)backgroundSessionId
-                                             error:(NSError * _Nullable * _Nullable)outError
+- (BOOL)cleanUpExtensionBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                      error:(NSError * _Nullable * _Nullable)outError
 {
     NSString *filePath = [self filePathOfExtensionBackgroundSessionId:backgroundSessionId];
     BOOL success = YES;

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionCacheClient.m
@@ -142,7 +142,6 @@ backgroundSessionId:(NSString *)backgroundSessionId
                                                         associateID:associateId
                                                               error:error];
     }
-
     return success;
 }
 
@@ -732,7 +731,7 @@ backgroundSessionId:(NSString *)backgroundSessionId
     NSArray *associateIds = nil;
 
     BOOL isDir = NO;
-    
+
     if ([[NSFileManager defaultManager] fileExistsAtPath:dirPath isDirectory:&isDir] == YES && isDir == YES) {
         associateIds = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dirPath error:error];
     }
@@ -891,26 +890,19 @@ backgroundSessionId:(NSString *)backgroundSessionId
 }
 
 - (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
-                                                                 userId:(NSString * _Nonnull)userId
-                                                                  error:(NSError * _Nullable * _Nullable)error
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error
 {
     NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userId
                                                  backgroundSessionID:backgroundSessionId];
 
     BOOL isDir = NO;
-    NSMutableArray *associateIDs = nil;
+    NSArray *associateIDs = [NSArray new];
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] == YES && isDir == YES) {
-        NSArray *filePaths = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
-        if (filePaths.count > 0) {
-            associateIDs = [NSMutableArray new];
-            for (NSString *associateID in filePaths) {
-                [associateIDs addObject:associateID];
-            }
-        }
+        associateIDs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
     }
-
-    return [associateIDs copy];
+    return associateIDs;
 }
 
 // Create dir if not exists, users/$userId/$associateId/$backgroundSessionId-$sessionTaskId
@@ -936,7 +928,6 @@ backgroundSessionId:(NSString *)backgroundSessionId
     NSString *path = [self filePathOfBackgroundSessionIndexGivenUserID:userID
                                                    backgroundSessionID:backgroundSessionID
                                                            associateID:associateID];
-
     return [self createFile:path error:error];
 }
 
@@ -1133,20 +1124,40 @@ backgroundSessionId:(NSString *)backgroundSessionId
     return [dirPath stringByAppendingPathComponent:associateID];
 }
 
+
+- (NSString *)dirPathOfBackgroundSessionIndexGivenUserID:(NSString * _Nonnull)userID
+{
+    return [[self dirPathOfBackgroundSessionsIndex] stringByAppendingPathComponent:userID];
+}
+
 - (NSString *)dirPathOfBackgroundSessionIndexGivenUserID:(NSString * _Nonnull)userID
                                      backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
 {
-    NSString *dirPath = [[self dirPathOfBackgroundSessionsIndex] stringByAppendingPathComponent:userID];
+    NSString *dirPath = [self dirPathOfBackgroundSessionIndexGivenUserID:userID];
     return [dirPath stringByAppendingPathComponent:backgroundSessionID];
 }
 
-- (BOOL)isBackgroundSessionValidGivenUserID:(NSString * _Nonnull)userID
-                        backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+- (BOOL)isBackgroundSessionID:(NSString *)backgroundSessionID
+         associatedWithUserID:(NSString *)userID
 {
     BOOL isDir = NO;
     NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userID
                                                  backgroundSessionID:backgroundSessionID];
     return [[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] && isDir == YES;
+}
+
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error
+{
+    BOOL isDir = NO;
+    NSString *dir = [self dirPathOfBackgroundSessionIndexGivenUserID:userID];
+    NSArray *backgroundSessionIDs = [NSArray new];
+
+    if ([[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] == YES && isDir == YES) {
+        backgroundSessionIDs = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:error];
+    }
+
+    return backgroundSessionIDs;
 }
 
 - (NSString *)filePathOfUserSessionTaskStartedForUserId:(NSString *)userId

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
@@ -299,10 +299,10 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 - (NSString *)backgroundSessionIdentifier;
 
 /**
- * Return currrently active background session IDs
-*/
-- (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
-
+ * Return existing background session IDs
+ */
+- (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 /**
  * Return all background session IDs created by the extensions
  * and reconnected to the app

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.h
@@ -255,13 +255,15 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
  * i.e. if the background session to be cleaned up is not the current
  * background session and has no pending tasks
  *
+ * @param userID    userID that this session belongs to
  * @param backgroundSessionID   background session ID to clean up
  * @param error error cleaning up this background session
  *
  * @return YES if successfully clean up, NO otherwise
 */
-- (BOOL)cleanUpBackgroundSessionIfPossibleGivenID:(NSString *)backgroundSessionID
-                                            error:(NSError **)error;
+- (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString * _Nonnull)userID
+                                  backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+                                                error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Asynchronously calls a completion callback with all background upload, and download tasks in a session.
@@ -287,7 +289,9 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
  *
  * @return NSArray of associateIds, nil if error
  */
-- (NSArray <NSString *> *)associateIdsOfBackgroundSessionId:(NSString *)backgroundSessionId userId:(NSString *)userId error:(NSError **)error;
+- (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Background session ID of background session

--- a/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.m
+++ b/BoxContentSDK/BoxContentSDK/BOXURLSessionManager.m
@@ -552,6 +552,9 @@ static NSString *backgroundSessionIdentifierForMainApp = @"com.box.BOXURLSession
                                  && (error.code == BOXContentSDKURLSessionCannotCleanUpCurrentBackgroundSession
                                      || error.code == BOXContentSDKURLSessionCannotCleanUpBackgroundSessionWithActiveTasks
                                      || error.code == BOXContentSDKURLSessionCannotCleanUpBackgroundSessionWithTasks));
+            if (success == YES) {
+                error = nil;
+            }
         }
     }
     if (outError != nil) {

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -280,9 +280,9 @@ extern NSString *const BOXContentClientBackgroundTempFolder;
  *
  * @return YES if successfully clean up, NO otherwise
 */
-+ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString *)userID
-                                  backgroundSessionID:(NSString *)backgroundSessionID
-                                                error:(NSError **)error;
++ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString * _Nonnull)userID
+                                  backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+                                                error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Background session ID of background session

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -265,20 +265,24 @@ extern NSString *const BOXContentClientBackgroundTempFolder;
  *
  * @return NSArray of associateIds, nil if error
  */
-+ (NSArray <NSString *> *)associateIdsOfBackgroundSessionId:(NSString *)backgroundSessionId userId:(NSString *)userId error:(NSError **)error;
++ (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Clean up background session from cache and invalidate it if possible,
  * i.e. if the background session to be cleaned up is not the current
  * background session and has no pending tasks
  *
+ * @param userID    userID that this session belongs to
  * @param backgroundSessionID   background session ID to clean up
  * @param error error cleaning up this background session
  *
  * @return YES if successfully clean up, NO otherwise
 */
-+ (BOOL)cleanUpBackgroundSessionIfPossibleGivenID:(NSString *)backgroundSessionID
-                                            error:(NSError **)error;
++ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString *)userID
+                                  backgroundSessionID:(NSString *)backgroundSessionID
+                                                error:(NSError **)error;
 
 /**
  * Background session ID of background session

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.h
@@ -290,9 +290,10 @@ extern NSString *const BOXContentClientBackgroundTempFolder;
 + (nullable NSString *)backgroundSessionIdentifier;
 
 /**
- * Return currrently active background session IDs
-*/
-+ (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error;
+ * Return existing background session IDs
+ */
++ (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error;
 
 /**
  * Return all background session IDs created by the extensions

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -481,9 +481,13 @@ static BOXContentClient *defaultInstance = nil;
     [[BOXURLSessionManager sharedInstance] reconnectWithBackgroundSessionIdFromExtension:backgroundSessionId completion:completionBlock];
 }
 
-+ (NSArray <NSString *> *)associateIdsOfBackgroundSessionId:(NSString *)backgroundSessionId userId:(NSString *)userId error:(NSError **)error
++ (NSArray <NSString *> * _Nullable)associateIdsOfBackgroundSessionId:(NSString * _Nonnull)backgroundSessionId
+                                                               userId:(NSString * _Nonnull)userId
+                                                                error:(NSError * _Nullable * _Nullable)error
 {
-    return [[BOXURLSessionManager sharedInstance] associateIdsOfBackgroundSessionId:backgroundSessionId userId:userId error:error];
+    return [[BOXURLSessionManager sharedInstance] associateIdsOfBackgroundSessionId:backgroundSessionId
+                                                                             userId:userId
+                                                                              error:error];
 }
 
 + (NSString *)backgroundSessionIdentifier
@@ -501,11 +505,13 @@ static BOXContentClient *defaultInstance = nil;
     return [[BOXURLSessionManager sharedInstance] backgroundSessionIDsReconnectedToAppWithError:error];
 }
 
-+ (BOOL)cleanUpBackgroundSessionIfPossibleGivenID:(NSString *)backgroundSessionID
-                                            error:(NSError **)error
++ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString *)userID
+                                  backgroundSessionID:(NSString *)backgroundSessionID
+                                                error:(NSError **)error
 {
-    return [[BOXURLSessionManager sharedInstance] cleanUpBackgroundSessionIfPossibleGivenID:backgroundSessionID
-                                                                                      error:error];
+    return [[BOXURLSessionManager sharedInstance] cleanUpBackgroundSessionIfPossibleGivenUserID:userID
+                                                                            backgroundSessionID:backgroundSessionID
+                                                                                          error:error];
 }
 
 #pragma mark - helper methods

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -495,9 +495,11 @@ static BOXContentClient *defaultInstance = nil;
     return [[BOXURLSessionManager sharedInstance] backgroundSessionIdentifier];
 }
 
-+ (NSArray <NSString *> *)onGoingBackgroundSessionIDsWithError:(NSError **)error
++ (NSArray <NSString *> * _Nullable)backgroundSessionIDsOfUserID:(NSString * _Nonnull)userID
+                                                           error:(NSError * _Nullable * _Nullable)error
 {
-    return [[BOXURLSessionManager sharedInstance] onGoingBackgroundSessionIDsWithError:error];
+    return [[BOXURLSessionManager sharedInstance] backgroundSessionIDsOfUserID:userID
+                                                                         error:error];
 }
 
 + (NSArray <NSString *> *)backgroundSessionIDsReconnectedToAppWithError:(NSError **)error

--- a/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
+++ b/BoxContentSDK/BoxContentSDK/Clients/BOXContentClient.m
@@ -507,9 +507,9 @@ static BOXContentClient *defaultInstance = nil;
     return [[BOXURLSessionManager sharedInstance] backgroundSessionIDsReconnectedToAppWithError:error];
 }
 
-+ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString *)userID
-                                  backgroundSessionID:(NSString *)backgroundSessionID
-                                                error:(NSError **)error
++ (BOOL)cleanUpBackgroundSessionIfPossibleGivenUserID:(NSString * _Nonnull)userID
+                                  backgroundSessionID:(NSString * _Nonnull)backgroundSessionID
+                                                error:(NSError * _Nullable * _Nullable)error
 {
     return [[BOXURLSessionManager sharedInstance] cleanUpBackgroundSessionIfPossibleGivenUserID:userID
                                                                             backgroundSessionID:backgroundSessionID


### PR DESCRIPTION
cherry-picked from master-v4 
https://github.com/box/box-ios-sdk/compare/5a66e351e8dd467652d7cca02dad1fcd0e062b93...72eac4fba64596d8731c68d0c5423a56027c3e1f