### PR TITLE
Add support for search param to get shared link items

### DIFF
--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -374,6 +374,9 @@
 		B40558B925AE54810068784E /* ZipDownloadItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40558B825AE54810068784E /* ZipDownloadItem.swift */; };
 		B40558BB25AE57C10068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
 		B40558BC25AE58540068784E /* ZipDownloadStatus.json in Resources */ = {isa = PBXBuildFile; fileRef = B40558BA25AE57C10068784E /* ZipDownloadStatus.json */; };
+		B41D9DB325D33456000BFE59 /* SearchResult200.json in Resources */ = {isa = PBXBuildFile; fileRef = B41D9DB225D33456000BFE59 /* SearchResult200.json */; };
+		B41D9DB525D3347C000BFE59 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D9DB425D3347C000BFE59 /* SearchResult.swift */; };
+		B41D9DB625D335F2000BFE59 /* SearchResult200.json in Resources */ = {isa = PBXBuildFile; fileRef = B41D9DB225D33456000BFE59 /* SearchResult200.json */; };
 		B492C0AB25B78A4500F3823D /* ZipDownloadConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */; };
 		B492C0AD25B78A6A00F3823D /* ZipDownloadConflictItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */; };
 		F90888EF246DAC110002267A /* URLSessionTaskExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */; };
@@ -861,6 +864,8 @@
 		B40558B625AE54680068784E /* ZipDownloadStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadStatus.swift; sourceTree = "<group>"; };
 		B40558B825AE54810068784E /* ZipDownloadItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadItem.swift; sourceTree = "<group>"; };
 		B40558BA25AE57C10068784E /* ZipDownloadStatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownloadStatus.json; sourceTree = "<group>"; };
+		B41D9DB225D33456000BFE59 /* SearchResult200.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SearchResult200.json; sourceTree = "<group>"; };
+		B41D9DB425D3347C000BFE59 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadConflict.swift; sourceTree = "<group>"; };
 		B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipDownloadConflictItem.swift; sourceTree = "<group>"; };
 		F90888EE246DAC110002267A /* URLSessionTaskExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskExtension.swift; sourceTree = "<group>"; };
@@ -1306,6 +1311,7 @@
 				B40558B825AE54810068784E /* ZipDownloadItem.swift */,
 				B492C0AA25B78A4500F3823D /* ZipDownloadConflict.swift */,
 				B492C0AC25B78A6A00F3823D /* ZipDownloadConflictItem.swift */,
+				B41D9DB425D3347C000BFE59 /* SearchResult.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1775,6 +1781,7 @@
 			isa = PBXGroup;
 			children = (
 				9731D2C3227D19860092BCCE /* Search200.json */,
+				B41D9DB225D33456000BFE59 /* SearchResult200.json */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -2106,6 +2113,7 @@
 				B40558BB25AE57C10068784E /* ZipDownloadStatus.json in Resources */,
 				806ACE4D22FB8E0000257353 /* GetWebLinkSharedLink.json in Resources */,
 				80E567B523061A5000798E3A /* RemoveWebLinkSharedLink.json in Resources */,
+				B41D9DB325D33456000BFE59 /* SearchResult200.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2113,6 +2121,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B41D9DB625D335F2000BFE59 /* SearchResult200.json in Resources */,
 				B40558BC25AE58540068784E /* ZipDownloadStatus.json in Resources */,
 				B40558B125AD2AFC0068784E /* ZipDownload.json in Resources */,
 				22E60D6B2303207300E86A4A /* FileRepresentationState.json in Resources */,
@@ -2383,6 +2392,7 @@
 				2228B19322C0C8F5001F759D /* Lock.swift in Sources */,
 				224E1BEE22C57C8400F31F3A /* MetadataModule+Files.swift in Sources */,
 				225639EE22539E8F00D951B5 /* BoxSDK.swift in Sources */,
+				B41D9DB525D3347C000BFE59 /* SearchResult.swift in Sources */,
 				F92CF9A1235695F50046A277 /* BoxNetworkError.swift in Sources */,
 				B40558AE25AD28C80068784E /* ZipDownload.swift in Sources */,
 				B40558B725AE54680068784E /* ZipDownloadStatus.swift in Sources */,

