### PR TITLE
Make authentication session classes public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ __Breaking Changes:__
 
 __New Features and Enhancements:__
 
+- Make authentication session classes `OAuth2Session`, `SingleTokenSession`, and `DelegatedAuthSession` public
 
 
 ## v3.1.0 [2020-01-09]

--- a/Sources/Sessions/OAuth2/OAuth2Session.swift
+++ b/Sources/Sessions/OAuth2/OAuth2Session.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
+public class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
     var authModule: AuthModule
     var configuration: BoxSDKConfiguration
     var tokenStore: TokenStore
@@ -23,7 +23,7 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
         self.tokenStore = tokenStore
     }
 
-    func getAccessToken(completion: @escaping AccessTokenClosure) {
+    public func getAccessToken(completion: @escaping AccessTokenClosure) {
 
         // Check if the cached token info is valid, if so just return that access token
         if isValidToken() {
@@ -50,7 +50,7 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
         }
     }
 
-    func handleExpiredToken(completion: @escaping Callback<Void>) {
+    public func handleExpiredToken(completion: @escaping Callback<Void>) {
         tokenStore.clear { result in
             switch result {
             case .success:
@@ -61,7 +61,7 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
         }
     }
 
-    func refreshToken(completion: @escaping AccessTokenClosure) {
+    public func refreshToken(completion: @escaping AccessTokenClosure) {
         guard let refreshToken = tokenInfo.refreshToken else {
             completion(.failure(BoxAPIAuthError(message: .refreshTokenNotFound)))
             return
@@ -107,7 +107,7 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
         }
     }
 
-    func revokeTokens(completion: @escaping Callback<Void>) {
+    public func revokeTokens(completion: @escaping Callback<Void>) {
         authModule.revokeToken(token: tokenInfo.accessToken) { [weak self] result in
             guard let self = self else {
                 return
@@ -129,7 +129,7 @@ class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
     ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
-    func downscopeToken(
+    public func downscopeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
         sharedLink: String? = nil,

--- a/Sources/Sessions/SingleToken/SingleTokenSession.swift
+++ b/Sources/Sessions/SingleToken/SingleTokenSession.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class SingleTokenSession: SessionProtocol {
+public class SingleTokenSession: SessionProtocol {
     var token: String
     var authModule: AuthModule
 
@@ -17,11 +17,11 @@ class SingleTokenSession: SessionProtocol {
         self.authModule = authModule
     }
 
-    func getAccessToken(completion: @escaping AccessTokenClosure) {
+    public func getAccessToken(completion: @escaping AccessTokenClosure) {
         completion(.success(token))
     }
 
-    func revokeTokens(completion: @escaping Callback<Void>) {
+    public func revokeTokens(completion: @escaping Callback<Void>) {
         authModule.revokeToken(token: token, completion: completion)
     }
 
@@ -32,7 +32,7 @@ class SingleTokenSession: SessionProtocol {
     ///   - resource: Full url path to the file that the token should be generated for, eg: https://api.box.com/2.0/files/{file_id}
     ///   - sharedLink: Shared link to get a token for.
     ///   - completion: Returns the success or an error.
-    func downscopeToken(
+    public func downscopeToken(
         scope: Set<TokenScope>,
         resource: String? = nil,
         sharedLink: String? = nil,


### PR DESCRIPTION
### Goals :soccer:
- Make authentication session classes public

### Implementation Details :construction:
- Made session classes `OAuth2Session` and `SingleTokenSession` public to match `DelegatedAuthSession` which was already public