### PR TITLE
Add path parameter sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ __New Features and Enhancements:__
 
 - Add support for the uploader display name field for Files and File Versions
 - Add support for the classification field for Files and Folders
+- Add path parameter sanitization
 
 __Bug Fixes:__
 

--- a/Sources/Core/Extensions/URLExtension.swift
+++ b/Sources/Core/Extensions/URLExtension.swift
@@ -19,11 +19,8 @@ extension URL {
     }
 
     private static func make(from string: String, relativeTo baseURL: URL) -> URL {
-        let range = NSRange(location: 0, length: string.utf16.count)
-        // Checks that url paths with relative paths like /../ are not sent to the API
-        // swiftlint:disable:next force_try
-        let regex = try! NSRegularExpression(pattern: "\\/\\.+\\/")
-        if regex.firstMatch(in: string, options: [], range: range) != nil {
+        let pattern = "\\/\\.+"
+        if string.range(of: pattern, options: .regularExpression) != nil {
             fatalError("An invalid path parameter exists in \(string). Relative path parameters cannot be passed.")
         }
         guard let url = URL(string: string, relativeTo: baseURL) else {

--- a/Sources/Core/Extensions/URLExtension.swift
+++ b/Sources/Core/Extensions/URLExtension.swift
@@ -19,6 +19,7 @@ extension URL {
     }
 
     private static func make(from string: String, relativeTo baseURL: URL) -> URL {
+        // Checks that url paths with relative paths like /.. are not sent to the API
         let pattern = "\\/\\.+"
         if string.range(of: pattern, options: .regularExpression) != nil {
             fatalError("An invalid path parameter exists in \(string). Relative path parameters cannot be passed.")

--- a/Sources/Core/Extensions/URLExtension.swift
+++ b/Sources/Core/Extensions/URLExtension.swift
@@ -19,19 +19,12 @@ extension URL {
     }
 
     private static func make(from string: String, relativeTo baseURL: URL) -> URL {
-        // This check is there to only run sanitization when string is path and not a full custom URL. Full URLs are just returned
-        if URL(string: string)?.scheme == nil {
-            let validParams = ["2.0", "thumbnail.jpg", "thumbnail.png"]
-            var sanitizedURL = string
-            validParams.forEach { param in
-                sanitizedURL = sanitizedURL.replacingOccurrences(of: param, with: "")
-            }
-            let range = NSRange(location: 0, length: sanitizedURL.utf16.count)
-            // Checks that url paths with relative paths like /../ or other invalid path parameters are not sent to the API
-            let regex = try? NSRegularExpression(pattern: "^[a-zA-Z0-9!@#$%^&*()_+\\/-]*$")
-            if regex?.firstMatch(in: sanitizedURL, options: [], range: range) == nil {
-                fatalError("An invalid path parameter exists in \(string). All parameters must be alphanumeric.")
-            }
+        let range = NSRange(location: 0, length: string.utf16.count)
+        // Checks that url paths with relative paths like /../ are not sent to the API
+        // swiftlint:disable:next force_try
+        let regex = try! NSRegularExpression(pattern: "\\/\\.+\\/")
+        if regex.firstMatch(in: string, options: [], range: range) != nil {
+            fatalError("An invalid path parameter exists in \(string). Relative path parameters cannot be passed.")
         }
         guard let url = URL(string: string, relativeTo: baseURL) else {
             fatalError("Could not create URL from \(string.isEmpty ? "empty string" : string) relative to base URL: \(baseURL)")

--- a/Sources/Core/Extensions/URLExtension.swift
+++ b/Sources/Core/Extensions/URLExtension.swift
@@ -19,6 +19,20 @@ extension URL {
     }
 
     private static func make(from string: String, relativeTo baseURL: URL) -> URL {
+        // This check is there to only run sanitization when string is path and not a full custom URL. Full URLs are just returned
+        if URL(string: string)?.scheme == nil {
+            let validParams = ["2.0", "thumbnail.jpg", "thumbnail.png"]
+            var sanitizedURL = string
+            validParams.forEach { param in
+                sanitizedURL = sanitizedURL.replacingOccurrences(of: param, with: "")
+            }
+            let range = NSRange(location: 0, length: sanitizedURL.utf16.count)
+            // Checks that url paths with relative paths like /../ or other invalid path parameters are not sent to the API
+            let regex = try? NSRegularExpression(pattern: "^[a-zA-Z0-9!@#$%^&*()_+\\/-]*$")
+            if regex?.firstMatch(in: sanitizedURL, options: [], range: range) == nil {
+                fatalError("An invalid path parameter exists in \(string). All parameters must be alphanumeric.")
+            }
+        }
         guard let url = URL(string: string, relativeTo: baseURL) else {
             fatalError("Could not create URL from \(string.isEmpty ? "empty string" : string) relative to base URL: \(baseURL)")
         }

--- a/Tests/Requests/URLs/URLExtensionTest.swift
+++ b/Tests/Requests/URLs/URLExtensionTest.swift
@@ -17,6 +17,7 @@ class URLExtensionTest: QuickSpec {
 
         let configuration: BoxSDKConfiguration = try! BoxSDKConfiguration(clientId: "", clientSecret: "")
         let customURLPart: String = "/testurl"
+        let invalidURLPart: String = "/test/../"
 
         describe("boxAPIEndpoint()") {
             it("should create an API Endpoint URL containing base url from configuration") {
@@ -24,13 +25,21 @@ class URLExtensionTest: QuickSpec {
                 expect(url.absoluteString).to(equal(configuration.apiBaseURL.absoluteString.appending(customURLPart)))
                 expect(url.absoluteString).to(contain(configuration.apiBaseURL.absoluteString))
             }
+
+            it("should fail to create an API Endpoint URL") {
+                expect { _ = URL.boxAPIEndpoint(invalidURLPart, configuration: configuration) }.to(throwAssertion())
+            }
         }
 
-        describe("boxAPIEndpoint()") {
+        describe("boxUploadEndpoint()") {
             it("should create an Upload Endpoint URL containing base url from configuration") {
                 let url = URL.boxUploadEndpoint(customURLPart, configuration: configuration)
                 expect(url.absoluteString).to(equal(configuration.uploadApiBaseURL.absoluteString.appending(customURLPart)))
                 expect(url.absoluteString).to(contain(configuration.uploadApiBaseURL.absoluteString))
+            }
+
+            it("should fail to create an Upload Endpoint URL") {
+                expect { _ = URL.boxUploadEndpoint(invalidURLPart, configuration: configuration) }.to(throwAssertion())
             }
 
             context("when providing full url string") {

--- a/Tests/Requests/URLs/URLExtensionTest.swift
+++ b/Tests/Requests/URLs/URLExtensionTest.swift
@@ -18,6 +18,7 @@ class URLExtensionTest: QuickSpec {
         let configuration: BoxSDKConfiguration = try! BoxSDKConfiguration(clientId: "", clientSecret: "")
         let customURLPart: String = "/testurl"
         let invalidURLPart: String = "/test/../"
+        let invalidURLPart2: String = "/test/.."
 
         describe("boxAPIEndpoint()") {
             it("should create an API Endpoint URL containing base url from configuration") {
@@ -28,6 +29,7 @@ class URLExtensionTest: QuickSpec {
 
             it("should fail to create an API Endpoint URL") {
                 expect { _ = URL.boxAPIEndpoint(invalidURLPart, configuration: configuration) }.to(throwAssertion())
+                expect { _ = URL.boxAPIEndpoint(invalidURLPart2, configuration: configuration) }.to(throwAssertion())
             }
         }
 
@@ -40,6 +42,7 @@ class URLExtensionTest: QuickSpec {
 
             it("should fail to create an Upload Endpoint URL") {
                 expect { _ = URL.boxUploadEndpoint(invalidURLPart, configuration: configuration) }.to(throwAssertion())
+                expect { _ = URL.boxUploadEndpoint(invalidURLPart2, configuration: configuration) }.to(throwAssertion())
             }
 
             context("when providing full url string") {
@@ -47,6 +50,11 @@ class URLExtensionTest: QuickSpec {
                     let urlString = "http://fakeurl.com/test"
                     let url = URL.boxUploadEndpoint(urlString, configuration: configuration)
                     expect(url.absoluteString).to(equal(urlString))
+                }
+
+                it("should fail") {
+                    let urlString = "http://fakeurl.com/test/../"
+                    expect { _ = URL.boxUploadEndpoint(urlString, configuration: configuration) }.to(throwAssertion())
                 }
             }
         }


### PR DESCRIPTION
### Issue Link :link:
- SDK-1363

### Goals :soccer:
- Sanitize path parameters when constructing a URL

### Implementation Details :construction:
- SDK throws an error if path parameters include relative paths such as /../ 

### Testing Details :mag:
- Unit tests
