### PR TITLE
Add zip download support

### DIFF
--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -367,6 +367,9 @@
 		9DE5D7E022EF53E30081A031 /* EventItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE5D7DF22EF53E30081A031 /* EventItemType.swift */; };
 		9DEA474522D384520035C959 /* GetFileSharedLink.json in Resources */ = {isa = PBXBuildFile; fileRef = 9DEA474322D380A50035C959 /* GetFileSharedLink.json */; };
 		9DEA474922D391220035C959 /* GetFolderSharedLink.json in Resources */ = {isa = PBXBuildFile; fileRef = 9DEA474822D391220035C959 /* GetFolderSharedLink.json */; };
+		B40558AE25AD28C80068784E /* ZipDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558AD25AD28C80068784E /* ZipDownload.swift */; };
+		B40558B025AD2ABF0068784E /* ZipDownload.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558AF25AD2ABF0068784E /* ZipDownload.json */; };
+		B40558B125AD2AFC0068784E /* ZipDownload.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558AF25AD2ABF0068784E /* ZipDownload.json */; };
 		F90888EF246DAC110002267A /* URLSessionTaskExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */; };
 		F928142C233DA3AB00E42EEE /* MetadataFieldFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */; };
 		F9281444233E826E00E42EEE /* FullRetentionPolicyAssignment.json in Resources */ = {isa = PBXBuildFile; fileRef = F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */; };
@@ -400,9 +403,9 @@
 		F92CF9A52356A8430046A277 /* BoxAPIAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */; };
 		F941067223513DD00061A3F8 /* ArrayInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = F941067123513DD00061A3F8 /* ArrayInputStream.swift */; };
 		F9571FB42371F47400D30EF1 /* LoggingSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */; };
+		F95A81C124606DC300C46E98 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A81C024606DC300C46E98 /* UIColorExtension.swift */; };
 		F95D6F802451F6D0008B09CF /* BoxDownloadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95D6F7F2451F6D0008B09CF /* BoxDownloadTask.swift */; };
 		F95D6F832453415A008B09CF /* BoxUploadTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95D6F822453415A008B09CF /* BoxUploadTask.swift */; };
-		F95A81C124606DC300C46E98 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A81C024606DC300C46E98 /* UIColorExtension.swift */; };
 		F95D6F85245C9DFF008B09CF /* Classification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95D6F84245C9DFF008B09CF /* Classification.swift */; };
 		F969D37C233A7146001301FC /* StoragePoliciesModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D37B233A7146001301FC /* StoragePoliciesModule.swift */; };
 		F969D381233A71B4001301FC /* StoragePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F969D380233A71B4001301FC /* StoragePolicy.swift */; };
@@ -847,6 +850,8 @@
 		9DE5D7DF22EF53E30081A031 /* EventItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventItemType.swift; sourceTree = "<group>"; };
 		9DEA474322D380A50035C959 /* GetFileSharedLink.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GetFileSharedLink.json; sourceTree = "<group>"; };
 		9DEA474822D391220035C959 /* GetFolderSharedLink.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GetFolderSharedLink.json; sourceTree = "<group>"; };
+		B40558AD25AD28C80068784E /* ZipDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownload.swift; sourceTree = "<group>"; };
+		B40558AF25AD2ABF0068784E /* ZipDownload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownload.json; sourceTree = "<group>"; };
 		F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskExtension.swift; sourceTree = "<group>"; };
 		F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataFieldFilter.swift; sourceTree = "<group>"; };
 		F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FullRetentionPolicyAssignment.json; sourceTree = "<group>"; };
@@ -880,9 +885,9 @@
 		F92CF9A42356A8430046A277 /* BoxAPIAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxAPIAuthError.swift; sourceTree = "<group>"; };
 		F941067123513DD00061A3F8 /* ArrayInputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayInputStream.swift; sourceTree = "<group>"; };
 		F9571FB22371ECCB00D30EF1 /* LoggingSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingSpecs.swift; sourceTree = "<group>"; };
+		F95A81C024606DC300C46E98 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		F95D6F7F2451F6D0008B09CF /* BoxDownloadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxDownloadTask.swift; sourceTree = "<group>"; };
 		F95D6F822453415A008B09CF /* BoxUploadTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxUploadTask.swift; sourceTree = "<group>"; };
-		F95A81C024606DC300C46E98 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		F95D6F84245C9DFF008B09CF /* Classification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Classification.swift; sourceTree = "<group>"; };
 		F969D37B233A7146001301FC /* StoragePoliciesModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePoliciesModule.swift; sourceTree = "<group>"; };
 		F969D380233A71B4001301FC /* StoragePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePolicy.swift; sourceTree = "<group>"; };
@@ -1285,6 +1290,7 @@
 				F969D385233A71EF001301FC /* StoragePolicyAssignment.swift */,
 				F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */,
 				F95D6F84245C9DFF008B09CF /* Classification.swift */,
