### PR TITLE
fix: An empty string `nextMarker` should be treated as end-of-paging.

### DIFF
--- a/Sources/Network/PagingIterator.swift
+++ b/Sources/Network/PagingIterator.swift
@@ -94,7 +94,9 @@ public class PagingIterator<Element: BoxModel> {
             nextPage = .streamPosition(nextStreamPosition)
         }
         // Handle marker based paging
-        else if let nextPageMarker = page.nextMarker {
+        // An Empty string, like a nil `nextMarker`, indicates the end has been reached.
+        // ref: https://developer.box.com/guides/api-calls/pagination/marker-based/
+        else if let nextPageMarker = page.nextMarker, !nextPageMarker.isEmpty {
             nextPage = .marker(nextPageMarker)
         }
         // Handle unexpected value with no paging information


### PR DESCRIPTION
The Box V2 API docs are inconsistent on this. However it is stated on the paging docs(1):
> If this value is null or an empty string there are no more results to fetch.

So with this change an empty string next_marker will end paging.

(1): https://developer.box.com/guides/api-calls/pagination/marker-based/#collections

### Issue Link :link:
https://github.com/box/box-ios-sdk/issues/892