### PR TITLE
Update cocoapods gem to patch activesupport security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', "~> 1.8.4"
+gem 'cocoapods', "~> 1.10.0"
 gem 'jazzy'
 gem 'danger'
 gem 'slather'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    activesupport (5.2.4.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
@@ -19,15 +19,14 @@ GEM
       nap
       open4 (~> 1.3)
     clamp (1.3.2)
-    cocoapods (1.8.4)
-      activesupport (>= 4.0.2, < 5)
+    cocoapods (1.10.0)
+      addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.8.4)
+      cocoapods-core (= 1.10.0)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-stats (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
@@ -37,19 +36,22 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.11.1, < 2.0)
-    cocoapods-core (1.8.4)
-      activesupport (>= 4.0.2, < 6)
+      xcodeproj (>= 1.19.0, < 2.0)
+    cocoapods-core (1.10.0)
+      activesupport (> 5.0, < 6)
+      addressable (~> 2.6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix
+      typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.4)
     cocoapods-downloader (1.4.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.5.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
@@ -72,6 +74,8 @@ GEM
       octokit (~> 4.7)
       terminal-table (~> 1)
     escape (0.0.4)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
@@ -84,7 +88,7 @@ GEM
     git (1.7.0)
       rchardet (~> 1.8)
     httpclient (2.8.3)
-    i18n (0.9.5)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jazzy (0.13.6)
       cocoapods (~> 1.5)
@@ -138,6 +142,8 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -154,7 +160,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.8.4)
+  cocoapods (~> 1.10.0)
   danger
   jazzy
   slather


### PR DESCRIPTION
### Issue Link :link:

- Security vulnerability in the ruby package activesupport, a dependency of cocoapods

### Goals :soccer:

- Upgrade cocoapods to version 1.10.0 to patch the security vulnerability

### Implementation Details :construction:

- Ran `bundle update cocoapods` to upgrade cocoapods' dependencies
- Note that the cocoapods upgrade from `1.8.4` -> `1.10.0` does include a breaking change, but it should have no impact on this project. The [cocoapods upgrade bumps the minimum Ruby version](https://github.com/CocoaPods/CocoaPods/releases/tag/1.10.0) to `2.3.3`. This should have no impact because this project's [Ruby version is already set to 2.4.5](https://github.com/box/box-ios-sdk/blob/master/.ruby-version).

### Testing Details :mag:

- Ran unit tests & TestApp