+				B40558AD25AD28C80068784E /* ZipDownload.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1430,6 +1436,7 @@
 				9DEA474322D380A50035C959 /* GetFileSharedLink.json */,
 				9DD0AA4422DDBFDD0028702B /* GetFileSharedLink_PasswordNotEnabled.json */,
 				9717866E22F0C9ED004A5F6D /* RemoveFileSharedLink.json */,
+				B40558AF25AD2ABF0068784E /* ZipDownload.json */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -2075,6 +2082,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B40558B025AD2ABF0068784E /* ZipDownload.json in Resources */,
 				8093D29822FA398500DB628E /* GetWebLink.json in Resources */,
 				8093D29A22FA399D00DB628E /* UpdateWebLink.json in Resources */,
 				80E5679822FB931300798E3A /* FullWebLink.json in Resources */,
@@ -2088,6 +2096,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B40558B125AD2AFC0068784E /* ZipDownload.json in Resources */,
 				22E60D6B2303207300E86A4A /* FileRepresentationState.json in Resources */,
 				F929D6152331AE280039E452 /* GetLegalHoldPolicies.json in Resources */,
 				92514E952319C9EB002D44A8 /* FullWatermark.json in Resources */,
@@ -2357,6 +2366,7 @@
 				224E1BEE22C57C8400F31F3A /* MetadataModule+Files.swift in Sources */,
 				225639EE22539E8F00D951B5 /* BoxSDK.swift in Sources */,
 				F92CF9A1235695F50046A277 /* BoxNetworkError.swift in Sources */,
+				B40558AE25AD28C80068784E /* ZipDownload.swift in Sources */,
 				0CCBC29A22841B0C00640FA8 /* TokenStore.swift in Sources */,
 				224E1BF322C57D4A00F31F3A /* MetadataModule+Templates.swift in Sources */,
 				225639522253897D00D951B5 /* BoxNetworkAgent.swift in Sources */,

--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -370,6 +370,10 @@
 		B40558AE25AD28C80068784E /* ZipDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558AD25AD28C80068784E /* ZipDownload.swift */; };
 		B40558B025AD2ABF0068784E /* ZipDownload.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558AF25AD2ABF0068784E /* ZipDownload.json */; };
 		B40558B125AD2AFC0068784E /* ZipDownload.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558AF25AD2ABF0068784E /* ZipDownload.json */; };
+		B40558B725AE54680068784E /* ZipDownloadStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558B625AE54680068784E /* ZipDownloadStatus.swift */; };
+		B40558B925AE54810068784E /* ZipDownloadItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558B825AE54810068784E /* ZipDownloadItem.swift */; };
+		B40558BB25AE57C10068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
+		B40558BC25AE58540068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
 		F90888EF246DAC110002267A /* URLSessionTaskExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */; };
 		F928142C233DA3AB00E42EEE /* MetadataFieldFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */; };
 		F9281444233E826E00E42EEE /* FullRetentionPolicyAssignment.json in Resources */ = {isa = PBXBuildFile; fileRef = F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */; };
@@ -852,6 +856,9 @@
 		9DEA474822D391220035C959 /* GetFolderSharedLink.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GetFolderSharedLink.json; sourceTree = "<group>"; };
 		B40558AD25AD28C80068784E /* ZipDownload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownload.swift; sourceTree = "<group>"; };
 		B40558AF25AD2ABF0068784E /* ZipDownload.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownload.json; sourceTree = "<group>"; };
+		B40558B625AE54680068784E /* ZipDownloadStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadStatus.swift; sourceTree = "<group>"; };
+		B40558B825AE54810068784E /* ZipDownloadItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadItem.swift; sourceTree = "<group>"; };
+		B40558BA25AE57C10068784E /* ZipDownloadStatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownloadStatus.json; sourceTree = "<group>"; };
 		F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskExtension.swift; sourceTree = "<group>"; };
 		F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataFieldFilter.swift; sourceTree = "<group>"; };
 		F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FullRetentionPolicyAssignment.json; sourceTree = "<group>"; };
@@ -1291,6 +1298,8 @@
 				F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */,
 				F95D6F84245C9DFF008B09CF /* Classification.swift */,
 				B40558AD25AD28C80068784E /* ZipDownload.swift */,
