### PR TITLE
Add support for copyInstanceOnItemCopy field for metadata templates

### DIFF
--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -377,6 +377,8 @@
 		B41D9DB325D33456000BFE59 /* SearchResult200.json in Resources */ = {isa = PBXBuildFile; fileRef = B41D9DB225D33456000BFE59 /* SearchResult200.json */; };
 		B41D9DB525D3347C000BFE59 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41D9DB425D3347C000BFE59 /* SearchResult.swift */; };
 		B41D9DB625D335F2000BFE59 /* SearchResult200.json in Resources */ = {isa = PBXBuildFile; fileRef = B41D9DB225D33456000BFE59 /* SearchResult200.json */; };
+		B47486CA26013A30005F4475 /* CreateMetadataTemplate2.json in Resources */ = {isa = PBXBuildFile; fileRef = B47486C926013A30005F4475 /* CreateMetadataTemplate2.json */; };
+		B47486CB26013B02005F4475 /* CreateMetadataTemplate2.json in Resources */ = {isa = PBXBuildFile; fileRef = B47486C926013A30005F4475 /* CreateMetadataTemplate2.json */; };
 		B4882E6E25EEBE1800EB57BA /* FolderLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4882E6D25EEBE1800EB57BA /* FolderLock.swift */; };
 		B4882E7025EEE12F00EB57BA /* FolderLock.json in Resources */ = {isa = PBXBuildFile; fileRef = B4882E6F25EEE12F00EB57BA /* FolderLock.json */; };
 		B4882E7125EEE14100EB57BA /* FolderLock.json in Resources */ = {isa = PBXBuildFile; fileRef = B4882E6F25EEE12F00EB57BA /* FolderLock.json */; };
@@ -871,6 +873,7 @@
 		B40558BA25AE57C10068784E /* ZipDownloadStatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ZipDownloadStatus.json; sourceTree = "<group>"; };
 		B41D9DB225D33456000BFE59 /* SearchResult200.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SearchResult200.json; sourceTree = "<group>"; };
 		B41D9DB425D3347C000BFE59 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
+		B47486C926013A30005F4475 /* CreateMetadataTemplate2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CreateMetadataTemplate2.json; sourceTree = "<group>"; };
 		B4882E6D25EEBE1800EB57BA /* FolderLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderLock.swift; sourceTree = "<group>"; };
 		B4882E6F25EEE12F00EB57BA /* FolderLock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FolderLock.json; sourceTree = "<group>"; };
 		B4882E7225EEFBC600EB57BA /* FolderLocks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = FolderLocks.json; sourceTree = "<group>"; };
@@ -1515,6 +1518,7 @@
 				224E1BEB22C5365400F31F3A /* GetEnterpriseTemplates.json */,
 				224E1BE922C522D800F31F3A /* UpdateMetadataTemplate.json */,
 				2268B33422BD880700ABBD47 /* CreateMetadataTemplate.json */,
+				B47486C926013A30005F4475 /* CreateMetadataTemplate2.json */,
 				2268B33522BD880700ABBD47 /* GetMetadataTemplate.json */,
 			);
 			path = Metadata;
@@ -2119,6 +2123,7 @@
 				B40558B025AD2ABF0068784E /* ZipDownload.json in Resources */,
 				B4882E7325EEFBC600EB57BA /* FolderLocks.json in Resources */,
 				8093D29822FA398500DB628E /* GetWebLink.json in Resources */,
+				B47486CA26013A30005F4475 /* CreateMetadataTemplate2.json in Resources */,
 				B4882E7025EEE12F00EB57BA /* FolderLock.json in Resources */,
 				8093D29A22FA399D00DB628E /* UpdateWebLink.json in Resources */,
 				80E5679822FB931300798E3A /* FullWebLink.json in Resources */,
