### PR TITLE
Add support for the classification field for Files and Folders

### DIFF
--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		F92CF9A52356A8430046A277 /* BoxAPIAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */; };
 		F941067223513DD00061A3F8 /* ArrayInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = F941067123513DD00061A3F8 /* ArrayInputStream.swift */; };
 		F9571FB42371F47400D30EF1 /* LoggingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */; };
+		F95D6F85245C9DFF008B09CF /* Classification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95D6F84245C9DFF008B09CF /* Classification.swift */; };
 		F969D37C233A7146001301FC /* StoragePoliciesModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D37B233A7146001301FC /* StoragePoliciesModule.swift */; };
 		F969D381233A71B4001301FC /* StoragePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D380233A71B4001301FC /* StoragePolicy.swift */; };
 		F969D386233A71EF001301FC /* StoragePolicyAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D385233A71EF001301FC /* StoragePolicyAssignment.swift */; };
@@ -873,6 +874,7 @@
 		F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxAPIAuthError.swift; sourceTree = "<group>"; };
 		F941067123513DD00061A3F8 /* ArrayInputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInputStream.swift; sourceTree = "<group>"; };
 		F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingSpecs.swift; sourceTree = "<group>"; };
+		F95D6F84245C9DFF008B09CF /* Classification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Classification.swift; sourceTree = "<group>"; };
 		F969D37B233A7146001301FC /* StoragePoliciesModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePoliciesModule.swift; sourceTree = "<group>"; };
 		F969D380233A71B4001301FC /* StoragePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePolicy.swift; sourceTree = "<group>"; };
 		F969D385233A71EF001301FC /* StoragePolicyAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePolicyAssignment.swift; sourceTree = "<group>"; };
@@ -1267,6 +1269,7 @@
 				F969D380233A71B4001301FC /* StoragePolicy.swift */,
 				F969D385233A71EF001301FC /* StoragePolicyAssignment.swift */,
 				F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */,
+				F95D6F84245C9DFF008B09CF /* Classification.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -2325,6 +2328,7 @@
 				22E39ED622F0913F0061E182 /* TrashModule.swift in Sources */,
 				80E567DB2315DBA000798E3A /* DevicePinsModule.swift in Sources */,
 				97BC7AAD228B69DE00DDE998 /* FieldsQueryParam.swift in Sources */,
+				F95D6F85245C9DFF008B09CF /* Classification.swift in Sources */,
 				0C44FF6C227C4B890018D8E9 /* LogDestination.swift in Sources */,
 				228C36162255F82000AC8888 /* BoxRequest.swift in Sources */,
 				0C44FF7B227C786D0018D8E9 /* Logger.swift in Sources */,

--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		F92CF9A52356A8430046A277 /* BoxAPIAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */; };
 		F941067223513DD00061A3F8 /* ArrayInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = F941067123513DD00061A3F8 /* ArrayInputStream.swift */; };
 		F9571FB42371F47400D30EF1 /* LoggingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */; };
+		F95A81C124606DC300C46E98 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A81C024606DC300C46E98 /* UIColorExtension.swift */; };
 		F95D6F85245C9DFF008B09CF /* Classification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95D6F84245C9DFF008B09CF /* Classification.swift */; };
 		F969D37C233A7146001301FC /* StoragePoliciesModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D37B233A7146001301FC /* StoragePoliciesModule.swift */; };
 		F969D381233A71B4001301FC /* StoragePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D380233A71B4001301FC /* StoragePolicy.swift */; };
