### PR TITLE
Fix Swift warning for deprecated tuple destructuring.

### DIFF
--- a/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
+++ b/Sources/Sessions/DelegatedAuth/DelegatedAuthSession.swift
@@ -103,7 +103,7 @@ public class DelegatedAuthSession: SessionProtocol {
 
             self.authClosure(self.uniqueID) { result in
                 switch result {
-                case let .success(accessToken, expiresIn):
+                case let .success((accessToken, expiresIn)):
                     if expiresIn < self.configuration.tokenRefreshThreshold {
                         completion(.failure(BoxAPIAuthError(message: .expiredToken)))
                         done()


### PR DESCRIPTION
### Issue Link #775
Swift compiler warning for deprecated syntax, which allowed for destructuring tuple elements in an enum associated value without writing the tuple parentheses.

### Testing Details :mag:
This change is purely syntactic.