+				B40558B625AE54680068784E /* ZipDownloadStatus.swift */,
+				B40558B825AE54810068784E /* ZipDownloadItem.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1437,6 +1446,7 @@
 				9DD0AA4422DDBFDD0028702B /* GetFileSharedLink_PasswordNotEnabled.json */,
 				9717866E22F0C9ED004A5F6D /* RemoveFileSharedLink.json */,
 				B40558AF25AD2ABF0068784E /* ZipDownload.json */,
+				B40558BA25AE57C10068784E /* ZipDownloadStatus.json */,
 			);
 			path = Files;
 			sourceTree = "<group>";
@@ -2087,6 +2097,7 @@
 				8093D29A22FA399D00DB628E /* UpdateWebLink.json in Resources */,
 				80E5679822FB931300798E3A /* FullWebLink.json in Resources */,
 				80E5679F2303683100798E3A /* GetWebLinkSharedLink_PasswordNotEnabled.json in Resources */,
+				B40558BB25AE57C10068784E /* ZipDownloadStatus.json in Resources */,
 				806ACE4D22FB8E0000257353 /* GetWebLinkSharedLink.json in Resources */,
 				80E567B523061A5000798E3A /* RemoveWebLinkSharedLink.json in Resources */,
 			);
@@ -2096,6 +2107,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B40558BC25AE58540068784E /* ZipDownloadStatus.json in Resources */,
 				B40558B125AD2AFC0068784E /* ZipDownload.json in Resources */,
 				22E60D6B2303207300E86A4A /* FileRepresentationState.json in Resources */,
 				F929D6152331AE280039E452 /* GetLegalHoldPolicies.json in Resources */,
@@ -2367,6 +2379,7 @@
 				225639EE22539E8F00D951B5 /* BoxSDK.swift in Sources */,
 				F92CF9A1235695F50046A277 /* BoxNetworkError.swift in Sources */,
 				B40558AE25AD28C80068784E /* ZipDownload.swift in Sources */,
+				B40558B725AE54680068784E /* ZipDownloadStatus.swift in Sources */,
 				0CCBC29A22841B0C00640FA8 /* TokenStore.swift in Sources */,
 				224E1BF322C57D4A00F31F3A /* MetadataModule+Templates.swift in Sources */,
 				225639522253897D00D951B5 /* BoxNetworkAgent.swift in Sources */,
@@ -2436,6 +2449,7 @@
 				97F04DAF22B96BA60034B9A3 /* TaskAssignment.swift in Sources */,
 				223A7F2422770A6E00C136E1 /* EncodableExtension.swift in Sources */,
 				223A7F2822770A6E00C136E1 /* URLComponentsExtension.swift in Sources */,
+				B40558B925AE54810068784E /* ZipDownloadItem.swift in Sources */,
 				1772A480230EBEBC00546866 /* EventContainer.swift in Sources */,
 				0C10B2CE22AA8D130035371D /* CollaborationItem.swift in Sources */,
 				97F04DB322B97E500034B9A3 /* Collaborator.swift in Sources */,

--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -374,6 +374,8 @@
 		B40558B925AE54810068784E /* ZipDownloadItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558B825AE54810068784E /* ZipDownloadItem.swift */; };
 		B40558BB25AE57C10068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
 		B40558BC25AE58540068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
+		B492C0AB25B78A4500F3823D /* ZipDownloadConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */; };
+		B492C0AD25B78A6A00F3823D /* ZipDownloadConflictItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */; };
 		F90888EF246DAC110002267A /* URLSessionTaskExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */; };
 		F928142C233DA3AB00E42EEE /* MetadataFieldFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */; };
 		F9281444233E826E00E42EEE /* FullRetentionPolicyAssignment.json in Resources */ = {isa = PBXBuildFile; fileRef = F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */; };
@@ -859,6 +861,8 @@
 		B40558B625AE54680068784E /* ZipDownloadStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadStatus.swift; sourceTree = "<group>"; };
 		B40558B825AE54810068784E /* ZipDownloadItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadItem.swift; sourceTree = "<group>"; };
 		B40558BA25AE57C10068784E /* ZipDownloadStatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownloadStatus.json; sourceTree = "<group>"; };
+		B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadConflict.swift; sourceTree = "<group>"; };
+		B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadConflictItem.swift; sourceTree = "<group>"; };
 		F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskExtension.swift; sourceTree = "<group>"; };
 		F928142B233DA3AB00E42EEE /* MetadataFieldFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataFieldFilter.swift; sourceTree = "<group>"; };
 		F9281430233E814400E42EEE /* FullRetentionPolicyAssignment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FullRetentionPolicyAssignment.json; sourceTree = "<group>"; };
@@ -1300,6 +1304,8 @@
 				B40558AD25AD28C80068784E /* ZipDownload.swift */,
 				B40558B625AE54680068784E /* ZipDownloadStatus.swift */,
 				B40558B825AE54810068784E /* ZipDownloadItem.swift */,
