### PR TITLE
Fix bug for OAuth where the callback is not called if token has been revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ __New Features and Enhancements:__
 __Bug Fixes:__
 
 - Update `listEnterpriseGroups()` to use documented parameter for filtering by name ([#757](https://github.com/box/box-ios-sdk/pull/757))
+- Fix bug for OAuth where the callback is not called if token has been revoked ([#762](https://github.com/box/box-ios-sdk/pull/762))
 
 ## v4.3.0 [2021-02-01]
 

--- a/Sources/Client/BoxClient.swift
+++ b/Sources/Client/BoxClient.swift
@@ -177,7 +177,7 @@ private extension BoxClient {
         case let .failure(error):
             if let apiError = error as? BoxAPIAuthError, apiError.message == .unauthorizedAccess {
                 if let tokenHandlingSession = session as? ExpiredTokenHandling {
-                    tokenHandlingSession.handleExpiredToken(completion: { _ in })
+                    tokenHandlingSession.handleExpiredToken(completion: { _ in completion(.failure(error)) })
                     return
                 }
             }


### PR DESCRIPTION
### Issue Link :link:
#761 

### Goals :soccer:
I believe in that it should always call completion handler even if token has been revoked.

### Implementation Details :construction:
There may be two ways to fix this problem.

1. Remove `return` after calling `handleExpiredToken(completion:)`
2. Call `completion` in a closure that is passed to `handleExpiredToken(completion:)`

I think 2 is preferable. Because `handleExpiredToken(completion:)` is an asynchronous method and the whole process is completed at its completion handler.

### Testing Details :mag:
Added test describes that issue. It occurs only when using `OAuth2Session` as a session (to be exact, only when the session conforms to `ExpiredTokenHandling` protocol.) In the test case, `BoxClient` is created by `getOAuth2Client` to use `OAuth2Session`.

Without fix, the test is timed out because completion handler is not called.
With fix, it passed.