@@ -2134,6 +2139,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B47486CB26013B02005F4475 /* CreateMetadataTemplate2.json in Resources */,
 				B4882E7425EEFBD900EB57BA /* FolderLocks.json in Resources */,
 				B4882E7125EEE14100EB57BA /* FolderLock.json in Resources */,
 				B41D9DB625D335F2000BFE59 /* SearchResult200.json in Resources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 - Add support for folder lock functionality ([#759](https://github.com/box/box-ios-sdk/pull/759))
+- Add support for copyInstanceOnItemCopy field for metadata templates ([#763](https://github.com/box/box-ios-sdk/pull/763))
 
 __Bug Fixes:__
 

--- a/Sources/Modules/MetadataModule+Templates.swift
+++ b/Sources/Modules/MetadataModule+Templates.swift
@@ -52,6 +52,7 @@ public extension MetadataModule {
     ///   - templateKey: A unique identifier for the template.
     ///   - displayName: The display name of the template.
     ///   - hidden: Whether this template is hidden in the UI. Defaults to false.
+    ///   - copyInstanceOnItemCopy: Whether to copy any metadata attached to a file or folder when it is copied. Defaults to false.
     ///   - fields: Definition of fields for this metadata template.
     ///   - completion: Returns success or an error if template is invalid or
     ///     the user doesn't have access to the file.
@@ -60,6 +61,7 @@ public extension MetadataModule {
         templateKey: String,
         displayName: String,
         hidden: Bool,
+        copyInstanceOnItemCopy: Bool? = nil,
         fields: [MetadataField],
         completion: @escaping Callback<MetadataTemplate>
     ) {
@@ -69,6 +71,10 @@ public extension MetadataModule {
             "displayName": displayName,
             "hidden": hidden
         ]
+
+        if let unwrappedCopyInstanceOnItemCopy = copyInstanceOnItemCopy {
+            json["copyInstanceOnItemCopy"] = unwrappedCopyInstanceOnItemCopy
+        }
 
         json["fields"] = fields.map { $0.bodyDictWithDefaultKeys }
 

--- a/Sources/Responses/MetadataTemplate.swift
+++ b/Sources/Responses/MetadataTemplate.swift
@@ -111,6 +111,8 @@ public class MetadataTemplate: BoxModel {
     public let displayName: String?
     /// Whether this template is hidden in the UI.
     public let hidden: Bool?
+    /// Whether or not to copy any metadata attached to a file or folder when it is copied. By default, metadata is not copied along with a file or folder when it is copied.
+    public let copyInstanceOnItemCopy: Bool?
     /// The ordered set of key:value pairs for the template.
     public let fields: [MetadataField]?
 
@@ -126,6 +128,7 @@ public class MetadataTemplate: BoxModel {
         scope = try BoxJSONDecoder.optionalDecode(json: json, forKey: "scope")
         displayName = try BoxJSONDecoder.optionalDecode(json: json, forKey: "displayName")
         hidden = try BoxJSONDecoder.optionalDecode(json: json, forKey: "hidden")
+        copyInstanceOnItemCopy = try BoxJSONDecoder.optionalDecode(json: json, forKey: "copyInstanceOnItemCopy")
         fields = try BoxJSONDecoder.optionalDecodeCollection(json: json, forKey: "fields")
     }
 }

--- a/Tests/Stubs/Resources/Metadata/CreateMetadataTemplate2.json
+++ b/Tests/Stubs/Resources/Metadata/CreateMetadataTemplate2.json
@@ -1,0 +1,16 @@
+{
+    "templateKey": "customer",
+    "scope": "enterprise_490685",
+    "displayName": "Customer",
+    "copyInstanceOnItemCopy": true,
+    "hidden": false,
+    "fields": [
+        {
+            "type": "string",
+            "key": "customerTeam",
+            "displayName": "Customer team",
+            "hidden": false
+        }
+    ]
+}
+

--- a/docs/usage/metadata.md
+++ b/docs/usage/metadata.md
@@ -86,7 +86,7 @@ Create Metadata Template
 ------------------------
 
 To create a new metadata template, call
-[`client.metadata.createTemplate(scope:templateKey:displayName:hidden:fields:completion:)`][create-md-template]
+[`client.metadata.createTemplate(scope:templateKey:displayName:hidden:copyInstanceOnItemCopy:fields:completion:)`][create-md-template]
 with the scope and name of the template, as well as the fields the template should contain.
 
 <!-- sample post_metadata_templates_schema -->


### PR DESCRIPTION
### Goals :soccer:

- Add support for copyInstanceOnItemCopy field for metadata templates

### Implementation Details :construction:

- Users can now optionally set the `copyInstanceOnItemCopy` field when creating a metadata templae by calling `client.metadata.createTemplate(scope:templateKey:displayName:hidden:copyInstanceOnItemCopy:fields:completion:)`

### Testing Details :mag:

- Added unit test