+				B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */,
+				B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -2414,6 +2420,8 @@
 				2228B19422C0C908001F759D /* FolderUploadEmail.swift in Sources */,
 				0C8B8DFC2285CA2C00D8A42F /* FileLogDestination.swift in Sources */,
 				F95D6F802451F6D0008B09CF /* BoxDownloadTask.swift in Sources */,
+				B492C0AB25B78A4500F3823D /* ZipDownloadConflict.swift in Sources */,
+				B492C0AD25B78A6A00F3823D /* ZipDownloadConflictItem.swift in Sources */,
 				225639AE2253897D00D951B5 /* FoldersModule.swift in Sources */,
 				0C4A9D18226DBCB4002D069D /* BoxSDKConfiguration.swift in Sources */,
 				8053E2C622AF06FF000B42E1 /* SharedItemsModule.swift in Sources */,

--- a/Sources/Core/BoxJSONDecoder.swift
+++ b/Sources/Core/BoxJSONDecoder.swift
@@ -164,6 +164,21 @@ class BoxJSONDecoder {
         return color
     }
 
+    static func optionalDecodeZip<T>(json: [[String: Any]]) throws -> T? where T: BoxModel {
+        var modelJSON: [String: Any] = [:]
+        modelJSON["conflict"] = json
+
+        return try decode(json: modelJSON)
+    }
+
+    static func optionalDecodeZipCollection<T>(json: [String: Any], forKey key: String) throws -> [T]? where T: BoxModel {
+        guard let modelCollectionJSON: [[[String: Any]]] = try optionalExtractJSON(json: json, key: key) else {
+            return nil
+        }
+
+        return try modelCollectionJSON.compactMap { try optionalDecodeZip(json: $0) }
+    }
+
     // MARK: - Decodes
 
     static func decode<T>(json: [String: Any]) throws -> T where T: BoxModel {

--- a/Sources/Modules/FilesModule.swift
+++ b/Sources/Modules/FilesModule.swift
@@ -1227,7 +1227,7 @@ public class FilesModule {
             switch result {
             case let .success(zip):
                 self.boxClient.download(
-                    url: URL.boxAPIEndpoint(zip.downloadUrl.absoluteString, configuration: self.boxClient.configuration),
+                    url: zip.downloadUrl,
                     downloadDestinationURL: destinationURL
                 ) { [weak self] zipDownloadResult in
                     guard let self = self else {

--- a/Sources/Modules/FilesModule.swift
+++ b/Sources/Modules/FilesModule.swift
@@ -1194,7 +1194,7 @@ public class FilesModule {
     ///   - name: The name of the zip file to be created
     ///   - items: Array of files or folders to be part of the created zip
     ///   - completion: Returns a standard ZipDownload object or an error
-    public func createZip(
+    private func createZip(
         name: String,
         items: [ZipDownloadItem],
         completion: @escaping Callback<ZipDownload>

--- a/Sources/Responses/ZipDownload.swift
+++ b/Sources/Responses/ZipDownload.swift
@@ -21,7 +21,7 @@ public class ZipDownload: BoxModel {
     /// Expiration date of the Zip file download.
     public let expiresAt: Date?
     /// Conflicts that occur between items that have the same name.
-    public let nameConflicts: [[[String: String]]]?
+    public let nameConflicts: [ZipDownloadConflict]?
 
 
     /// Initializer.
@@ -33,6 +33,6 @@ public class ZipDownload: BoxModel {
         downloadUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "download_url")
         statusUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "status_url")
         expiresAt = try BoxJSONDecoder.optionalDecodeDate(json: json, forKey: "expires_at")
-        nameConflicts = json["name_conflicts"] as? [[[String: String]]]
+        nameConflicts = try BoxJSONDecoder.optionalDecodeZipCollection(json: json, forKey: "name_conflicts")
     }
 }

--- a/Sources/Responses/ZipDownload.swift
+++ b/Sources/Responses/ZipDownload.swift
@@ -1,0 +1,38 @@
+//
+//  ZipDownload.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 1/11/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a Zip Download
+public class ZipDownload: BoxModel {
+    // MARK: - Properties
+
+    public private(set) var rawData: [String: Any]
+
+    /// The URL to download the Zip file. If entered in a browser, this URL will trigger a download of the Zip file.
+    public let downloadUrl: URL
+    /// The URL to monitor the status of the download.
+    public let statusUrl: URL
+    /// Expiration date of the Zip file download.
+    public let expiresAt: Date?
+    /// Conflicts that occur between items that have the same name.
+    public let nameConflicts: [[String: String]]?
+
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary.
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        rawData = json
+        downloadUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "download_url")
+        statusUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "status_url")
+        expiresAt = try BoxJSONDecoder.optionalDecodeDate(json: json, forKey: "expires_at")
+        nameConflicts = json["name_conflicts"] as? [[String: String]]
+    }
+}

--- a/Sources/Responses/ZipDownload.swift
+++ b/Sources/Responses/ZipDownload.swift
@@ -21,7 +21,7 @@ public class ZipDownload: BoxModel {
     /// Expiration date of the Zip file download.
     public let expiresAt: Date?
     /// Conflicts that occur between items that have the same name.
-    public let nameConflicts: [[String: String]]?
+    public let nameConflicts: [[[String: String]]]?
 
 
     /// Initializer.
@@ -33,6 +33,6 @@ public class ZipDownload: BoxModel {
         downloadUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "download_url")
         statusUrl = try BoxJSONDecoder.decodeURL(json: json, forKey: "status_url")
         expiresAt = try BoxJSONDecoder.optionalDecodeDate(json: json, forKey: "expires_at")
-        nameConflicts = json["name_conflicts"] as? [[String: String]]
+        nameConflicts = json["name_conflicts"] as? [[[String: String]]]
     }
 }

--- a/Sources/Responses/ZipDownloadConflict.swift
+++ b/Sources/Responses/ZipDownloadConflict.swift
@@ -1,0 +1,28 @@
+//
+//  ZipDownloadConflict.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 1/19/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a Zip Download Conflict
+public class ZipDownloadConflict: BoxModel {
+    // MARK: - Properties
+
+    public private(set) var rawData: [String: Any]
+
+    /// Conflict that occurs between items that have the same name.
+    public let conflict: [ZipDownloadConflictItem]?
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary.
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        rawData = json
+        conflict = try BoxJSONDecoder.optionalDecodeCollection(json: json, forKey: "conflict")
+    }
+}

--- a/Sources/Responses/ZipDownloadConflictItem.swift
+++ b/Sources/Responses/ZipDownloadConflictItem.swift
@@ -1,0 +1,38 @@
+//
+//  ZipDownloadConflictItem.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 1/19/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a Zip Download Conflict Item
+public class ZipDownloadConflictItem: BoxModel {
+
+    // MARK: - Properties
+
+    public private(set) var rawData: [String: Any]
+
+    /// Identfier
+    public let id: String
+    /// Box item type - file or folder.
+    public let type: String
+    /// The original name of the item that has the conflict
+    public let originalName: String
+    /// The new name of the item when it downloads that resolves the conflict
+    public let downloadName: String
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary.
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        rawData = json
+        id = try BoxJSONDecoder.decode(json: json, forKey: "id")
+        type = try BoxJSONDecoder.decode(json: json, forKey: "type")
+        originalName = try BoxJSONDecoder.decode(json: json, forKey: "original_name")
+        downloadName = try BoxJSONDecoder.decode(json: json, forKey: "download_name")
+    }
+}

