### PR TITLE
Pin dev dependencies

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "Quick/Quick"
 github "Quick/Nimble" "v8.0.0"
-github "AliSoftware/OHHTTPStubs"
+github "AliSoftware/OHHTTPStubs" "8.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
 github "Quick/Nimble" "v8.0.0"
-github "Quick/Quick" "v2.2.0"
+github "Quick/Quick" "v3.1.2"


### PR DESCRIPTION
### Issue Link :link:
- Tests don't run on new version of OHHTTPStubs

### Goals :soccer:
- Fix tests

### Implementation Details :construction:
- Pin OHHTTPStubs to 8.0.0

### Testing Details :mag:
- Tests compile and run