@@ -874,6 +875,7 @@
 		F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxAPIAuthError.swift; sourceTree = "<group>"; };
 		F941067123513DD00061A3F8 /* ArrayInputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInputStream.swift; sourceTree = "<group>"; };
 		F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingSpecs.swift; sourceTree = "<group>"; };
+		F95A81C024606DC300C46E98 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		F95D6F84245C9DFF008B09CF /* Classification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Classification.swift; sourceTree = "<group>"; };
 		F969D37B233A7146001301FC /* StoragePoliciesModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePoliciesModule.swift; sourceTree = "<group>"; };
 		F969D380233A71B4001301FC /* StoragePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePolicy.swift; sourceTree = "<group>"; };
@@ -1120,6 +1122,7 @@
 				2261F82B228477B8008E7BD0 /* UIDeviceExtension.swift */,
 				22C95BDD230AE9A0004F5C18 /* DataExtension.swift */,
 				22B7782D230C3B8D00FF6614 /* StringExtension.swift */,
+				F95A81C024606DC300C46E98 /* UIColorExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2336,6 +2339,7 @@
 				9DE5D7E022EF53E30081A031 /* EventItemType.swift in Sources */,
 				8053E2CC22AF15F7000B42E1 /* SharedItem.swift in Sources */,
 				172A4F212317F464009F5293 /* RetentionPolicyModule.swift in Sources */,