--- a/Sources/Responses/ZipDownloadItem.swift
+++ b/Sources/Responses/ZipDownloadItem.swift
@@ -1,0 +1,33 @@
+//
+//  ZipDownloadItem.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 1/12/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Item field for creating a Zip download.
+public struct ZipDownloadItem: BoxInnerModel {
+
+    // MARK: - Properties
+
+    /// Identfier
+    public let id: String
+    /// Box item type - should be file or folder.
+    public let type: String
+
+    /// Initializer.
+    ///
+    /// - Parameters:
+    ///   - id: Identfier
+    ///   - type: Box item type - should be file or folder
+    public init(
+        id: String,
+        type: String
+    ) {
+        self.id = id
+        self.type = type
+    }
+}

--- a/Sources/Responses/ZipDownloadStatus.swift
+++ b/Sources/Responses/ZipDownloadStatus.swift
@@ -24,7 +24,7 @@ public class ZipDownloadStatus: BoxModel {
     public let skippedFolderCount: Int
     /// State of the download for the zip file
     public let state: String
-    /// Conflicts that occur between items that have the same name. This is manually added in the FilesModule.getZipDownloadStatus() method.
+    /// Conflicts that occur between items that have the same name. This is always initially nil and updated manually later, via the FilesModule.getZipDownloadStatus() method.
     public var nameConflicts: [ZipDownloadConflict]?
 
 

--- a/Sources/Responses/ZipDownloadStatus.swift
+++ b/Sources/Responses/ZipDownloadStatus.swift
@@ -1,0 +1,41 @@
+//
+//  ZipDownloadStatus.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 1/12/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Status of a Zip download
+public class ZipDownloadStatus: BoxModel {
+    // MARK: - Properties
+
+    public private(set) var rawData: [String: Any]
+
+    /// The total number of files in the zip
+    public let totalFileCount: Int
+    /// The number of files in the zip that were downloaded
+    public let downloadedFileCount: Int
+    /// The number of files that were skipped when downloading
+    public let skippedFileCount: Int
+    /// The number of folders that were skipped when downloading
+    public let skippedFolderCount: Int
+    /// State of the download for the zip file
+    public let state: String
+
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary.
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        rawData = json
+        totalFileCount = try BoxJSONDecoder.decode(json: json, forKey: "total_file_count")
+        downloadedFileCount = try BoxJSONDecoder.decode(json: json, forKey: "downloaded_file_count")
+        skippedFileCount = try BoxJSONDecoder.decode(json: json, forKey: "skipped_file_count")
+        skippedFolderCount = try BoxJSONDecoder.decode(json: json, forKey: "skipped_folder_count")
+        state = try BoxJSONDecoder.decode(json: json, forKey: "state")
+    }
+}

