### PR TITLE
Change task assignment status from String to Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## Next Release
+
+__Breaking Changes:__
+
+- Change `status` field for task assignments from a String to an Enum
+
+__New Features and Enhancements:__
+
+
+
 ## v3.1.0 [2020-01-09]
 
 __Breaking Changes:__

--- a/Sources/Responses/TaskAssignment.swift
+++ b/Sources/Responses/TaskAssignment.swift
@@ -8,6 +8,50 @@
 
 import Foundation
 
+/// Status of assignment.
+public enum AssignmentStatus: BoxEnum {
+    /// Completed
+    case completed
+    /// Incomplete
+    case incomplete
+    /// Approved
+    case approved
+    /// Rejected
+    case rejected
+    /// Custom value not implemented in this version of SDK.
+    case customValue(String)
+
+    public init(_ value: String) {
+        switch value {
+        case "completed":
+            self = .completed
+        case "incomplete":
+            self = .incomplete
+        case "approved":
+            self = .approved
+        case "rejected":
+            self = .rejected
+        default:
+            self = .customValue(value)
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .completed:
+            return "completed"
+        case .incomplete:
+            return "incomplete"
+        case .approved:
+            return "approved"
+        case .rejected:
+            return "rejected"
+        case let .customValue(value):
+            return value
+        }
+    }
+}
+
 /// State of assignment.
 public enum AssignmentState: BoxEnum {
     /// Completed
@@ -70,7 +114,7 @@ public class TaskAssignment: BoxModel {
     /// Date of assignment.
     public let assignedAt: Date?
     /// Assignment status.
-    public let status: String?
+    public let status: AssignmentStatus?
     /// A message from the assignee about this task.
     public let message: String?
     /// The user task is assigned to.
@@ -99,7 +143,7 @@ public class TaskAssignment: BoxModel {
         id = try BoxJSONDecoder.decode(json: json, forKey: "id")
         item = try BoxJSONDecoder.optionalDecode(json: json, forKey: "item")
         assignedAt = try BoxJSONDecoder.optionalDecodeDate(json: json, forKey: "assigned_at")
-        status = try BoxJSONDecoder.optionalDecode(json: json, forKey: "status")
+        status = try BoxJSONDecoder.optionalDecodeEnum(json: json, forKey: "status")
         message = try BoxJSONDecoder.optionalDecode(json: json, forKey: "message")
         assignedTo = try BoxJSONDecoder.optionalDecode(json: json, forKey: "assigned_to")
         assignedBy = try BoxJSONDecoder.optionalDecode(json: json, forKey: "assigned_by")

--- a/Tests/Responses/TaskSpecs.swift
+++ b/Tests/Responses/TaskSpecs.swift
@@ -51,7 +51,7 @@ class TaskSpecs: QuickSpec {
                         expect(task.taskAssignmentCollection?.entries[0].type).to(equal("task_assignment"))
                         expect(task.taskAssignmentCollection?.entries[0].id).to(equal("12345"))
                         expect(task.taskAssignmentCollection?.entries[0].message).to(equal(""))
-                        expect(task.taskAssignmentCollection?.entries[0].status).to(equal("incomplete"))
+                        expect(task.taskAssignmentCollection?.entries[0].status).to(equal(.incomplete))
                         expect(task.taskAssignmentCollection?.entries[0].resolutionState).to(equal(.incomplete))
 
                         guard case let .file(assignmentFile)? = task.taskAssignmentCollection?.entries[0].item else {
@@ -77,7 +77,7 @@ class TaskSpecs: QuickSpec {
                         expect(task.taskAssignmentCollection?.entries[0].type).to(equal("task_assignment"))
                         expect(task.taskAssignmentCollection?.entries[0].id).to(equal("12345"))
                         expect(task.taskAssignmentCollection?.entries[0].message).to(equal(""))
-                        expect(task.taskAssignmentCollection?.entries[0].status).to(equal("incomplete"))
+                        expect(task.taskAssignmentCollection?.entries[0].status).to(equal(.incomplete))
                         expect(task.taskAssignmentCollection?.entries[0].resolutionState).to(equal(.incomplete))
 
                         expect(task.isCompleted).to(beFalse())


### PR DESCRIPTION
### Goals :soccer:
- Change `status` field from a String to an Enum in the Task Assignment model

### Implementation Details :construction:
- Used the same enum as the one for the `resolution_state` field because both fields have the same value
- The `status` field is redundant and is not publicly documented, but it is returned by the API, so we must support it

### Testing Details :mag:
- Unit testing