--- a/Sources/Modules/SearchModule.swift
+++ b/Sources/Modules/SearchModule.swift
@@ -237,4 +237,87 @@ public class SearchModule {
             completion: ResponseHandler.pagingIterator(client: boxClient, wrapping: completion)
         )
     }
+
+    /// Searches for items in Box, including items that a user might have accessed recently through a shared link.
+    ///
+    /// - Parameters:
+    ///   - query: The text to serach for.
+    ///   - scope: The scope of content to search within; admins can search within their entire enterprise.
+    ///   - fileExtensions: Limit the search to files with the given extensions.
+    ///   - createdAfter: Limit the search to items created after this date.
+    ///   - createdBefore: Limit the search to items created before this date.
+    ///   - updatedAfter: Limit the search to items updated after this date.
+    ///   - updatedBefore: Limit the search to items updated before this date.
+    ///   - sizeAtLeast: Limit the search to items at least this size, in bytes.
+    ///   - sizeAtMost: Limit the search to items at most this size, in bytes.
+    ///   - ownerUserIDs: Limit the search to only items owned by one of the specified users.
+    ///   - ancestorFolderIDs: Limit the search to items within the specified folders.  This includes all
+    ///     content under these folders, not just their immediate children.
+    ///   - searchIn: Specifies the areas where the search should look for the query string.
+    ///   - itemType: Limits the search to only items of the given type.
+    ///   - searchTrash: Whether to search in the trash.  The options are mutually exclusive; either
+    ///     only trashed content or non-trashed content will be searched.
+    ///   - metadataFilter: The metadata template filters to limit the search results to.
+    ///   - offest: The offset within the collection of results to start from.
+    ///   - limit: The limit for how many search results will be returned.
+    ///   - completion: Called with the results of the search query, or an error if the request is unsuccessful.
+    public func queryWithSharedLinks(
+        query: String?,
+        scope: SearchScope? = nil,
+        fileExtensions: [String]? = nil,
+        createdAfter: Date? = nil,
+        createdBefore: Date? = nil,
+        updatedAfter: Date? = nil,
+        updatedBefore: Date? = nil,
+        sizeAtLeast: Int64? = nil,
+        sizeAtMost: Int64? = nil,
+        ownerUserIDs: [String]? = nil,
+        ancestorFolderIDs: [String]? = nil,
+        searchIn: [SearchContentType]? = nil,
+        itemType: SearchItemType? = nil,
+        searchTrash: Bool? = nil,
+        metadataFilter: MetadataSearchFilter? = nil,
+        fields: [String]? = nil,
+        offset: Int? = nil,
+        limit: Int? = nil,
+        completion: @escaping Callback<PagingIterator<SearchResult>>
+    ) {
+
+        let dateEncoder = JSONEncoder()
+        dateEncoder.dateEncodingStrategy = .iso8601
+
+        var queryParams: [String: QueryParameterConvertible] = [
+            "query": query,
+            "scope": scope,
+            "file_extensions": fileExtensions?.joined(separator: ","),
+            "owner_user_ids": ownerUserIDs?.joined(separator: ","),
+            "ancestor_folder_ids": ancestorFolderIDs?.joined(separator: ","),
+            "content_types": searchIn?.map { $0.description }.joined(separator: ","),
+            "type": itemType,
+            "trash_content": searchTrash.flatMap { $0 ? "trashed_only" : "non_trashed_only" },
+            "fields": FieldsQueryParam(fields),
+            "limit": limit,
+            "offset": offset,
+            "mdfilters": MetadataFilterQueryParam(metadataFilter),
+            "include_recent_shared_links": true
+        ]
+
+        if createdAfter != nil || createdBefore != nil {
+            queryParams["created_at_range"] = "\(createdAfter?.iso8601 ?? ""),\(createdBefore?.iso8601 ?? "")"
+        }
+
+        if updatedAfter != nil || updatedBefore != nil {
+            queryParams["updated_at_range"] = "\(updatedAfter?.iso8601 ?? ""),\(updatedBefore?.iso8601 ?? "")"
+        }
+
+        if sizeAtLeast != nil || sizeAtMost != nil {
+            queryParams["size_range"] = "\(sizeAtLeast.flatMap { String($0) } ?? ""),\(sizeAtMost.flatMap { String($0) } ?? "")"
+        }
+
+        boxClient.get(
+            url: URL.boxAPIEndpoint("/2.0/search", configuration: boxClient.configuration),
+            queryParameters: queryParams,
+            completion: ResponseHandler.pagingIterator(client: boxClient, wrapping: completion)
+        )
+    }
 }

