### PR TITLE
Add shared link downscoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ __Breaking Changes:__
 
 
 __New Features and Enhancements:__
-
+- Add shared link downscoping
 - Add marker based pagination to list users endpoint
 
 ## v3.0.0 [2019-11-18]

--- a/Sources/Client/BoxClient.swift
+++ b/Sources/Client/BoxClient.swift
@@ -121,13 +121,15 @@ public class BoxClient {
     /// - Parameters:
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
     public func exchangeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
+        sharedLink: String? = nil,
         completion: @escaping TokenInfoClosure
     ) {
-        session.downscopeToken(scope: scope, resource: resource, completion: completion)
+        session.downscopeToken(scope: scope, resource: resource, sharedLink: sharedLink, completion: completion)
     }
 }
 

--- a/Sources/Modules/AuthModule.swift
+++ b/Sources/Modules/AuthModule.swift
@@ -129,8 +129,9 @@ public class AuthModule: TokenRefreshing {
     ///   - parentToken: Fully-scoped access token. This can be an OAuth (Managed User), JWT (App User or Service Account) or an App Token (New Box View) token.
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the token data or an error.
-    public func downscopeToken(parentToken: String, scope: Set<TokenScope>, resource: String? = nil, completion: @escaping TokenInfoClosure) {
+    public func downscopeToken(parentToken: String, scope: Set<TokenScope>, resource: String? = nil, sharedLink: String? = nil, completion: @escaping TokenInfoClosure) {
 
         let scopeList = Array(scope).map { $0.description }.joined(separator: " ")
 
@@ -143,6 +144,10 @@ public class AuthModule: TokenRefreshing {
 
         if let unwrappedResource = resource {
             params["resource"] = unwrappedResource
+        }
+
+        if let unwrappedSharedLink = sharedLink {
+            params["box_shared_link"] = unwrappedSharedLink
         }
 
         networkAgent.send(

--- a/Sources/Network/BoxNetworkAgent.swift
+++ b/Sources/Network/BoxNetworkAgent.swift
@@ -168,12 +168,12 @@ public class BoxNetworkAgent: NSObject, NetworkAgentProtocol {
 
         let urlRequest = createRequest(for: updatedRequest)
         var observation: NSKeyValueObservation?
-        
+
         let task = session.dataTask(with: urlRequest) { [weak self] data, response, error in
             guard let self = self else {
                 return
             }
-            
+
             observation?.invalidate()
 
             if let unwrappedError = error {

--- a/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
+++ b/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
@@ -135,10 +135,12 @@ public class DelegatedAuthSession: SessionProtocol {
     /// - Parameters:
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
     public func downscopeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
+        sharedLink: String? = nil,
         completion: @escaping TokenInfoClosure
     ) {
         getAccessToken { [weak self] result in
@@ -149,7 +151,7 @@ public class DelegatedAuthSession: SessionProtocol {
 
             switch result {
             case let .success(accessToken):
-                self.authModule.downscopeToken(parentToken: accessToken, scope: scope, resource: resource, completion: completion)
+                self.authModule.downscopeToken(parentToken: accessToken, scope: scope, resource: resource, sharedLink: sharedLink, completion: completion)
             case let .failure(error):
                 completion(.failure(error))
             }

--- a/Sources/Sessions/OAuth2/OAuth2Session.swift
+++ b/Sources/Sessions/OAuth2/OAuth2Session.swift
@@ -127,13 +127,15 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
     /// - Parameters:
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
     func downscopeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
+        sharedLink: String? = nil,
         completion: @escaping TokenInfoClosure
     ) {
-        authModule.downscopeToken(parentToken: tokenInfo.accessToken, scope: scope, resource: resource, completion: completion)
+        authModule.downscopeToken(parentToken: tokenInfo.accessToken, scope: scope, resource: resource, sharedLink: sharedLink, completion: completion)
     }
 }
 

--- a/Sources/Sessions/SessionProtocol.swift
+++ b/Sources/Sessions/SessionProtocol.swift
@@ -28,8 +28,9 @@ public protocol SessionProtocol {
     /// - Parameters:
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
-    func downscopeToken(scope: Set<TokenScope>, resource: String?, completion: @escaping TokenInfoClosure)
+    func downscopeToken(scope: Set<TokenScope>, resource: String?, sharedLink: String?, completion: @escaping TokenInfoClosure)
 }
 
 /// Defines handler for expired token.

--- a/Sources/Sessions/SingleToken/SingleTokenSession.swift
+++ b/Sources/Sessions/SingleToken/SingleTokenSession.swift
@@ -30,12 +30,14 @@ class SingleTokenSession: SessionProtocol {
     /// - Parameters:
     ///   - scope: Scope or scopes that you want to apply to the resulting token.
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
+    ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
     func downscopeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
+        sharedLink: String? = nil,
         completion: @escaping TokenInfoClosure
     ) {
-        authModule.downscopeToken(parentToken: token, scope: scope, resource: resource, completion: completion)
+        authModule.downscopeToken(parentToken: token, scope: scope, resource: resource, sharedLink: sharedLink, completion: completion)
     }
 }

--- a/Tests/Modules/AuthModuleSpecs.swift
+++ b/Tests/Modules/AuthModuleSpecs.swift
@@ -170,7 +170,8 @@ class AuthModuleSpecs: QuickSpec {
                                 "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
                                 "scope": "item_preview item_upload",
                                 "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                                "resource": "https://api.box.com/2.0/files/123"
+                                "resource": "https://api.box.com/2.0/files/123",
+                                "box_shared_link": "https://app.box.com/s/xyz"
                             ],
                             checkClosure: { (checkTuple: CheckClosureTuple) in
                                 if let lastPathElement = checkTuple.path.last {
@@ -196,7 +197,7 @@ class AuthModuleSpecs: QuickSpec {
                 }
 
                 waitUntil(timeout: 10) { done in
-                    self.sut.downscopeToken(parentToken: tokenToDownscope, scope: [.itemPreview, .itemUpload], resource: "https://api.box.com/2.0/files/123") { result in
+                    self.sut.downscopeToken(parentToken: tokenToDownscope, scope: [.itemPreview, .itemUpload], resource: "https://api.box.com/2.0/files/123", sharedLink: "https://app.box.com/s/xyz") { result in
                         switch result {
                         case let .success(tokenInfo):
                             expect(tokenInfo).to(beAKindOf(TokenInfo.self))


### PR DESCRIPTION
## Goals :soccer:
- Add token downscoping using a shared link

### Implementation Details :construction:
- Added sharedLink parameter to all downscopeToken() methods and the exchangeToken() method

### Testing Details :mag:
- Amended exchangeToken() unit test to test that the shared link parameter is correctly passed
