### PR TITLE
Add support for OAuth 2 custom callback url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## Next Release
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+- Add support for OAuth 2 custom callback URL
+
+__Bug Fixes:__
+
 ## v4.2.0 [2020-11-16]
 
 __Breaking Changes:__

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -53,7 +53,7 @@ public class BoxSDK {
     ///     The text of that item is your application's client secret.
     ///   - callbackURL: An optional custom callback URL string. The URL to which Box redirects the browser when authentication completes.
     ///     The user's actual interaction with your application begins when Box redirects to this URL.
-    ///     If not specified, default URL is used in a format of `boxsdk-clientId://boxsdkoauth2redirect` with the real value of `clientId`.
+    ///     If not specified, the default URL is used, in the format of `boxsdk-CLIENTID://boxsdkoauth2redirect`, where CLIENTID is replaced with the value of the `clientId` parameter.
     public init(clientId: String, clientSecret: String, callbackURL: String? = nil) {
         // swiftlint:disable:next force_try
         configuration = try! BoxSDKConfiguration(clientId: clientId, clientSecret: clientSecret, callbackURL: callbackURL)

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -51,10 +51,9 @@ public class BoxSDK {
     ///     log in to your Box developer console and click the Edit Application link for the application you're working with.
     ///     In the OAuth 2 Parameters section of the configuration page, find the item labeled "client_secret".
     ///     The text of that item is your application's client secret.
-    ///   - callbackURL: An optional string containing the URI to load after the user completes the OAuth 2 webview authentication flow.
-    ///     This URI allows Box to redirect back to your app with an authentication code.
-    ///     This should be a custom url scheme registered to your app. Do not set this to a custom value,
-    ///     unless you are also setting a custom redirect URI in your app's developer settings.
+    ///   - callbackURL: An optional custom callback URL string. The URL to which Box redirects the browser when authentication completes.
+    ///     The user's actual interaction with your application begins when Box redirects to this URL.
+    ///     If not specified, default URL is used in a format of `boxsdk-clientId://boxsdkoauth2redirect` with the real value of `clientId`.
     public init(clientId: String, clientSecret: String, callbackURL: String? = nil) {
         // swiftlint:disable:next force_try
         configuration = try! BoxSDKConfiguration(clientId: clientId, clientSecret: clientSecret, callbackURL: callbackURL)
@@ -361,7 +360,7 @@ public class BoxSDK {
         @available(iOS 13.0, *)
         func obtainAuthorizationCodeFromWebSession(context: ASWebAuthenticationPresentationContextProviding, completion: @escaping Callback<String>) {
             let authorizeURL = makeAuthorizeURL(state: nonce)
-            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL ?? defaultCallbackURL, context: context) { resultURL, error in
+            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL, context: context) { resultURL, error in
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
@@ -389,7 +388,7 @@ public class BoxSDK {
     func obtainAuthorizationCodeFromWebSession(completion: @escaping Callback<String>) {
         let authorizeURL = makeAuthorizeURL(state: nonce)
         #if os(iOS)
-            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL ?? defaultCallbackURL) { resultURL, error in
+            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL) { resultURL, error in
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
@@ -465,15 +464,12 @@ extension BoxSDK {
     /// Creates OAuth2 authorization URL you can use in browser to authorize.
     ///
     /// - Parameters:
-    ///   - callbackURL: Custom callback URL string. The URL to which Box redirects the browser when authentication completes.
-    ///     The user's actual interaction with your application begins when Box redirects to this URL.
-    ///     If not specified, default URL is used in a format of `boxsdk-clientId://boxsdkoauth2redirect` with the real value of `clientId`.
     ///   - state: A text string that you choose. Box sends the same string to your redirect URL when authentication is complete.
     ///     This parameter is provided for your use in protecting against hijacked sessions and other attacks.
     /// - Returns: Standard URL object to be used for authorization in external browser.
-    public func makeAuthorizeURL(callbackURL: String? = nil, state: String? = nil) -> URL {
+    public func makeAuthorizeURL(state: String? = nil) -> URL {
         // swiftlint:disable:next line_length
-        var urlString = "\(configuration.oauth2AuthorizeURL)?\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)&\(BoxOAuth2ParamsKey.redirectURL)=\(callbackURL ?? self.configuration.callbackURL ?? defaultCallbackURL)"
+        var urlString = "\(configuration.oauth2AuthorizeURL)?\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)&\(BoxOAuth2ParamsKey.redirectURL)=\(configuration.callbackURL)"
 
         if let state = state {
             urlString.append("&\(BoxOAuth2ParamsKey.state)=\(state)")
@@ -489,10 +485,6 @@ extension BoxSDK {
         // swiftlint:disable:next force_unwrapping
         let randomCharacters = (0 ..< length).map { _ in characters.randomElement()! }
         return String(randomCharacters)
-    }
-
-    private var defaultCallbackURL: String {
-        return "boxsdk-\(configuration.clientId)://boxsdkoauth2redirect"
     }
 
     private func getURLComponentValueAt(key: String, from url: URL?) -> String? {

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -35,7 +35,6 @@ public class BoxSDK {
         private var webSession: AuthenticationSession?
     #endif
     private var networkAgent: BoxNetworkAgent
-    private var customCallbackURL: String?
 
     /// Auth module providing authorization and token related requests.
     /// Is set upon BoxSDK initialisation
@@ -52,9 +51,13 @@ public class BoxSDK {
     ///     log in to your Box developer console and click the Edit Application link for the application you're working with.
     ///     In the OAuth 2 Parameters section of the configuration page, find the item labeled "client_secret".
     ///     The text of that item is your application's client secret.
-    public init(clientId: String, clientSecret: String) {
+    ///   - callbackURL: An optional string containing the URI to load after the user completes the OAuth 2 webview authentication flow.
+    ///     This URI allows Box to redirect back to your app with an authentication code.
+    ///     This should be a custom url scheme registered to your app. Do not set this to a custom value,
+    ///     unless you are also setting a custom redirect URI in your app's developer settings.
+    public init(clientId: String, clientSecret: String, callbackURL: String? = nil) {
         // swiftlint:disable:next force_try
-        configuration = try! BoxSDKConfiguration(clientId: clientId, clientSecret: clientSecret)
+        configuration = try! BoxSDKConfiguration(clientId: clientId, clientSecret: clientSecret, callbackURL: callbackURL)
         networkAgent = BoxNetworkAgent(configuration: configuration)
         auth = AuthModule(networkAgent: networkAgent, configuration: configuration)
     }
@@ -182,12 +185,10 @@ public class BoxSDK {
         public func getOAuth2Client(
             tokenInfo: TokenInfo? = nil,
             tokenStore: TokenStore? = nil,
-            callbackURL: String? = nil,
             context: ASWebAuthenticationPresentationContextProviding,
             completion: @escaping Callback<BoxClient>
         ) {
             var designatedTokenStore: TokenStore
-            customCallbackURL = callbackURL
 
             if tokenInfo == nil, let unWrappedTokenStore = tokenStore {
                 designatedTokenStore = unWrappedTokenStore
@@ -242,11 +243,9 @@ public class BoxSDK {
     public func getOAuth2Client(
         tokenInfo: TokenInfo? = nil,
         tokenStore: TokenStore? = nil,
-        callbackURL: String? = nil,
         completion: @escaping Callback<BoxClient>
     ) {
         var designatedTokenStore: TokenStore
-        customCallbackURL = callbackURL
 
         if tokenInfo == nil, let unWrappedTokenStore = tokenStore {
             designatedTokenStore = unWrappedTokenStore
@@ -362,7 +361,7 @@ public class BoxSDK {
         @available(iOS 13.0, *)
         func obtainAuthorizationCodeFromWebSession(context: ASWebAuthenticationPresentationContextProviding, completion: @escaping Callback<String>) {
             let authorizeURL = makeAuthorizeURL(state: nonce)
-            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.customCallbackURL ?? defaultCallbackURL, context: context) { resultURL, error in
+            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL ?? defaultCallbackURL, context: context) { resultURL, error in
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
@@ -390,7 +389,7 @@ public class BoxSDK {
     func obtainAuthorizationCodeFromWebSession(completion: @escaping Callback<String>) {
         let authorizeURL = makeAuthorizeURL(state: nonce)
         #if os(iOS)
-            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.customCallbackURL ?? defaultCallbackURL) { resultURL, error in
+            webSession = AuthenticationSession(url: authorizeURL, callbackURLScheme: self.configuration.callbackURL ?? defaultCallbackURL) { resultURL, error in
                 guard error == nil,
                     let successURL = resultURL else {
                     print(error.debugDescription)
@@ -474,7 +473,7 @@ extension BoxSDK {
     /// - Returns: Standard URL object to be used for authorization in external browser.
     public func makeAuthorizeURL(callbackURL: String? = nil, state: String? = nil) -> URL {
         // swiftlint:disable:next line_length
-        var urlString = "\(configuration.oauth2AuthorizeURL)?\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)&\(BoxOAuth2ParamsKey.redirectURL)=\(callbackURL ?? self.customCallbackURL ?? defaultCallbackURL)"
+        var urlString = "\(configuration.oauth2AuthorizeURL)?\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)&\(BoxOAuth2ParamsKey.redirectURL)=\(callbackURL ?? self.configuration.callbackURL ?? defaultCallbackURL)"
 
         if let state = state {
             urlString.append("&\(BoxOAuth2ParamsKey.state)=\(state)")

--- a/Sources/Core/BoxSDKConfiguration.swift
+++ b/Sources/Core/BoxSDKConfiguration.swift
@@ -59,6 +59,11 @@ public struct BoxSDKConfiguration {
     public let consoleLogDestination: ConsoleLogDestination
     /// File log destination.
     public let fileLogDestination: FileLogDestination?
+    /// An optional string containing the URI to load after the user completes the OAuth 2 webview authentication flow.
+    /// This URI allows Box to redirect back to your app with an authentication code.
+    /// This should be a custom url scheme registered to your app. Do not set this to a custom value,
+    /// unless you are also setting a custom redirect URI in your app's developer settings.
+    public let callbackURL: String?
 
     /// Initializer
     ///
@@ -73,6 +78,7 @@ public struct BoxSDKConfiguration {
     ///   - consoleLogDestination: Console log destination.
     ///   - fileLogDestination: File log destination.
     ///   - clientAnalyticsInfo: Analytics info that is set to request headers.
+    ///   - callbackURL: Optional callback URL for OAuth 2 authentication flow
     init(
         clientId: String = "",
         clientSecret: String = "",
@@ -84,7 +90,8 @@ public struct BoxSDKConfiguration {
         retryBaseInterval: TimeInterval? = defaultRetryBaseInterval,
         consoleLogDestination: ConsoleLogDestination? = ConsoleLogDestination(),
         fileLogDestination: FileLogDestination? = nil,
-        clientAnalyticsInfo: ClientAnalyticsInfo? = nil
+        clientAnalyticsInfo: ClientAnalyticsInfo? = nil,
+        callbackURL: String? = nil
     ) throws {
         self.clientId = clientId
         self.clientSecret = clientSecret
@@ -92,6 +99,7 @@ public struct BoxSDKConfiguration {
         self.apiBaseURL = apiBaseURL ?? defaultAPIBaseURL
         self.uploadApiBaseURL = uploadApiBaseURL ?? defaultUploadAPIBaseURL
         self.oauth2AuthorizeURL = oauth2AuthorizeURL ?? defaultOAuth2AuthorizeURL
+        self.callbackURL = callbackURL
 
         try URLValidation.validate(networkUrl: self.apiBaseURL)
         try URLValidation.validate(networkUrl: self.uploadApiBaseURL)

--- a/Sources/Core/BoxSDKConfiguration.swift
+++ b/Sources/Core/BoxSDKConfiguration.swift
@@ -59,11 +59,10 @@ public struct BoxSDKConfiguration {
     public let consoleLogDestination: ConsoleLogDestination
     /// File log destination.
     public let fileLogDestination: FileLogDestination?
-    /// An optional string containing the URI to load after the user completes the OAuth 2 webview authentication flow.
-    /// This URI allows Box to redirect back to your app with an authentication code.
-    /// This should be a custom url scheme registered to your app. Do not set this to a custom value,
-    /// unless you are also setting a custom redirect URI in your app's developer settings.
-    public let callbackURL: String?
+    /// An optional custom callback URL string. The URL to which Box redirects the browser when authentication completes.
+    /// The user's actual interaction with your application begins when Box redirects to this URL.
+    /// If not specified, default URL is used in a format of `boxsdk-clientId://boxsdkoauth2redirect` with the real value of `clientId`.
+    public let callbackURL: String
 
     /// Initializer
     ///
@@ -99,7 +98,9 @@ public struct BoxSDKConfiguration {
         self.apiBaseURL = apiBaseURL ?? defaultAPIBaseURL
         self.uploadApiBaseURL = uploadApiBaseURL ?? defaultUploadAPIBaseURL
         self.oauth2AuthorizeURL = oauth2AuthorizeURL ?? defaultOAuth2AuthorizeURL
-        self.callbackURL = callbackURL
+
+        let defaultCallbackURL = "boxsdk-\(clientId)://boxsdkoauth2redirect"
+        self.callbackURL = callbackURL ?? defaultCallbackURL
 
         try URLValidation.validate(networkUrl: self.apiBaseURL)
         try URLValidation.validate(networkUrl: self.uploadApiBaseURL)

--- a/docs/usage/authentication.md
+++ b/docs/usage/authentication.md
@@ -107,6 +107,24 @@ sdk.getOAuth2Client() { result in
 }
 ```
 
+If your application requires a custom URL scheme that differs from the default format `boxsdk-<<CLIENT ID>>://boxsdkoauth2redirect`,
+you have the option to pass in a custom callback URL string when creating the SDK client. This is the URL to which Box will redirect the user
+when authentication completes. This requires that the application using the SDK registers itself for the same custom callback URL.
+
+```swift
+import BoxSDK
+
+let sdk = BoxSDK(clientId: "YOUR CLIENT ID HERE", clientSecret: "YOUR CLIENT SECRET HERE", callbackURL: "YOUR CALLBACK URL HERE")
+sdk.getOAuth2Client() { result in
+    switch result {
+    case let .success(client):
+        // Use client to make API calls
+    case let .failure(error):
+        // Handle error creating client
+    }
+}
+```
+
 Token Store
 -----------
 


### PR DESCRIPTION
### Issue Link :link:

- https://github.com/box/box-ios-sdk/issues/689

### Goals :soccer:

- Add support for OAuth 2 custom callback url

### Implementation Details :construction:

- Users now have the option to pass in a custom `callbackURL` when initializing the SDK: `BoxSDK(clientId: "YOUR CLIENT ID HERE", clientSecret: "YOUR CLIENT SECRET HERE", callbackURL: "YOUR CALLBACK URL HERE")`

### Testing Details :mag:

- Added unit tests & ran TestApp