--- a/Sources/Responses/SearchResult.swift
+++ b/Sources/Responses/SearchResult.swift
@@ -1,0 +1,48 @@
+//
+//  SearchResult.swift
+//  BoxSDK-iOS
+//
+//  Created by Skye Free on 2/9/21.
+//  Copyright © 2021 box. All rights reserved.
+//
+
+import Foundation
+
+/// Files, folders and web links that matched the search query, including the additional information about any shared links through which the item has been shared with the user.
+public class SearchResult: BoxModel {
+
+    // MARK: - BoxModel
+
+    private static var resourceType: String = "search_result"
+    /// Box item type
+    public var type: String
+    public private(set) var rawData: [String: Any]
+
+    // MARK: - Properties
+
+    /// The optional shared link through which the user has access to this item.
+    /// This value is only returned for items for which the user has recently accessed the file through a shared link. For all other items this value will return nil.
+    public let accessibleViaSharedLink: URL?
+    /// The file, folder or web link that matched the search query.
+    public let item: FolderItem
+
+    /// Initializer.
+    ///
+    /// - Parameter json: JSON dictionary
+    /// - Throws: Decoding error.
+    public required init(json: [String: Any]) throws {
+        guard let itemType = json["type"] as? String else {
+            throw BoxCodingError(message: .typeMismatch(key: "type"))
+        }
+
+        guard itemType == SearchResult.resourceType else {
+            throw BoxCodingError(message: .valueMismatch(key: "type", value: itemType, acceptedValues: [SearchResult.resourceType]))
+        }
+
+        rawData = json
+        type = itemType
+
+        accessibleViaSharedLink = try BoxJSONDecoder.optionalDecodeURL(json: json, forKey: "accessible_via_shared_link")
+        item = try BoxJSONDecoder.decode(json: json, forKey: "item")
+    }
+}

--- a/Tests/Stubs/Resources/Search/SearchResult200.json
+++ b/Tests/Stubs/Resources/Search/SearchResult200.json
@@ -1,0 +1,71 @@
+{
+    "entries": [
+        {
+            "accessible_via_shared_link": "https://www.box.com/s/vspke7y05sb214wjokpk",
+            "item": {
+                "type": "file",
+                "id": "11111",
+                "file_version": {
+                    "type": "file_version",
+                    "id": "111110",
+                    "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd"
+                },
+                "sequence_id": "9",
+                "etag": "9",
+                "sha1": "97cc02de7c356f94e3beeb1e0c63f78a6edb01fd",
+                "name": "test file.txt",
+                "description": "",
+                "size": 16,
+                "path_collection": {
+                    "total_count": 1,
+                    "entries": [
+                        {
+                            "type": "folder",
+                            "id": "0",
+                            "sequence_id": null,
+                            "etag": null,
+                            "name": "All Files"
+                        }
+                    ]
+                },
+                "created_at": "2016-12-07T15:53:59-08:00",
+                "modified_at": "2018-04-24T15:08:58-07:00",
+                "trashed_at": null,
+                "purged_at": null,
+                "content_created_at": "2016-12-07T15:53:59-08:00",
+                "content_modified_at": "2016-12-07T15:59:32-08:00",
+                "created_by": {
+                    "type": "user",
+                    "id": "33333",
+                    "name": "Test User",
+                    "login": "testuser@example.com"
+                },
+                "modified_by": {
+                    "type": "user",
+                    "id": "33333",
+                    "name": "Test User",
+                    "login": "testuser@example.com"
+                },
+                "owned_by": {
+                    "type": "user",
+                    "id": "33333",
+                    "name": "Test User",
+                    "login": "testuser@example.com"
+                },
+                "shared_link": null,
+                "parent": {
+                    "type": "folder",
+                    "id": "0",
+                    "sequence_id": null,
+                    "etag": null,
+                    "name": "All Files"
+                },
+                "item_status": "active"
+            },
+            "type": "search_result"
+        }
+    ],
+    "limit": 30,
+    "offset": 0,
+    "total_count": 1
+}

