### PR TITLE
Fix bug with creating collaboration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## Next Release
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+__Bug Fixes:__
+
+- Fix bug with creating collaboration
+
 ## v4.1.0 [2020-05-15]
 
 __Breaking Changes:__

--- a/Sources/Modules/CollaborationsModule.swift
+++ b/Sources/Modules/CollaborationsModule.swift
@@ -107,11 +107,11 @@ public class CollaborationsModule {
                 "id": itemId,
                 "type": itemType
             ],
-            "role": role.description,
             "accessible_by": [
                 "id": accessibleBy,
                 "type": accessibleByType.description
-            ]
+            ],
+            "role": role.description
         ]
 
         if let canViewPath = canViewPath {

--- a/Sources/Modules/CollaborationsModule.swift
+++ b/Sources/Modules/CollaborationsModule.swift
@@ -107,15 +107,16 @@ public class CollaborationsModule {
                 "id": itemId,
                 "type": itemType
             ],
-            "role": role.description
+            "role": role.description,
+            "accessible_by": [
+                "id": accessibleBy,
+                "type": accessibleByType.description
+            ]
         ]
 
         if let canViewPath = canViewPath {
             json["can_view_path"] = canViewPath
         }
-
-        var accessibleByJSON: [String: Any] = ["type": accessibleByType.description]
-        accessibleByJSON["id"] = accessibleBy
 
         boxClient.post(
             url: URL.boxAPIEndpoint("/2.0/collaborations", configuration: boxClient.configuration),
@@ -153,15 +154,16 @@ public class CollaborationsModule {
                 "id": itemId,
                 "type": itemType
             ],
-            "role": role.description
+            "role": role.description,
+            "accessible_by": [
+                "login": login,
+                "type": "user"
+            ]
         ]
 
         if let canViewPath = canViewPath {
             json["can_view_path"] = canViewPath
         }
-
-        var accessibleByJSON: [String: Any] = ["type": "user"]
-        accessibleByJSON["login"] = login
 
         boxClient.post(
             url: URL.boxAPIEndpoint("/2.0/collaborations", configuration: boxClient.configuration),

--- a/Sources/Modules/CollaborationsModule.swift
+++ b/Sources/Modules/CollaborationsModule.swift
@@ -154,11 +154,11 @@ public class CollaborationsModule {
                 "id": itemId,
                 "type": itemType
             ],
-            "role": role.description,
             "accessible_by": [
                 "login": login,
                 "type": "user"
-            ]
+            ],
+            "role": role.description
         ]
 
         if let canViewPath = canViewPath {

--- a/Tests/Modules/CollaborationsModuleSpecs.swift
+++ b/Tests/Modules/CollaborationsModuleSpecs.swift
@@ -76,7 +76,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             condition: isHost("api.box.com") &&
                                 isPath("/2.0/collaborations") &&
                                 isMethodPOST() &&
-                                self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "role": "editor", "can_view_path": true])
+                                self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["id": "123456", "type": "group"], "role": "editor", "can_view_path": true])
                         ) { _ in
                             OHHTTPStubsResponse(
                                 fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
@@ -119,7 +119,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             condition: isHost("api.box.com") &&
                                 isPath("/2.0/collaborations") &&
                                 isMethodPOST() &&
-                                self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "role": "editor"])
+                                self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["id": "123456", "type": "group"], "role": "editor"])
                         ) { _ in
                             OHHTTPStubsResponse(
                                 fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,


### PR DESCRIPTION
### Goals :soccer:
- Fix bug with creating a collaboration

### Implementation Details :construction:
- `collaborations.create()` and `collaborations.createByUserEmail()` did not add the `accessible_by` parameters to the POST body. I added the parameters to the POST body.

### Testing Details :mag:
- Updated unit tests
