### PR TITLE
Fix logging of API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ __New Features and Enhancements:__
 
 - Add support for the uploader display name field for Files and File Versions
 
+__Bug Fixes:__
+
+- Fix logging of API responses
 
 ## v4.0.0 [2020-02-13]
 

--- a/Sources/Logger/Logger.swift
+++ b/Sources/Logger/Logger.swift
@@ -28,7 +28,7 @@ class Logger {
 
 extension Logger {
     func debug(_ message: StaticString, _ args: CVarArg...) {
-        log(message, level: .debug, args)
+        log(message, level: LogLevel.debug, args)
     }
 
     func info(_ message: StaticString, _ args: CVarArg...) {
@@ -118,10 +118,10 @@ extension Logger {
 
         let output = StaticString("\n\n%{public}@\n◁ Headers: %{private}@\n◁ Body: %{private}@\n")
         if errorOutput {
-            debug(output, responseString, headersString, bodyString)
+            error(output, responseString, headersString, bodyString)
         }
         else {
-            error(output, responseString, headersString, bodyString)
+            debug(output, responseString, headersString, bodyString)
         }
     }
 }

--- a/Sources/Logger/Logger.swift
+++ b/Sources/Logger/Logger.swift
@@ -28,7 +28,7 @@ class Logger {
 
 extension Logger {
     func debug(_ message: StaticString, _ args: CVarArg...) {
-        log(message, level: LogLevel.debug, args)
+        log(message, level: .debug, args)
     }
 
     func info(_ message: StaticString, _ args: CVarArg...) {


### PR DESCRIPTION
### Goals :soccer:
- Fix logging of API responses. API responses are being logged as error information rather than debug information

### Implementation Details :construction:
- Responses were being logged as errors when no error occurred and debug information when errors occurred. The logic was flipped to correct this.

### Testing Details :mag:
- Manual testing
