### PR TITLE
Add support for filtering groups by name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## Next Release
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+- Add support for filtering groups by name ([#757](https://github.com/box/box-ios-sdk/pull/757))
+
+__Bug Fixes:__
+
 ## v4.3.0 [2021-02-01]
 
 __Breaking Changes:__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ __Breaking Changes:__
 
 __New Features and Enhancements:__
 
-- Add support for filtering groups by name ([#757](https://github.com/box/box-ios-sdk/pull/757))
-
 __Bug Fixes:__
+
+- Update `listEnterpriseGroups()` to use documented parameter for filtering by name ([#757](https://github.com/box/box-ios-sdk/pull/757))
 
 ## v4.3.0 [2021-02-01]
 

--- a/Sources/Modules/GroupsModule.swift
+++ b/Sources/Modules/GroupsModule.swift
@@ -164,12 +164,14 @@ public class GroupsModule {
     ///
     /// - Parameters:
     ///   - name: Only return groups whose name contains the given string (case insensitive).
+    ///   - filterTerm: Limits the results to only groups whose name starts with the search term
     ///   - offset: The offset of the item at which to begin the response.
     ///   - limit: The maximum number of items to return. The default is 100 and the maximum is 1,000.
     ///   - fields: Comma-separated list of [fields](https://developer.box.com/reference#fields) to
     ///     include in the response.
     public func listForEnterprise(
         name: String? = nil,
+        filterTerm: String? = nil,
         offset: Int? = nil,
         limit: Int? = nil,
         fields: [String]? = nil,
@@ -179,6 +181,7 @@ public class GroupsModule {
             url: URL.boxAPIEndpoint("/2.0/groups", configuration: boxClient.configuration),
             queryParameters: [
                 "name": name,
+                "filter_term": filterTerm,
                 "offset": offset,
                 "limit": limit,
                 "fields": FieldsQueryParam(fields)

--- a/Sources/Modules/GroupsModule.swift
+++ b/Sources/Modules/GroupsModule.swift
@@ -164,14 +164,12 @@ public class GroupsModule {
     ///
     /// - Parameters:
     ///   - name: Only return groups whose name contains the given string (case insensitive).
-    ///   - filterTerm: Limits the results to only groups whose name starts with the search term
     ///   - offset: The offset of the item at which to begin the response.
     ///   - limit: The maximum number of items to return. The default is 100 and the maximum is 1,000.
     ///   - fields: Comma-separated list of [fields](https://developer.box.com/reference#fields) to
     ///     include in the response.
     public func listForEnterprise(
         name: String? = nil,
-        filterTerm: String? = nil,
         offset: Int? = nil,
         limit: Int? = nil,
         fields: [String]? = nil,
@@ -180,8 +178,7 @@ public class GroupsModule {
         boxClient.get(
             url: URL.boxAPIEndpoint("/2.0/groups", configuration: boxClient.configuration),
             queryParameters: [
-                "name": name,
-                "filter_term": filterTerm,
+                "filter_term": name,
                 "offset": offset,
                 "limit": limit,
                 "fields": FieldsQueryParam(fields)

--- a/docs/usage/groups.md
+++ b/docs/usage/groups.md
@@ -87,7 +87,7 @@ client.groups.get(groupId: "12345") {
 Get Enterprise Groups
 ---------------------
 
-To retrieve information about the groups within the enterprise, call [`client.groups.listForEnterprise(name: String?, filterTerm: String?, offset: Int?, limit: Int?, fields: [String]?)`][get-enterprise-groups]. You can also pass in a `name` paramter to act as a filter. This method will return an iterator object in the completion, which is used to retrieve groups in the enterprise.
+To retrieve information about the groups within the enterprise, call [`client.groups.listForEnterprise(name: String?, offset: Int?, limit: Int?, fields: [String]?)`][get-enterprise-groups]. You can also pass in a `name` paramter to act as a filter. This method will return an iterator object in the completion, which is used to retrieve groups in the enterprise.
 
 <!-- sample get_groups -->
 ```swift

--- a/docs/usage/groups.md
+++ b/docs/usage/groups.md
@@ -87,7 +87,7 @@ client.groups.get(groupId: "12345") {
 Get Enterprise Groups
 ---------------------
 
-To retrieve information about the groups within the enterprise, call [`client.groups.listForEnterprise(name: String?, offset: Int?, limit: Int?, fields: [String]?)`][get-enterprise-groups]. You can also pass in a `name` paramter to act as a filter. This method will return an iterator object in the completion, which is used to retrieve groups in the enterprise.
+To retrieve information about the groups within the enterprise, call [`client.groups.listForEnterprise(name: String?, filterTerm: String?, offset: Int?, limit: Int?, fields: [String]?)`][get-enterprise-groups]. You can also pass in a `name` paramter to act as a filter. This method will return an iterator object in the completion, which is used to retrieve groups in the enterprise.
 
 <!-- sample get_groups -->
 ```swift


### PR DESCRIPTION
### Goals :soccer:
- Update `listEnterpriseGroups()` to use documented parameter for filtering by name

### Implementation Details :construction:
- Change undocumented `name` key to documented `filter_term` because they both do the same thing

### Testing Details :mag:
- None