--- a/docs/usage/search.md
+++ b/docs/usage/search.md
@@ -6,6 +6,7 @@ Search
 
 
 - [Content Search](#content-search)
+- [Content Search with Shared Link Items](#content-search-with-shared-link-items)
 - [Metadata Search](#metadata-search)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -46,6 +47,44 @@ client.search.query(query: "Quarterly Business Review") { results in
 ```
 
 [search]: https://opensource.box.com/box-ios-sdk/Classes/SearchModule.html#/s:6BoxSDK12SearchModuleC5queryAD5scope14fileExtensions12createdAfter0I6Before07updatedJ00lK011sizeAtLeast0mN4Most12ownerUserIDs014ancestorFolderS08searchIn8itemType0V5Trash14metadataFilter6fields6offset5limit10completionySSSg_AA0C5ScopeOSgSaySSGSg10Foundation4DateVSgA4_A4_A4_s5Int64VSgA7_A0_A0_SayAA0c7ContentY0OGSgAA0c4ItemY0OSgSbSgAA08MetadataC6FilterCSgA0_SiSgA19_ys6ResultOyAA14PagingIteratorCyAA0U4ItemOGAA0A8SDKErrorCGctF
+
+Content Search with Shared Link Items
+--------------
+
+To get a list of items matching a search query, including items that a user might have accessed recently through a shared link, call [`client.search.queryWithSharedLinks(query:...)`][search_with_shared_link_items] with the
+string to query for.  There are many possible options for advanced search filtering, which can be used to narrow down
+the search results. This method will return an iterator object in the completion, which is used to get the results.
+
+<!-- sample get_search_with_shared_link_items -->
+```swift
+client.search.queryWithSharedLinks(query: "Quarterly Business Review") { results in
+    switch results {
+    case let .success(iterator):
+        for i in 1 ... 10 {
+            iterator.next { result in
+                switch result {
+                case let .success(searchResult):
+                    let item = searchResult.item
+                    switch item {
+                    case let .file(file):
+                        print("- File \(file.name) (ID: \(file.id))")
+                    case let .folder(folder):
+                        print("- Folder \(file.name) (ID: \(file.id))")
+                    case let .webLink(webLink):
+                        print("- Web Link \(file.name) (ID: \(file.id))")
+                    }
+                case let .failure(error):
+                    print(error)
+                }
+            }
+        }
+    case let .failure(error):
+        print(error)
+    }
+}
+```
+
+[search_with_shared_link_items]: https://opensource.box.com/box-ios-sdk/Classes/SearchModule.html#/s:6BoxSDK12SearchModuleC5queryAD5scope14fileExtensions12createdAfter0I6Before07updatedJ00lK011sizeAtLeast0mN4Most12ownerUserIDs014ancestorFolderS08searchIn8itemType0V5Trash14metadataFilter6fields6offset5limit10completionySSSg_AA0C5ScopeOSgSaySSGSg10Foundation4DateVSgA4_A4_A4_s5Int64VSgA7_A0_A0_SayAA0c7ContentY0OGSgAA0c4ItemY0OSgSbSgAA08MetadataC6FilterCSgA0_SiSgA19_ys6ResultOyAA14PagingIteratorCyAA0U4ItemOGAA0A8SDKErrorCGctF
 
 Metadata Search
 ---------------


### PR DESCRIPTION
### Goals :soccer:

- Add support for search param to get shared link items

### Implementation Details :construction:

- Users can now include items recently accessed through shared links in their searches, by calling `client.search.queryWithSharedLinks(query:...)`

### Testing Details :mag:

- Added unit tests & tested manually