+				F95A81C124606DC300C46E98 /* UIColorExtension.swift in Sources */,
 				2228B19322C0C8F5001F759D /* Lock.swift in Sources */,
 				224E1BEE22C57C8400F31F3A /* MetadataModule+Files.swift in Sources */,
 				225639EE22539E8F00D951B5 /* BoxSDK.swift in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 - Add support for the uploader display name field for Files and File Versions
+- Add support for the classification field for Files and Folders
 
 __Bug Fixes:__
 

--- a/Sources/Core/BoxJSONDecoder.swift
+++ b/Sources/Core/BoxJSONDecoder.swift
@@ -34,7 +34,6 @@ class BoxJSONDecoder {
         }
 
         guard let object = objectJSON as? T else {
-            // here
             throw BoxCodingError(message: .typeMismatch(key: key))
         }
 

--- a/Sources/Core/BoxJSONDecoder.swift
+++ b/Sources/Core/BoxJSONDecoder.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // swiftlint:disable:next convenience_type
 class BoxJSONDecoder {
@@ -33,6 +34,7 @@ class BoxJSONDecoder {
         }
 
         guard let object = objectJSON as? T else {
+            // here
             throw BoxCodingError(message: .typeMismatch(key: key))
         }
 
@@ -149,6 +151,18 @@ class BoxJSONDecoder {
         }
 
         return url
+    }
+
+    static func optionalDecodeColor(json: [String: Any], forKey key: String) throws -> UIColor? {
+        guard let value: String = try optionalExtractJSON(json: json, key: key), !value.isEmpty else {
+            return nil
+        }
+
+        guard let color = UIColor(hex: value) else {
+            throw BoxCodingError(message: .invalidValueFormat(key: key))
+        }
+
+        return color
     }
 
     // MARK: - Decodes

--- a/Sources/Core/Extensions/UIColorExtension.swift
+++ b/Sources/Core/Extensions/UIColorExtension.swift
@@ -1,0 +1,36 @@
+//
+//  UIColorExtension.swift
+//  BoxSDK-iOS
+//
+//  Created by Sujay Garlanka on 5/4/20.
+//  Copyright © 2020 box. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    convenience init?(hex: String) {
+        let red, green, blue, alpha: CGFloat
+        if hex.hasPrefix("#") {
+            let start = hex.index(hex.startIndex, offsetBy: 1)
+            let hexColor = String(hex[start...])
+
+            if hexColor.count == 6 {
+                let scanner = Scanner(string: hexColor)
+                var hexNumber: UInt64 = 0
+
+                if scanner.scanHexInt64(&hexNumber) {
+                    red = CGFloat((hexNumber & 0xFF0000) >> 16) / 255
+                    green = CGFloat((hexNumber & 0x00FF00) >> 8) / 255
+                    blue = CGFloat(hexNumber & 0x0000FF) / 255
+                    alpha = CGFloat(1.0)
+
+                    self.init(red: red, green: green, blue: blue, alpha: alpha)
+                    return
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Responses/Classification.swift
+++ b/Sources/Responses/Classification.swift
@@ -7,15 +7,28 @@
 //
 
 import Foundation
+import UIKit
 
 /// Details about the classification applied to a Box file or folder
-public class Classification: BoxInnerModel {
+public class Classification: BoxModel {
     // MARK: - Properties
 
+    public private(set) var rawData: [String: Any]
     /// The color that is used to display the classification label in a user-interface
-    public let color: String?
+    public let color: UIColor?
     /// An explanation of the meaning of this classification
     public let definition: String?
     /// Name of the classification
     public let name: String?
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary.
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        rawData = json
+        color = try BoxJSONDecoder.optionalDecodeColor(json: json, forKey: "color")
+        definition = try BoxJSONDecoder.optionalDecode(json: json, forKey: "definition")
+        name = try BoxJSONDecoder.optionalDecode(json: json, forKey: "name")
+    }
 }

--- a/Sources/Responses/Classification.swift
+++ b/Sources/Responses/Classification.swift
@@ -1,0 +1,21 @@
+//
+//  Classification.swift
+//  BoxSDK-iOS
+//
+//  Created by Sujay Garlanka on 5/1/20.
+//  Copyright © 2020 box. All rights reserved.
+//
+
+import Foundation
+
+/// Details about the classification applied to a Box file or folder
+public class Classification: BoxInnerModel {
+    // MARK: - Properties
+
+    /// The color that is used to display the classification label in a user-interface
+    public let color: String?
+    /// An explanation of the meaning of this classification
+    public let definition: String?
+    /// Name of the classification
+    public let name: String?
+}

--- a/Sources/Responses/File.swift
+++ b/Sources/Responses/File.swift
@@ -112,6 +112,8 @@ public class File: BoxModel {
     public let allowedInviteeRoles: [CollaborationRole]?
     /// Digital assets created for this file.
     public let representations: EntryContainerInnerModel<FileRepresentation>?
+    /// Details about the classification applied to a Box file
+    public let classification: Classification?
 
     /// Initializer.
     ///
@@ -167,5 +169,6 @@ public class File: BoxModel {
         allowedInviteeRoles = try BoxJSONDecoder.optionalDecodeEnumCollection(json: json, forKey: "allowed_invitee_roles")
         representations = try BoxJSONDecoder.optionalDecode(json: json, forKey: "representations")
         collections = json["collections"] as? [[String: String]]
+        classification = try BoxJSONDecoder.optionalDecode(json: json, forKey: "classification")
     }
 }

--- a/Sources/Responses/Folder.swift
+++ b/Sources/Responses/Folder.swift
@@ -132,6 +132,8 @@ public class Folder: BoxModel {
     public let isExternallyOwned: Bool?
     /// The collections the folder belongs to
     public let collections: [[String: String]]?
+    /// Details about the classification applied to a Box folder
+    public let classification: Classification?
 
     /// Initializer.
     ///
@@ -181,5 +183,6 @@ public class Folder: BoxModel {
         allowedInviteeRoles = try BoxJSONDecoder.optionalDecode(json: json, forKey: "allowed_invitee_roles")
         isExternallyOwned = try BoxJSONDecoder.optionalDecode(json: json, forKey: "is_externally_owned")
         collections = json["collections"] as? [[String: String]]
+        classification = try BoxJSONDecoder.optionalDecode(json: json, forKey: "classification")
     }
 }

--- a/Tests/Responses/FileSpecs.swift
+++ b/Tests/Responses/FileSpecs.swift
@@ -130,7 +130,7 @@ class FileSpecs: QuickSpec {
                         expect(file.allowedInviteeRoles?.count).to(equal(2))
                         expect(file.allowedInviteeRoles?[0]).to(equal(.editor))
                         expect(file.allowedInviteeRoles?[1]).to(equal(.viewer))
-                        expect(file.classification?.color).to(equal("#FF0000"))
+                        expect(file.classification?.color).to(equal(UIColor.red))
                         expect(file.classification?.definition).to(equal("Content that should not be shared outside the company."))
                         expect(file.classification?.name).to(equal("Top Secret"))
                     }

--- a/Tests/Responses/FileSpecs.swift
+++ b/Tests/Responses/FileSpecs.swift
@@ -130,6 +130,9 @@ class FileSpecs: QuickSpec {
                         expect(file.allowedInviteeRoles?.count).to(equal(2))
                         expect(file.allowedInviteeRoles?[0]).to(equal(.editor))
                         expect(file.allowedInviteeRoles?[1]).to(equal(.viewer))
+                        expect(file.classification?.color).to(equal("#FF0000"))
+                        expect(file.classification?.definition).to(equal("Content that should not be shared outside the company."))
+                        expect(file.classification?.name).to(equal("Top Secret"))
                     }
                     catch {
                         fail("Failed with Error: \(error)")

--- a/Tests/Responses/FolderSpecs.swift
+++ b/Tests/Responses/FolderSpecs.swift
@@ -106,7 +106,7 @@ class FolderSpecs: QuickSpec {
                         expect(folder.allowedInviteeRoles?[5]).to(equal("co-owner"))
                         expect(folder.allowedInviteeRoles?[6]).to(equal("viewer uploader"))
                         expect(folder.isExternallyOwned).to(beFalse())
-                        expect(folder.classification?.color).to(equal("#FF0000"))
+                        expect(folder.classification?.color).to(equal(UIColor.cyan))
                         expect(folder.classification?.definition).to(equal("Content that should not be shared outside the company."))
                         expect(folder.classification?.name).to(equal("Top Secret"))
                     }

--- a/Tests/Responses/FolderSpecs.swift
+++ b/Tests/Responses/FolderSpecs.swift
@@ -106,6 +106,9 @@ class FolderSpecs: QuickSpec {
                         expect(folder.allowedInviteeRoles?[5]).to(equal("co-owner"))
                         expect(folder.allowedInviteeRoles?[6]).to(equal("viewer uploader"))
                         expect(folder.isExternallyOwned).to(beFalse())
+                        expect(folder.classification?.color).to(equal("#FF0000"))
+                        expect(folder.classification?.definition).to(equal("Content that should not be shared outside the company."))
+                        expect(folder.classification?.name).to(equal("Top Secret"))
                     }
                     catch {
                         fail("Failed with Error: \(error)")

--- a/Tests/Stubs/Resources/Files/FullFile.json
+++ b/Tests/Stubs/Resources/Files/FullFile.json
@@ -270,5 +270,10 @@
         "editor",
         "viewer"
     ],
-    "default_invitee_role": "editor"
+    "default_invitee_role": "editor",
+    "classification": {
+      "color": "#FF0000",
+      "definition": "Content that should not be shared outside the company.",
+      "name": "Top Secret"
+    }
 }

--- a/Tests/Stubs/Resources/Folders/FullFolder.json
+++ b/Tests/Stubs/Resources/Folders/FullFolder.json
@@ -126,5 +126,10 @@
     },
     "file_count": 1238,
     "is_collaboration_restricted_to_enterprise": true,
-    "can_non_owners_view_collaborators": true
+    "can_non_owners_view_collaborators": true,
+    "classification": {
+      "color": "#FF0000",
+      "definition": "Content that should not be shared outside the company.",
+      "name": "Top Secret"
+    }
 }

--- a/Tests/Stubs/Resources/Folders/FullFolder.json
+++ b/Tests/Stubs/Resources/Folders/FullFolder.json
@@ -128,7 +128,7 @@
     "is_collaboration_restricted_to_enterprise": true,
     "can_non_owners_view_collaborators": true,
     "classification": {
-      "color": "#FF0000",
+      "color": "#00FFFF",
       "definition": "Content that should not be shared outside the company.",
       "name": "Top Secret"
     }


### PR DESCRIPTION
## Goals :soccer:
- Add support for the classification field for Files and Folders

### Implementation Details :construction:
- Added classification field to `File` and `Folder` models
- Created a new model for this field because this field has fields within it
- Return hex color as UIColor

### Testing Details :mag:
- Added serialization tests
