### PR TITLE
Fix bug with getting enterprise events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __New Features and Enhancements:__
 __Bug Fixes:__
 
 - Fix bug with creating collaboration
+- Fix bug with getting enterprise events
 
 ## v4.1.0 [2020-05-15]
 

--- a/Sources/Modules/EventsModule.swift
+++ b/Sources/Modules/EventsModule.swift
@@ -168,7 +168,7 @@ public class EventsModule {
     /// and seven years via exported reports in the Box Admin Console.
     ///
     /// - Parameters:
-    ///   - evenType: Restricts returned value to listed events.
+    ///   - eventType: Restricts returned value to listed events.
     ///   - createdAfter: A lower bound on the timestamp of the events returned.
     ///   - createdBefore: An upper bound on the timestamp of the events returned.
     ///   - streamPosition: The location in the event stream from which you want to start receiving events.

--- a/Sources/Responses/EventItemType.swift
+++ b/Sources/Responses/EventItemType.swift
@@ -22,6 +22,8 @@ public class EventItem: BoxModel {
         case file(File)
         /// Comment type
         case comment(Comment)
+        /// User type
+        case user(User)
         /// Unknown type
         case unknown
     }
@@ -35,20 +37,36 @@ public class EventItem: BoxModel {
     /// - Throws: Decoding error.
     public required init(json: [String: Any]) throws {
         rawData = json
+        var updatedJson: [String: Any] = json
 
-        guard let type = json["type"] as? String else {
+        if let entry = updatedJson.removeValue(forKey: "item_id") {
+            updatedJson["id"] = entry
+        }
+
+        if let entry = updatedJson.removeValue(forKey: "item_type") {
+            updatedJson["type"] = entry
+        }
+
+        if let entry = updatedJson.removeValue(forKey: "item_name") {
+            updatedJson["name"] = entry
+        }
+
+        guard let type = updatedJson["type"] as? String else {
             throw BoxCodingError(message: .typeMismatch(key: "type"))
         }
         switch type {
         case "file":
-            let file = try File(json: json)
+            let file = try File(json: updatedJson)
             itemValue = .file(file)
         case "folder":
-            let folder = try Folder(json: json)
+            let folder = try Folder(json: updatedJson)
             itemValue = .folder(folder)
         case "comment":
-            let comment = try Comment(json: json)
+            let comment = try Comment(json: updatedJson)
             itemValue = .comment(comment)
+        case "user":
+            let user = try User(json: updatedJson)
+            itemValue = .user(user)
         default:
             // Clients to use rawData directly
             itemValue = .unknown

--- a/Tests/Modules/EventsModuleSpecs.swift
+++ b/Tests/Modules/EventsModuleSpecs.swift
@@ -219,7 +219,7 @@ class EventsModuleSpecs: QuickSpec {
                         isMethodGET(),
                     response: { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetUserEvents.json", type(of: self))!,
+                            fileAtPath: OHPathForFile("GetEnterpriseEvents.json", type(of: self))!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -239,11 +239,16 @@ class EventsModuleSpecs: QuickSpec {
                                 case let .success(event):
                                     expect(event).toNot(beNil())
                                     expect(event).to(beAKindOf(Event.self))
-                                    expect(event.id).to(equal("f82c3ba03e41f7e8a7608363cc6c0390183c3f83"))
-                                    expect(event.createdBy?.id).to(equal("11111"))
-                                    expect(event.eventType).to(equal(.itemCreated))
-                                    expect(event.sessionId).to(equal("70090280850c8d2a1933c1"))
-
+                                    expect(event.id).to(equal("1a4ade15-b1ff-4cc3-89a8-955e1522557c"))
+                                    expect(event.createdBy?.id).to(equal("55555"))
+                                    expect(event.sessionId).to(beNil())
+                                    switch event.source?.itemValue {
+                                    case let .file(file):
+                                        expect(file.id).to(equal("22222"))
+                                        expect(file.name).to(equal("test.docx"))
+                                    default:
+                                        fail("Unable to get event source")
+                                    }
                                 case let .failure(error):
                                     fail("Unable to get event details, but instead got \(error)")
                                 }

--- a/Tests/Modules/EventsModuleSpecs.swift
+++ b/Tests/Modules/EventsModuleSpecs.swift
@@ -244,6 +244,7 @@ class EventsModuleSpecs: QuickSpec {
                                     expect(event.sessionId).to(beNil())
                                     switch event.source?.itemValue {
                                     case let .file(file):
+                                        expect(file.type).to(equal("file"))
                                         expect(file.id).to(equal("22222"))
                                         expect(file.name).to(equal("test.docx"))
                                     default:
@@ -252,7 +253,28 @@ class EventsModuleSpecs: QuickSpec {
                                 case let .failure(error):
                                     fail("Unable to get event details, but instead got \(error)")
                                 }
-                                done()
+                            }
+
+                            iterator.next { result in
+                                switch result {
+                                case let .success(event):
+                                    expect(event).toNot(beNil())
+                                    expect(event).to(beAKindOf(Event.self))
+                                    expect(event.id).to(equal("b9a2393a-20cf-4307-90f5-004110dec209"))
+                                    expect(event.createdBy?.id).to(equal("222853849"))
+                                    expect(event.sessionId).to(beNil())
+                                    switch event.source?.itemValue {
+                                    case let .user(user):
+                                        expect(user.type).to(equal("user"))
+                                        expect(user.id).to(equal("11111"))
+                                        expect(user.name).to(equal("Test User"))
+                                        done()
+                                    default:
+                                        fail("Unable to get event source")
+                                    }
+                                case let .failure(error):
+                                    fail("Unable to get event details, but instead got \(error)")
+                                }
                             }
                         case let .failure(error):
                             fail("Unable to get event details, but instead got \(error)")

--- a/Tests/Stubs/Resources/Events/GetEnterpriseEvents.json
+++ b/Tests/Stubs/Resources/Events/GetEnterpriseEvents.json
@@ -4,27 +4,6 @@
     "entries": [
         {
             "source": {
-                "type": "user",
-                "id": "11111",
-                "name": "Test User",
-                "login": "testuser@example.com"
-            },
-            "created_by": {
-                "type": "user",
-                "id": "222853849",
-                "name": "Test User",
-                "login": "testuser@example.com"
-            },
-            "created_at": "2015-12-02T09:41:31-08:00",
-            "event_id": "b9a2393a-20cf-4307-90f5-004110dec209",
-            "event_type": "ADD_LOGIN_ACTIVITY_DEVICE",
-            "ip_address": "Unknown IP",
-            "type": "event",
-            "session_id": null,
-            "additional_details": null
-        },
-        {
-            "source": {
                 "item_type": "file",
                 "item_id": "22222",
                 "item_name": "test.docx",
@@ -58,6 +37,27 @@
                 "ekm_id": "8afe49be-4ced-42cb-a3b0-8342a1cfe111",
                 "version_id": "77777"
             }
+        },
+        {
+            "source": {
+                "type": "user",
+                "id": "11111",
+                "name": "Test User",
+                "login": "testuser@example.com"
+            },
+            "created_by": {
+                "type": "user",
+                "id": "222853849",
+                "name": "Test User",
+                "login": "testuser@example.com"
+            },
+            "created_at": "2015-12-02T09:41:31-08:00",
+            "event_id": "b9a2393a-20cf-4307-90f5-004110dec209",
+            "event_type": "ADD_LOGIN_ACTIVITY_DEVICE",
+            "ip_address": "Unknown IP",
+            "type": "event",
+            "session_id": null,
+            "additional_details": null
         }
     ]
 }


### PR DESCRIPTION
### Issue Link :link:
- Deserialization error with enterprise events reported in issue #727.

### Goals :soccer:
- Fix deserialization issue for the `EventItem` model used when getting events.

### Implementation Details :construction:
- The sources of [events](https://developer.box.com/reference/resources/event#param-source) can have keys `item_id`, `item_type` and `item_name`. Our `EventItem` model could not handle these keys.

### Testing Details :mag:
- Added unit test
