### PR TITLE
Move Objective-C code to a maintenance branch

### DIFF
--- a/BoxContentSDKSampleApp/Cartfile
+++ b/BoxContentSDKSampleApp/Cartfile
@@ -1,2 +1,2 @@
 # Box SDKs
-github "box/box-ios-sdk" ~> 2.0
+github "box/box-ios-sdk" "objective-c-maintenance"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 [![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
 [![Build Status](https://api.travis-ci.org/box/box-ios-content-sdk.svg)](https://travis-ci.org/box/box-ios-content-sdk)
 
+NOTE:
+===================
+
+The iOS SDK in **Objective-C** (prior to v3.0.0) has been moved from the master branch to this objective-c-maintenance branch.
+Going forward, the master branch will contain the iOS SDK in **Swift**, starting with v3.0.0.
+
 Box iOS SDK
 ===================
 


### PR DESCRIPTION
Moving the iOS SDK in Objective-C (prior to v3.0.0) from `master` to the `objective-c-maintenance` branch.
The `master` branch will contain the iOS SDK in Swift (starting with v3.0.0), going forward.