--- a/Sources/Responses/ZipDownloadStatus.swift
+++ b/Sources/Responses/ZipDownloadStatus.swift
@@ -24,6 +24,8 @@ public class ZipDownloadStatus: BoxModel {
     public let skippedFolderCount: Int
     /// State of the download for the zip file
     public let state: String
+    /// Conflicts that occur between items that have the same name. This is manually added in the FilesModule.getZipDownloadStatus() method.
+    public var nameConflicts: [ZipDownloadConflict]?
 
 
     /// Initializer.
@@ -37,5 +39,6 @@ public class ZipDownloadStatus: BoxModel {
         skippedFileCount = try BoxJSONDecoder.decode(json: json, forKey: "skipped_file_count")
         skippedFolderCount = try BoxJSONDecoder.decode(json: json, forKey: "skipped_folder_count")
         state = try BoxJSONDecoder.decode(json: json, forKey: "state")
+        nameConflicts = nil
     }
 }

--- a/Tests/Modules/FilesModuleSpecs.swift
+++ b/Tests/Modules/FilesModuleSpecs.swift
@@ -1875,49 +1875,6 @@ class FilesModuleSpecs: QuickSpec {
             })
         }
 
-        describe("createZip()") {
-            it("should produce zip download model when API call succeeds") {
-                stub(
-                    condition: isHost("api.box.com") &&
-                    isPath("/2.0/zip_downloads") &&
-                    isMethodPOST() &&
-                    hasJsonBody([
-                        "download_file_name": "New zip file",
-                        "items": [[
-                            "type": "file",
-                            "id": "5000948880"
-                        ]]
-                    ])
-                ) { _ in
-                    OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ZipDownload.json", type(of: self))!,
-                        statusCode: 202, headers: ["Content-Type": "application/json"]
-                    )
-                }
-
-                waitUntil(timeout: 10) { done in
-                    var items: [ZipDownloadItem] = []
-                    items.append(ZipDownloadItem(
-                        id: "5000948880",
-                        type: "file"
-                    ))
-                    self.sut.files.createZip(name: "New zip file", items: items, completion: { result in
-                        switch result {
-                        case let .success(file):
-                            expect(file).toNot(beNil())
-                            expect(file.expiresAt).to(equal(Date(fromISO8601String: "2020-07-22T11:26:08Z")))
-                            expect(file.downloadUrl).toNot(beNil())
-                            expect(file.nameConflicts).toNot(beNil())
-                            expect(file.nameConflicts?[0].conflict?[0].downloadName).to(equal("3aa6a7.pdf"))
-                        case let .failure(error):
-                            fail("Expected call to succeed, but instead got \(error)")
-                        }
-                        done()
-                    })
-                }
-            }
-        }
-
         describe("downloadZip()") {
             context("Download zip file to the provided destination folder") {
                 let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]

--- a/Tests/Modules/FilesModuleSpecs.swift
+++ b/Tests/Modules/FilesModuleSpecs.swift
@@ -1907,6 +1907,8 @@ class FilesModuleSpecs: QuickSpec {
                             expect(file).toNot(beNil())
                             expect(file.expiresAt).to(equal(Date(fromISO8601String: "2020-07-22T11:26:08Z")))
                             expect(file.downloadUrl).toNot(beNil())
+                            expect(file.nameConflicts).toNot(beNil())
+                            expect(file.nameConflicts?[0].conflict?[0].downloadName).to(equal("3aa6a7.pdf"))
                         case let .failure(error):
                             fail("Expected call to succeed, but instead got \(error)")
                         }

--- a/Tests/Modules/FilesModuleSpecs.swift
+++ b/Tests/Modules/FilesModuleSpecs.swift
@@ -1937,6 +1937,7 @@ class FilesModuleSpecs: QuickSpec {
 
                                 expect(fileContents).to(equal("Downloaded zip"))
                                 expect(status.state).to(equal("succeeded"))
+                                expect(status.nameConflicts?[0].conflict?[0].downloadName).to(equal("3aa6a7.pdf"))
 
                             case let .failure(error):
                                 fail("Expected call to downloadZip to suceeded, but instead got \(error)")

--- a/Tests/Stubs/Resources/Files/ZipDownload.json
+++ b/Tests/Stubs/Resources/Files/ZipDownload.json
@@ -1,0 +1,21 @@
+{
+    "download_url": "https://dl.boxcloud.com/2.0/zip_downloads/29l00nfxDyHOt7RphI9zT_w==nDnZEDjY2S8iEWWCHEEiptFxwoWojjlibZjJ6geuE5xnXENDTPxzgbks_yY=/content",
+    "status_url": "https://api.box.com/2.0/zip_downloads/29l00nfxDyHOt7RphI9zT_w==nDnZEDjY2S8iEWWCHEEiptFxwoWojjlibZjJ6geuE5xnXENDTPxzgbks_yY=/status",
+    "expires_at": "2020-07-22T11:26:08Z",
+    "name_conflicts": [
+        [
+            {
+                "id": "12345",
+                "type": "file",
+                "original_name": "Report.pdf",
+                "download_name": "3aa6a7.pdf"
+            },
+            {
+                "id": "34325",
+                "type": "file",
+                "original_name": "Report.pdf",
+                "download_name": "5d53f2.pdf"
+            }
+        ]
+    ]
+}

--- a/Tests/Stubs/Resources/Files/ZipDownloadStatus.json
+++ b/Tests/Stubs/Resources/Files/ZipDownloadStatus.json
@@ -1,0 +1,7 @@
+{
+    "total_file_count": 1,
+    "downloaded_file_count": 1,
+    "skipped_file_count": 0,
+    "skipped_folder_count": 0,
+    "state": "succeeded"
+}

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -521,29 +521,6 @@ client.files.listRepresentations(
 
 [get-representations]: https://opensource.box.com/box-ios-sdk/Classes/FilesModule.html#/s:6BoxSDK11FilesModuleC19listRepresentations6fileId18representationHint10completionySS_AA018FileRepresentationJ0OSgys6ResultOySayAA0lM0VGAA0A8SDKErrorCGctF
 
-Create Zip
--------------------
-
-Calling [`client.files.createZip(name:items:completion:)`][create-zip] will let you create a new zip file with the specified name and with the specified items and will return a response with the download and status link. This file does not show up in your Box account, but will be temporarily available for download.
-
-<!-- sample create_zip -->
-```swift
-let name = "New zip name"
-var items: [ZipDownloadItem] = []
-items.append(ZipDownloadItem(
-    type: "file",
-    id: "11111"
-))
-client.files.createZip(name: name, items: items) { (result: Result<ZipDownload, BoxSDKError>) in
-    guard case let .success(zip) = result else {
-        print("Error creating zip")
-        return
-    }
-
-    print("Zip file URL is \(zip.downloadUrl.absoluteString)")
-}
-```
-
 Download Zip
 -------------------
 

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -529,7 +529,11 @@ Calling [`client.files.createZip(name:items:completion:)`][create-zip] will let 
 <!-- sample create_zip -->
 ```swift
 let name = "New zip name"
-let items: [[String: String]] = [["type": "file", "id": "11111"]]
+var items: [ZipDownloadItem] = []
+items.append(ZipDownloadItem(
+    type: "file",
+    id: "11111"
+))
 client.files.createZip(name: name, items: items) { (result: Result<ZipDownload, BoxSDKError>) in
     guard case let .success(zip) = result else {
         print("Error creating zip")
@@ -548,17 +552,27 @@ Calling [`client.files.downloadZip(name:items:destinationURL:completion:)`][down
 <!-- sample download_zip -->
 ```swift
 let name = "New zip name"
-let items: [[String: String]] = [["type": "file", "id": "11111"], ["type": "folder", "id": "22222"]]
+var items: [ZipDownloadItem] = []
+items.append(ZipDownloadItem(
+    type: "file",
+    id: "11111"
+))
+let items: [ZipDownloadItem] = []
+items.append(ZipDownloadItem(
+    type: "folder",
+    id: "22222"
+))
 let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
 let destinationURL = documentsURL.appendingPathComponent("New zip name.zip")
 
 
-client.files.downloadZip(name: name, items: items, destinationURL: destinationURL) { (result: Result<Void, BoxSDKError>) in
+client.files.downloadZip(name: name, items: items, destinationURL: destinationURL) { (result: Result<ZipDownloadStatus, BoxSDKError>) in
     guard case .success = result else {
+    guard case let .success(zipDownloadStatus) = result else {
         print("Error downloading zip")
         return
     }
 
-    print("Zip downloaded successfully")
+    print("Zip download status: \(zipDownloadStatus.state)")
 }
 ```

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -554,5 +554,3 @@ client.files.downloadZip(name: name, items: items, destinationURL: destinationUR
     print("Zip download status: \(zipDownloadStatus.state)")
 }
 ```
-
-[download-zip]: https://opensource.box.com/box-ios-sdk/Classes/FilesModule.html

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -520,3 +520,45 @@ client.files.listRepresentations(
 ```
 
 [get-representations]: https://opensource.box.com/box-ios-sdk/Classes/FilesModule.html#/s:6BoxSDK11FilesModuleC19listRepresentations6fileId18representationHint10completionySS_AA018FileRepresentationJ0OSgys6ResultOySayAA0lM0VGAA0A8SDKErrorCGctF
+
+Create Zip
+-------------------
+
+Calling [`client.files.createZip(name:items:completion:)`][create-zip] will let you create a new zip file with the specified name and with the specified items and will return a response with the download and status link. This file does not show up in your Box account, but will be temporarily available for download.
+
+<!-- sample create_zip -->
+```swift
+let name = "New zip name"
+let items: [[String: String]] = [["type": "file", "id": "11111"]]
+client.files.createZip(name: name, items: items) { (result: Result<ZipDownload, BoxSDKError>) in
+    guard case let .success(zip) = result else {
+        print("Error creating zip")
+        return
+    }
+
+    print("Zip file URL is \(zip.downloadUrl.absoluteString)")
+}
+```
+
+Download Zip
+-------------------
+
+Calling [`client.files.downloadZip(name:items:destinationURL:completion:)`][download-zip] will let you create a new zip file with the specified name and with the specified items and download it to the specified URL location where the file should be downloaded to. The created zip file does not show up in your Box account.
+
+<!-- sample download_zip -->
+```swift
+let name = "New zip name"
+let items: [[String: String]] = [["type": "file", "id": "11111"], ["type": "folder", "id": "22222"]]
+let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+let destinationURL = documentsURL.appendingPathComponent("New zip name.zip")
+
+
+client.files.downloadZip(name: name, items: items, destinationURL: destinationURL) { (result: Result<Void, BoxSDKError>) in
+    guard case .success = result else {
+        print("Error downloading zip")
+        return
+    }
+
+    print("Zip downloaded successfully")
+}
+```

--- a/docs/usage/files.md
+++ b/docs/usage/files.md
@@ -28,6 +28,7 @@ file's contents, upload new versions, and perform other common file operations
 - [Set Shared Link](#set-shared-link)
 - [Remove Shared Link](#remove-shared-link)
 - [Get Representations](#get-representations)
+- [Download Zip](#download-zip)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -553,3 +554,5 @@ client.files.downloadZip(name: name, items: items, destinationURL: destinationUR
     print("Zip download status: \(zipDownloadStatus.state)")
 }
 ```
+
+[download-zip]: https://opensource.box.com/box-ios-sdk/Classes/FilesModule.html


### PR DESCRIPTION
### Goals :soccer:

- Add support for zip download functionality

### Implementation Details :construction:

- Users can now create and download zip files by calling `client.files.downloadZip(name:items:destinationURL:completion:)`.

### Testing Details :mag:

- Added unit tests & tested manually
