### PR TITLE
Add error information to OAuth web session failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ __Breaking Changes:__
 
 __New Features and Enhancements:__
 
+- Add error information to OAuth web session failures
+
 __Bug Fixes:__
 
 - Fix bug with creating collaboration

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -361,7 +361,7 @@ public class BoxSDK {
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
-                        completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
+                    completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
                     return
                 }
 
@@ -389,7 +389,7 @@ public class BoxSDK {
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
-                        completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
+                    completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
                     return
                 }
 

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -361,7 +361,7 @@ public class BoxSDK {
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
-                    completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration)))
+                        completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
                     return
                 }
 
@@ -389,7 +389,7 @@ public class BoxSDK {
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
-                    completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration)))
+                        completion(.failure(BoxAPIAuthError(message: .invalidOAuthRedirectConfiguration, error: error)))
                     return
                 }
 


### PR DESCRIPTION
### Issue Link :link:
- #728

### Goals :soccer:
- Return a more detailed error when OAuth web session fails so developers can determine the cause of failure

### Implementation Details :construction:
- Pass in error to `BoxAPIAuthError()` in `obtainAuthorizationCodeFromWebSession()`

### Testing Details :mag:
- No testing
