### PR TITLE
Make swiftlint produce errors instead of warnings

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -17,5 +17,6 @@
 # rules
 --disable blankLinesAroundMark
 --disable blankLinesAtStartOfScope
+--disable wrapMultilineStatementBraces
 --wraparguments before-first
 --elseposition next-line

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,7 +42,7 @@ opt_in_rules:
   # - function_default_parameter_at_end
   - identical_operands
   - implicitly_unwrapped_optional
-  - implicit_return
+  #- implicit_return
   - last_where
   - legacy_multiple
   - legacy_random
@@ -76,7 +76,7 @@ opt_in_rules:
   - unowned_variable_capture
   - untyped_error_in_catch
   - unused_import
-  - unused_private_declaration
+  - unused_declaration
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - yoda_condition

--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -2421,7 +2421,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		0C4D9F5F2237E1480061671D /* SwiftFormat Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/BoxSDK.swift
+++ b/Sources/BoxSDK.swift
@@ -373,8 +373,7 @@ public class BoxSDK {
 
                 if let authorizationCode = self.getURLComponentValueAt(key: "code", from: successURL),
                    let receivedState = self.getURLComponentValueAt(key: "state", from: successURL),
-                   receivedState == usedState
-                {
+                   receivedState == usedState {
                     completion(.success(authorizationCode))
                     return
                 }
@@ -403,8 +402,7 @@ public class BoxSDK {
 
                 if let authorizationCode = self.getURLComponentValueAt(key: "code", from: successURL),
                    let receivedState = self.getURLComponentValueAt(key: "state", from: successURL),
-                   receivedState == usedState
-                {
+                   receivedState == usedState {
                     completion(.success(authorizationCode))
                     return
                 }

--- a/Sources/Core/URLValidation.swift
+++ b/Sources/Core/URLValidation.swift
@@ -10,9 +10,7 @@ import Foundation
 
 enum URLValidation {
     static func validate(networkUrl: URL) throws {
-        if networkUrl.scheme != "https" ||
-            networkUrl.host == nil
-        {
+        if networkUrl.scheme != "https" || networkUrl.host == nil {
             throw BoxSDKError(message: .invalidURL(urlString: networkUrl.absoluteString))
         }
     }

--- a/Sources/Logger/Logger.swift
+++ b/Sources/Logger/Logger.swift
@@ -57,8 +57,7 @@ extension Logger {
         let file = URL(fileURLWithPath: String(describing: file)).deletingPathExtension().lastPathComponent
         var function = String(describing: function)
         if let firstIndex = function.firstIndex(of: "("),
-           let lastIndex = function.lastIndex(of: ")")
-        {
+           let lastIndex = function.lastIndex(of: ")") {
             function.removeSubrange(firstIndex ... lastIndex)
         }
         log("%{public}@.%{public}@():%ld", level: .debug, [file, function, line])

--- a/Sources/Modules/FilesModule.swift
+++ b/Sources/Modules/FilesModule.swift
@@ -81,6 +81,8 @@ public enum ThumbnailExtension: BoxEnum {
 
 /// Provides [File](../Structs/File.html) management.
 public class FilesModule {
+    // swiftlint:disable:previous type_body_length
+
     /// Required for communicating with Box APIs.
     weak var boxClient: BoxClient!
     // swiftlint:disable:previous implicitly_unwrapped_optional

--- a/Sources/Network/ArrayInputStream.swift
+++ b/Sources/Network/ArrayInputStream.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable all
+
 /// Notes:
 /// The purpose of this class (ArrayInputStream) is to "merge" multiple InputStreams into a single InputStream.
 /// This merging can be implemented by sequentially reading from an array of input streams with an interface that is the same as InputStream.
@@ -18,8 +20,6 @@
 import Foundation
 
 class ArrayInputStream: InputStream {
-    // swiftlint:disable all
-
     private let inputStreams: [InputStream]
 
     private var currentIndex: Int
@@ -132,6 +132,4 @@ class ArrayInputStream: InputStream {
     override func schedule(in _: RunLoop, forMode _: RunLoop.Mode) {}
 
     override func remove(from _: RunLoop, forMode _: RunLoop.Mode) {}
-
-    // swiftlint:enable all
 }

--- a/Sources/Network/BoxNetworkTask.swift
+++ b/Sources/Network/BoxNetworkTask.swift
@@ -17,7 +17,7 @@ public class BoxNetworkTask: Cancellable {
 
     var tasks: [Cancellable] = []
     /// Whether the task is cancelled or not
-    public internal(set) var cancelled: Bool = false
+    public internal(set) var cancelled = false
 
     /// Closure that is called when API calls are nested within each other
     func receiveTask(_ task: Cancellable) {

--- a/Sources/Responses/EventType.swift
+++ b/Sources/Responses/EventType.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2019 box. All rights reserved.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 /// Defines user or enterprise event type
 public enum EventType: BoxEnum {
-
+    // swiftlint:disable:previous type_body_length
     // MARK: - User events
 
     /// A folder or file was created.


### PR DESCRIPTION
Till now swiftilnt was generating warnings that someone might have overlooked.

To make lint messages more visible, which will also improve code quality, now they will be shown as errors.
As a result of this, each PR pushed to repository will have to follow the rules set in .swiftlint.yml.

