### PR TITLE
Fix clearing of tokenInfo

### DIFF
--- a/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
+++ b/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
@@ -65,6 +65,7 @@ public class DelegatedAuthSession: SessionProtocol {
             switch result {
             case .success:
                 self.tokenStore.clear { _ in }
+                self.tokenInfo = nil
                 completion(.success(()))
             case let .failure(error):
                 completion(.failure(error))

--- a/Sources/Sessions/OAuth2/OAuth2Session.swift
+++ b/Sources/Sessions/OAuth2/OAuth2Session.swift
@@ -119,7 +119,6 @@ public class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
             switch result {
             case .success:
                 self.tokenStore.clear { _ in }
-                self.tokenInfo = nil
                 completion(.success(()))
             case let .failure(error):
                 completion(.failure(error))

--- a/Sources/Sessions/OAuth2/OAuth2Session.swift
+++ b/Sources/Sessions/OAuth2/OAuth2Session.swift
@@ -119,6 +119,7 @@ public class OAuth2Session: SessionProtocol, ExpiredTokenHandling {
             switch result {
             case .success:
                 self.tokenStore.clear { _ in }
+                self.tokenInfo = nil
                 completion(.success(()))
             case let .failure(error):
                 completion(.failure(error))


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
The revoked token was not properly clearing causing a 401 error. This fix clears the revoked token so the new token can be saved. 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
