### PR TITLE
fix: Identify iPhone Simulator on Apple Silicon

### DIFF
--- a/Sources/Core/Extensions/UIDeviceExtension.swift
+++ b/Sources/Core/Extensions/UIDeviceExtension.swift
@@ -29,6 +29,8 @@ import Foundation
                 return "iPhone Simulator"
             case "x86_64":
                 return "iPhone Simulator"
+            case "arm64":
+                return "iPhone Simulator"
 
             case "iPhone1,1":
                 return "iPhone"


### PR DESCRIPTION
### Goals :soccer:

Fix UIDevice.modelName test, when run on iOS Simulator on an Apple Silicon Mac.
