### PR TITLE
chore: Unify access to test assets.

### DIFF
--- a/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		0CD4842522956C2200E61C35 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD4842422956C2200E61C35 /* Task.swift */; };
 		0CD4843B2295EBC000E61C35 /* LockFile.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CD484292295A22C00E61C35 /* LockFile.json */; };
 		0CD4843D2295F8CA00E61C35 /* UnlockFile.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CD4843C2295F8CA00E61C35 /* UnlockFile.json */; };
+		0D9D60FC2A4124B7006CF672 /* TestAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9D60FB2A4124B6006CF672 /* TestAssets.swift */; };
 		17145DC6230D8C3E00857868 /* URLValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17145DC5230D8C3E00857868 /* URLValidation.swift */; };
 		1725D2A12310321100935000 /* URLValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725D2A02310321100935000 /* URLValidationTest.swift */; };
 		172A4F212317F464009F5293 /* RetentionPolicyModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172A4F202317F464009F5293 /* RetentionPolicyModule.swift */; };
@@ -802,6 +803,7 @@
 		0CD484292295A22C00E61C35 /* LockFile.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = LockFile.json; sourceTree = "<group>"; };
 		0CD4842E2295A28100E61C35 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		0CD4843C2295F8CA00E61C35 /* UnlockFile.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UnlockFile.json; sourceTree = "<group>"; };
+		0D9D60FB2A4124B6006CF672 /* TestAssets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAssets.swift; sourceTree = "<group>"; };
 		17145DC5230D8C3E00857868 /* URLValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLValidation.swift; sourceTree = "<group>"; };
 		1725D2A02310321100935000 /* URLValidationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLValidationTest.swift; sourceTree = "<group>"; };
 		172A4F202317F464009F5293 /* RetentionPolicyModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetentionPolicyModule.swift; sourceTree = "<group>"; };
@@ -1387,6 +1389,7 @@
 			children = (
 				0C28DCC322AF099F0005AC46 /* JSONComparison */,
 				0C506CBC22A6AF97007F18A4 /* OHTTPStubs+JSONComparer.swift */,
+				0D9D60FB2A4124B6006CF672 /* TestAssets.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -3169,6 +3172,7 @@
 				22C41457231ED1A500D3992C /* MetadataCascadePolicyModuleSpecs.swift in Sources */,
 				0546B2FF26F9F5C500922C04 /* CommentItemSpecs.swift in Sources */,
 				05B51E0429D7144C00CDFA9B /* PagingIteratorSpecs.swift in Sources */,
+				0D9D60FC2A4124B7006CF672 /* TestAssets.swift in Sources */,
 				0546B2FC26F9EDDA00922C04 /* TokenScopeSpecs.swift in Sources */,
 				97D3FFBC22B1DBB9008C1CE6 /* FolderSpecs.swift in Sources */,
 				05EE814627185554006A2329 /* SignRequestSpecs.swift in Sources */,

--- a/Tests/BoxSDKSpecs.swift
+++ b/Tests/BoxSDKSpecs.swift
@@ -246,7 +246,7 @@ class BoxSDKSpecs: QuickSpec {
                             && isMethodPOST()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -449,7 +449,7 @@ class BoxSDKSpecs: QuickSpec {
                         && isMethodPOST()
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }

--- a/Tests/Client/BoxClientSpecs.swift
+++ b/Tests/Client/BoxClientSpecs.swift
@@ -200,7 +200,7 @@ class BoxClientSpecs: QuickSpec {
                         && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -235,7 +235,7 @@ class BoxClientSpecs: QuickSpec {
                             && hasJsonBody(body)
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullWebLink.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -274,7 +274,7 @@ class BoxClientSpecs: QuickSpec {
                             && hasJsonBody(body)
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateFileInfo.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -400,7 +400,7 @@ class BoxClientSpecs: QuickSpec {
                             && hasJsonBody(["some_key": "some_value"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Helpers/TestAssets.swift
+++ b/Tests/Helpers/TestAssets.swift
@@ -1,0 +1,35 @@
+//
+//  TestAssets.swift
+//  BoxSDK
+//
+//  Created by James Lawton on 6/19/23.
+//  Copyright © 2023 Box. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+final class TestAssets {
+
+    static let resourceBundle: Bundle = {
+        return Bundle(for: TestAssets.self)
+    }()
+
+    static func url(forResource name: String) -> URL? {
+        resourceBundle.url(forResource: name, withExtension: nil)
+    }
+
+    static func path(forResource name: String) -> String? {
+        resourceBundle.path(forResource: name, ofType: nil)
+    }
+
+#if canImport(UIKit)
+    static func image(named: String) -> UIImage? {
+        UIImage(named: named, in: resourceBundle, compatibleWith: nil)
+    }
+#endif
+}
+

--- a/Tests/Modules/AuthModuleSpecs.swift
+++ b/Tests/Modules/AuthModuleSpecs.swift
@@ -42,7 +42,7 @@ class AuthModuleSpecs: QuickSpec {
                             && self.compareURLEncodedBody(["client_id": self.clientId, "client_secret": self.clientSecret, "code": self.code, "grant_type": "authorization_code"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -191,7 +191,7 @@ class AuthModuleSpecs: QuickSpec {
                         )
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("DownscopeToken.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "DownscopeToken.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -235,7 +235,7 @@ class AuthModuleSpecs: QuickSpec {
                         )
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }

--- a/Tests/Modules/CollaborationAllowlistModuleSpecs.swift
+++ b/Tests/Modules/CollaborationAllowlistModuleSpecs.swift
@@ -33,7 +33,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaborationWhitelistEntries.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaborationWhitelistEntries.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -65,7 +65,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaborationWhitelistEntryByID.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaborationWhitelistEntryByID.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -113,7 +113,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateCollaborationWhitelistEntry.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateCollaborationWhitelistEntry.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -183,7 +183,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaborationWhitelistExemptUsers.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaborationWhitelistExemptUsers.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -223,7 +223,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaborationWhitelistExemptUsersByID.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaborationWhitelistExemptUsersByID.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -277,7 +277,7 @@ class CollaborationAllowlistModuleSpecs: QuickSpec {
                             hasJsonBody(["user": ["id": "12345"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateCollaborationWhitelistExemptUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateCollaborationWhitelistExemptUser.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/CollaborationsModuleSpecs.swift
+++ b/Tests/Modules/CollaborationsModuleSpecs.swift
@@ -33,7 +33,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaboration.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -79,7 +79,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                                 self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["id": "123456", "type": "group"], "role": "editor", "can_view_path": true])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetCollaboration.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -122,7 +122,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                                 self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["id": "123456", "type": "group"], "role": "editor"])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetCollaboration.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -166,7 +166,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["login": "testuser@example.com", "type": "user"], "role": "editor"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaboration.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -208,7 +208,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                                 self.compareJSONBody(["item": ["id": "11446500", "type": "folder"], "accessible_by": ["id": "123456", "type": "group"], "role": "editor"])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetCollaboration.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetCollaboration.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -253,7 +253,7 @@ class CollaborationsModuleSpecs: QuickSpec {
 
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateCollaboration.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateCollaboration.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -296,7 +296,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             containsQueryParams(["fields": "acceptance_requirements_status"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullCollaboration.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullCollaboration.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -347,7 +347,7 @@ class CollaborationsModuleSpecs: QuickSpec {
                             containsQueryParams(["status": "pending", "offset": "0", "limit": "2"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("PendingCollaborations.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "PendingCollaborations.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/CollectionsModuleSpecs.swift
+++ b/Tests/Modules/CollectionsModuleSpecs.swift
@@ -33,7 +33,7 @@ class CollectionsModulesSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -68,7 +68,7 @@ class CollectionsModulesSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -96,7 +96,7 @@ class CollectionsModulesSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollectionsEmpty.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollectionsEmpty.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -124,7 +124,7 @@ class CollectionsModulesSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollectionItems.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollectionItems.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/CommentsModuleSpecs.swift
+++ b/Tests/Modules/CommentsModuleSpecs.swift
@@ -41,7 +41,7 @@ class CommentsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateComment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateComment.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -77,7 +77,7 @@ class CommentsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateTaggedComment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateTaggedComment.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -109,7 +109,7 @@ class CommentsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetComment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetComment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -143,7 +143,7 @@ class CommentsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateCommentInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateCommentInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -175,7 +175,7 @@ class CommentsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateTaggedComment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateTaggedComment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/DevicePinsModuleSpecs.swift
+++ b/Tests/Modules/DevicePinsModuleSpecs.swift
@@ -52,7 +52,7 @@ public class DevicePinsModuleSpecs: QuickSpec {
                 it("should make an API call to retrieve a specified Device Pin") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/device_pinners/12345") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullDevicePin.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullDevicePin.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -84,7 +84,7 @@ public class DevicePinsModuleSpecs: QuickSpec {
                             && containsQueryParams(["direction": "ASC"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetDevicePins.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetDevicePins.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/EventsModuleSpecs.swift
+++ b/Tests/Modules/EventsModuleSpecs.swift
@@ -36,7 +36,7 @@ class EventsModuleSpecs: QuickSpec {
                                 isMethodGET(),
                             response: { _ in
                                 OHHTTPStubsResponse(
-                                    fileAtPath: OHPathForFile("GetUserEvents.json", type(of: self))!,
+                                    fileAtPath: TestAssets.path(forResource: "GetUserEvents.json")!,
                                     statusCode: 200, headers: [:]
                                 )
                             }
@@ -76,7 +76,7 @@ class EventsModuleSpecs: QuickSpec {
                                 isMethodGET(),
                             response: { _ in
                                 OHHTTPStubsResponse(
-                                    fileAtPath: OHPathForFile("GetUserEvents.json", type(of: self))!,
+                                    fileAtPath: TestAssets.path(forResource: "GetUserEvents.json")!,
                                     statusCode: 200, headers: [:]
                                 )
                             }
@@ -113,7 +113,7 @@ class EventsModuleSpecs: QuickSpec {
                                 isMethodGET(),
                             response: { _ in
                                 OHHTTPStubsResponse(
-                                    fileAtPath: OHPathForFile("GetUserEvents.json", type(of: self))!,
+                                    fileAtPath: TestAssets.path(forResource: "GetUserEvents.json")!,
                                     statusCode: 200, headers: [:]
                                 )
                             }
@@ -150,7 +150,7 @@ class EventsModuleSpecs: QuickSpec {
                                 isMethodGET(),
                             response: { _ in
                                 OHHTTPStubsResponse(
-                                    fileAtPath: OHPathForFile("GetUserEvents.json", type(of: self))!,
+                                    fileAtPath: TestAssets.path(forResource: "GetUserEvents.json")!,
                                     statusCode: 200, headers: [:]
                                 )
                             }
@@ -197,7 +197,7 @@ class EventsModuleSpecs: QuickSpec {
                             isMethodGET(),
                         response: { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetEnterpriseEvents.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetEnterpriseEvents.json")!,
                                 statusCode: 200, headers: [:]
                             )
                         }
@@ -268,7 +268,7 @@ class EventsModuleSpecs: QuickSpec {
                             isMethodGET(),
                         response: { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetEnterpriseEventsStreaming.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetEnterpriseEventsStreaming.json")!,
                                 statusCode: 200, headers: [:]
                             )
                         }
@@ -335,7 +335,7 @@ class EventsModuleSpecs: QuickSpec {
                             isPath("/2.0/events"),
                         response: { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetPollingURL.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetPollingURL.json")!,
                                 statusCode: 200, headers: [:]
                             )
                         }
@@ -364,7 +364,7 @@ class EventsModuleSpecs: QuickSpec {
                         isMethodGET(),
                         response: { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetNewEvents.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetNewEvents.json")!,
                                 statusCode: 200, headers: [:]
                             )
                         }

--- a/Tests/Modules/FileRequestsModuleSpecs.swift
+++ b/Tests/Modules/FileRequestsModuleSpecs.swift
@@ -33,7 +33,7 @@ class FileRequestsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileRequest.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -94,7 +94,7 @@ class FileRequestsModuleSpecs: QuickSpec {
                             && hasHeaderNamed("If-Match", value: "1")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateFileRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateFileRequest.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -166,7 +166,7 @@ class FileRequestsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CopyFileRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CopyFileRequest.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }

--- a/Tests/Modules/FilesModuleSpecs.swift
+++ b/Tests/Modules/FilesModuleSpecs.swift
@@ -29,7 +29,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should make API call to get file info and produce file model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5000948880") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -58,7 +58,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should produce error when API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/500094889") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 404, headers: [:]
                         )
                     }
@@ -76,9 +76,8 @@ class FilesModuleSpecs: QuickSpec {
                                     return
                                 }
 
-                                let bundle = Bundle(for: type(of: self))
                                 // swiftlint:disable:next force_unwrap
-                                let templatePath = bundle.url(forResource: "APIErrorTemplate", withExtension: "json")!.path
+                                let templatePath = TestAssets.path(forResource: "APIErrorTemplate.json")!
                                 var errorNoStackTrace = apiError.getDictionary()
                                 errorNoStackTrace["stackTrace"] = nil
                                 let errorJSON = try! JSONSerialization.data(withJSONObject: errorNoStackTrace)
@@ -116,7 +115,7 @@ class FilesModuleSpecs: QuickSpec {
                             && hasHeaderNamed("x-rep-hints", value: "[extracted_text]")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRepresentations.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRepresentations.json")!,
                             statusCode: 200, headers: ["x-rep-hints": "[extracted_text]"]
                         )
                     }
@@ -154,7 +153,7 @@ class FilesModuleSpecs: QuickSpec {
                             && containsQueryParams(["fields": "representations"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRepresentationsNoHeader.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRepresentationsNoHeader.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -193,7 +192,7 @@ class FilesModuleSpecs: QuickSpec {
                                 && hasHeaderNamed("x-rep-hints", value: "[extracted_text]")
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetRepresentations.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetRepresentations.json")!,
                                 statusCode: 200, headers: ["x-rep-hints": "[extracted_text]"]
                             )
                         }
@@ -240,7 +239,7 @@ class FilesModuleSpecs: QuickSpec {
                                 && hasHeaderNamed("x-rep-hints", value: "[jpg?dimensions=320x320]")
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetRepresentationsErrorState.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetRepresentationsErrorState.json")!,
                                 statusCode: 200, headers: ["x-rep-hints": "[jpg?dimensions=320x320]"]
                             )
                         }
@@ -279,7 +278,7 @@ class FilesModuleSpecs: QuickSpec {
                                 && hasHeaderNamed("x-rep-hints", value: "[jpg?dimensions=320x320]")
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetRepresentationsUnknownState.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetRepresentationsUnknownState.json")!,
                                 statusCode: 200, headers: ["x-rep-hints": "[jpg?dimensions=320x320]"]
                             )
                         }
@@ -317,7 +316,7 @@ class FilesModuleSpecs: QuickSpec {
                                 && hasHeaderNamed("x-rep-hints", value: "[extracted_text]")
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetRepresentationsPendingState.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetRepresentationsPendingState.json")!,
                                 statusCode: 200, headers: ["x-rep-hints": "[extracted_text]"]
                             )
                         }
@@ -333,7 +332,7 @@ class FilesModuleSpecs: QuickSpec {
                             condition: isHost("api.box.com") && isPath("/2.0/internal_files/12345/versions/11111/representations/jpg_thumb_320x320")
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("FileRepresentationState.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "FileRepresentationState.json")!,
                                 statusCode: 200, headers: ["x-rep-hints": "[extracted_text]"]
                             )
                         }
@@ -388,7 +387,7 @@ class FilesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateFileInfo.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -439,7 +438,7 @@ class FilesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateFileInfo.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -458,7 +457,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should produce error when API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/50009488812") && isMethodPUT()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateFileInfo.json")!,
                             statusCode: 404, headers: [:]
                         )
                     }
@@ -490,7 +489,7 @@ class FilesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CopyFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CopyFile.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -520,7 +519,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should produce error when the API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/500094889/copy")) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CopyFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CopyFile.json")!,
                             statusCode: 404, headers: [:]
                         )
                     }
@@ -550,7 +549,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -589,7 +588,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("FullFile.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "FullFile.json")!,
                                 statusCode: 200, headers: [:]
                             )
                         }
@@ -619,7 +618,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -660,7 +659,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -709,7 +708,7 @@ class FilesModuleSpecs: QuickSpec {
                             condition: isHost("upload.box.com") && isPath("/api/2.0/files/content") && isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -755,7 +754,7 @@ class FilesModuleSpecs: QuickSpec {
                             condition: isHost("upload.box.com") && isPath("/api/2.0/files/content") && isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -801,7 +800,7 @@ class FilesModuleSpecs: QuickSpec {
                             condition: isHost("upload.box.com") && isPath("/api/2.0/files/content") && isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -848,7 +847,7 @@ class FilesModuleSpecs: QuickSpec {
                         condition: isHost("upload.box.com") && isPath("/api/2.0/files/content") && isMethodPOST()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UploadFileVersion.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UploadFileVersion.json")!,
                             statusCode: 201, headers: [:]
                         )
                     }
@@ -880,7 +879,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFile.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFile.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -924,7 +923,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFile.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFile.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -967,7 +966,7 @@ class FilesModuleSpecs: QuickSpec {
                                 isMethodPOST()
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("UploadFile.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "UploadFile.json")!,
                                 statusCode: 201, headers: [:]
                             )
                         }
@@ -991,7 +990,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should produce file model when API call succeeds") {
                     stub(condition: isHost("upload.box.com") && isPath("/api/2.0/files/content") && isMethodPOST()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UploadFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UploadFile.json")!,
                             statusCode: 201, headers: [:]
                         )
                     }
@@ -1024,7 +1023,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should produce file model when API call succeeds") {
                     stub(condition: isHost("upload.box.com") && isPath("/api/2.0/files/123456/content") && isMethodPOST()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UploadFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UploadFile.json")!,
                             statusCode: 201, headers: [:]
                         )
                     }
@@ -1106,7 +1105,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should be able to lock a file") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/76017730626") && isMethodPUT() && containsQueryParams(["fields": "lock"]) && hasJsonBody(["lock": ["type": "lock", "is_download_prevented": false]])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("LockFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "LockFile.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1140,7 +1139,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should be able to unlock the file") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/76017730626") && isMethodPUT() && containsQueryParams(["fields": "lock"]) && hasJsonBody(["lock": NSNull()])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UnlockFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UnlockFile.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1167,7 +1166,7 @@ class FilesModuleSpecs: QuickSpec {
             describe("getThumbnail()") {
                 it("should be able to get file thumbnail") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/76017730626/thumbnail.jpg") && isMethodGET() && containsQueryParams(["min_height": "256", "max_width": "256"])) { _ in
-                        let image = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!
+                        let image = TestAssets.image(named: "image")!
                         let data = image.jpegData(compressionQuality: 1.0)!
                         return OHHTTPStubsResponse(data: data, statusCode: 200, headers: [:])
                     }
@@ -1197,7 +1196,7 @@ class FilesModuleSpecs: QuickSpec {
                 beforeEach {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/34122832467") && isMethodGET() && containsQueryParams(["fields": "expiring_embed_link"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetEmbedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetEmbedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1225,7 +1224,7 @@ class FilesModuleSpecs: QuickSpec {
                         condition: isHost("api.box.com") && isPath("/2.0/files/123456/collaborations") && isMethodGET() && containsQueryParams(["limit": "100"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FileCollaborations.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FileCollaborations.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1261,7 +1260,7 @@ class FilesModuleSpecs: QuickSpec {
                 it("should be able to get file comments") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5000948880/comments") && isMethodGET() && containsQueryParams(["offset": "0", "limit": "100"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FileComments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FileComments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1292,7 +1291,7 @@ class FilesModuleSpecs: QuickSpec {
 
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5000948880/tasks") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileTasks.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileTasks.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1321,7 +1320,7 @@ class FilesModuleSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1332,7 +1331,7 @@ class FilesModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1344,7 +1343,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["collections": [["id": "405151"]]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AddFileToFavorites.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AddFileToFavorites.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1372,7 +1371,7 @@ class FilesModuleSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1383,7 +1382,7 @@ class FilesModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1395,7 +1394,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["collections": []])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RemoveFileFromFavorites.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RemoveFileFromFavorites.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1426,7 +1425,7 @@ class FilesModuleSpecs: QuickSpec {
                         && isMethodGET()
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullFileVersion.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullFileVersion.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1462,7 +1461,7 @@ class FilesModuleSpecs: QuickSpec {
                         ])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullFileVersion.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullFileVersion.json")!,
                         statusCode: 201, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1512,7 +1511,7 @@ class FilesModuleSpecs: QuickSpec {
 
                 stub(condition: isHost("api.box.com") && isPath("/2.0/files/12345/versions") && isMethodGET()) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetFileVersions.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetFileVersions.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1545,7 +1544,7 @@ class FilesModuleSpecs: QuickSpec {
                         && isMethodGET()
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullWatermark.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullWatermark.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1579,7 +1578,7 @@ class FilesModuleSpecs: QuickSpec {
                         ])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullWatermark.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullWatermark.json")!,
                         statusCode: 201, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1745,7 +1744,7 @@ class FilesModuleSpecs: QuickSpec {
                         containsQueryParams(["fields": "shared_link"])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetFileSharedLink.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetFileSharedLink.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -1776,7 +1775,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open", "permissions": ["can_download": true, "can_edit": true]]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1811,7 +1810,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open", "permissions": ["can_download": true, "can_edit": false]]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1845,7 +1844,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open", "password": "frog"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1879,7 +1878,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open", "vanity_name": "testVanityName"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink_VanityNameEnabled.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink_VanityNameEnabled.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1916,7 +1915,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1950,7 +1949,7 @@ class FilesModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": ["access": "open", "password": NSNull()]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileSharedLink_PasswordNotEnabled.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileSharedLink_PasswordNotEnabled.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -1984,7 +1983,7 @@ class FilesModuleSpecs: QuickSpec {
                         hasJsonBody(["shared_link": NSNull()])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("RemoveFileSharedLink.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "RemoveFileSharedLink.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2027,7 +2026,7 @@ class FilesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("ZipDownload.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "ZipDownload.json")!,
                             statusCode: 202, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -2041,7 +2040,7 @@ class FilesModuleSpecs: QuickSpec {
                         condition: isHost("api.box.com") && isPath("/2.0/zip_downloads/29l00nfxDyHOt7RphI9zT_w==nDnZEDjY2S8iEWWCHEEiptFxwoWojjlibZjJ6geuE5xnXENDTPxzgbks_yY=/status")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("ZipDownloadStatus.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "ZipDownloadStatus.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -2094,7 +2093,7 @@ class FilesModuleSpecs: QuickSpec {
 
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionNewFile.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionNewFile.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2133,7 +2132,7 @@ class FilesModuleSpecs: QuickSpec {
 
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionNewFileVersion.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionNewFileVersion.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2173,7 +2172,7 @@ class FilesModuleSpecs: QuickSpec {
                         hasHeaderNamed("content-range", value: "bytes 8388608-8389052/100000000")
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionUploadPart.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionUploadPart.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2207,7 +2206,7 @@ class FilesModuleSpecs: QuickSpec {
                         isMethodGET()
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionListParts.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionListParts.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2256,7 +2255,7 @@ class FilesModuleSpecs: QuickSpec {
 
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionCommit.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionCommit.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -2329,7 +2328,7 @@ class FilesModuleSpecs: QuickSpec {
                         && isMethodGET()
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("ChunkedUploadSessionGetSession.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "ChunkedUploadSessionGetSession.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }

--- a/Tests/Modules/FolderModuleSpecs.swift
+++ b/Tests/Modules/FolderModuleSpecs.swift
@@ -40,7 +40,7 @@ class FolderModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateFolder.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -67,7 +67,7 @@ class FolderModuleSpecs: QuickSpec {
                 it("should produce error when API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders") && isMethodPOST()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateFolder.json")!,
                             statusCode: 409, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -101,7 +101,7 @@ class FolderModuleSpecs: QuickSpec {
                         ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -139,14 +139,14 @@ class FolderModuleSpecs: QuickSpec {
                 it("should get folder items using offset pagination iterator when usemarker flag is not set") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/\(BoxSDK.Constants.rootFolder)/items") && isMethodGET() && containsQueryParams(["offset": "0"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItemsOffsetIterator1.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItemsOffsetIterator1.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
 
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/\(BoxSDK.Constants.rootFolder)/items") && isMethodGET() && containsQueryParams(["offset": "2"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItemsOffsetIterator2.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItemsOffsetIterator2.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -194,14 +194,14 @@ class FolderModuleSpecs: QuickSpec {
                 it("should get folder items using marker pagination iterator when usemarker flag is set") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/\(BoxSDK.Constants.rootFolder)/items") && isMethodGET() && containsQueryParams(["marker": "eyJ0eXBlIjoiZm9sZGVyIiwiZGlyIjoibmV4dCIsInRhaWwiOiJleUoxYzJWeVgybGtJam8zTlRBeU5UUTNPRGd5TENKd1lYSmxiblJmWm05c1pHVnlYMmxrSWpvd0xDSmtaV3hsZEdWa0lqb3dMQ0ptYjJ4a1pYSmZibUZ0WlNJNklrMTVJRUp2ZUNCT2IzUmxjeUlzSW1admJHUmxjbDlwWkNJNk5qa3hNREk1TURRNE5UVjkifQ"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItemsMarkerIterator2.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItemsMarkerIterator2.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
 
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/\(BoxSDK.Constants.rootFolder)/items") && isMethodGET() && !containsQueryParams(["marker": "eyJ0eXBlIjoiZm9sZGVyIiwiZGlyIjoibmV4dCIsInRhaWwiOiJleUoxYzJWeVgybGtJam8zTlRBeU5UUTNPRGd5TENKd1lYSmxiblJmWm05c1pHVnlYMmxrSWpvd0xDSmtaV3hsZEdWa0lqb3dMQ0ptYjJ4a1pYSmZibUZ0WlNJNklrMTVJRUp2ZUNCT2IzUmxjeUlzSW1admJHUmxjbDlwWkNJNk5qa3hNREk1TURRNE5UVjkifQ"]) && !containsQueryParams(["offset": "2"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItemsMarkerIterator1.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItemsMarkerIterator1.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -236,7 +236,7 @@ class FolderModuleSpecs: QuickSpec {
                 it("should produce error when API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/\(BoxSDK.Constants.rootFolder)/items") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItems.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItems.json")!,
                             statusCode: 404, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -317,7 +317,7 @@ class FolderModuleSpecs: QuickSpec {
                 it("should produce error when the API call fails") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/1231231") && isMethodDELETE()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderItems.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderItems.json")!,
                             statusCode: 404, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -341,7 +341,7 @@ class FolderModuleSpecs: QuickSpec {
                 it("should copy the folder in the destinated folder") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/11446498/copy") && isMethodPOST() && self.compareJSONBody(["parent": ["id": "123456"], "name": "Pictures copy"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CopyFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CopyFolder.json")!,
                             statusCode: 202, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -376,7 +376,7 @@ class FolderModuleSpecs: QuickSpec {
                 it("should get folder collaborations") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/14176246/collaborations") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FolderCollaborations.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FolderCollaborations.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -409,7 +409,7 @@ class FolderModuleSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -420,7 +420,7 @@ class FolderModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -431,7 +431,7 @@ class FolderModuleSpecs: QuickSpec {
                             isMethodPUT()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AddFolderToFavorites.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AddFolderToFavorites.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -459,7 +459,7 @@ class FolderModuleSpecs: QuickSpec {
                             isPath("/2.0/collections")
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollections.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollections.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -470,7 +470,7 @@ class FolderModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -481,7 +481,7 @@ class FolderModuleSpecs: QuickSpec {
                             isMethodPUT()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RemoveFolderFromFavorites.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RemoveFolderFromFavorites.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -511,7 +511,7 @@ class FolderModuleSpecs: QuickSpec {
                             containsQueryParams(["fields": "shared_link"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFolderSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFolderSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -544,7 +544,7 @@ class FolderModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "password": "frog"]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetFolderSharedLink.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetFolderSharedLink.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -578,7 +578,7 @@ class FolderModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "vanity_name": "testVanityName"]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetFolderSharedLink_VanityNameEnabled.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetFolderSharedLink_VanityNameEnabled.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -615,7 +615,7 @@ class FolderModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "permissions": ["can_download": true]]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetFolderSharedLink.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetFolderSharedLink.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -652,7 +652,7 @@ class FolderModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "password": NSNull()]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetFolderSharedLink_PasswordNotEnabled.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetFolderSharedLink_PasswordNotEnabled.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -686,7 +686,7 @@ class FolderModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": NSNull()])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RemoveFolderSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RemoveFolderSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -714,7 +714,7 @@ class FolderModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullWatermark.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullWatermark.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -748,7 +748,7 @@ class FolderModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullWatermark.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullWatermark.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -796,7 +796,7 @@ class FolderModuleSpecs: QuickSpec {
                             containsQueryParams(["folder_id": "14176246"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FolderLocks.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FolderLocks.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -840,7 +840,7 @@ class FolderModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FolderLock.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FolderLock.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/GroupsModuleSpecs.swift
+++ b/Tests/Modules/GroupsModuleSpecs.swift
@@ -34,7 +34,7 @@ class GroupsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroup.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroup.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -74,7 +74,7 @@ class GroupsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroup.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroup.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -114,7 +114,7 @@ class GroupsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroup.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroup.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -167,7 +167,7 @@ class GroupsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroupMembership.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroupMembership.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -215,7 +215,7 @@ class GroupsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroupMembership.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroupMembership.json")!,
                             statusCode: 201, headers: [:]
                         )
                     }
@@ -256,7 +256,7 @@ class GroupsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullGroupMembership.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullGroupMembership.json")!,
                             statusCode: 200, headers: [:]
                         )
                     }
@@ -309,7 +309,7 @@ class GroupsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMembershipsForGroup.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMembershipsForGroup.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -341,7 +341,7 @@ class GroupsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMembershipsForUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMembershipsForUser.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -376,7 +376,7 @@ class GroupsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCollaborationsForGroup.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCollaborationsForGroup.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/LegalHoldsModuleSpecs.swift
+++ b/Tests/Modules/LegalHoldsModuleSpecs.swift
@@ -37,7 +37,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateLegalHoldPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateLegalHoldPolicy.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -68,7 +68,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetLegalHoldPolicyInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetLegalHoldPolicyInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -103,7 +103,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateLegalHoldPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateLegalHoldPolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -158,7 +158,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetLegalHoldPolicies.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetLegalHoldPolicies.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -197,7 +197,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AssignPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AssignPolicy.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -228,7 +228,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetPolicyAssignmentInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetPolicyAssignmentInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -284,7 +284,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && containsQueryParams(["policy_id": "255473"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetPolicyAssignments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetPolicyAssignments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -315,7 +315,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileVersionLegalHoldInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileVersionLegalHoldInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -347,7 +347,7 @@ class LegalHoldsModuleSpecs: QuickSpec {
                             && containsQueryParams(["policy_id": "240997"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileVersionLegalHolds.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileVersionLegalHolds.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/MetadataCascadePolicyModuleSpecs.swift
+++ b/Tests/Modules/MetadataCascadePolicyModuleSpecs.swift
@@ -35,7 +35,7 @@ class MetadataCascadePolicyModuleSpecs: QuickSpec {
                             && containsQueryParams(["owner_enterprise_id": "abcde", "folder_id": "12345"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataCascadePolicies.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataCascadePolicies.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -77,7 +77,7 @@ class MetadataCascadePolicyModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataCascadePolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataCascadePolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -110,7 +110,7 @@ class MetadataCascadePolicyModuleSpecs: QuickSpec {
                             && hasJsonBody(["scope": "enterprise", "folder_id": "998951261", "templateKey": "documentFlow"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateMetadataCascadePolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateMetadataCascadePolicy.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/MetadataModuleSpecs.swift
+++ b/Tests/Modules/MetadataModuleSpecs.swift
@@ -32,7 +32,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata template by name and produce file model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/metadata_templates/enterprise/productInfo/schema") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataTemplate.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataTemplate.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -74,7 +74,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata template by id and produce file model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/metadata_templates/f7a9891f") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataTemplate.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataTemplate.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -137,7 +137,7 @@ class MetadataModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateMetadataTemplate.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateMetadataTemplate.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -226,7 +226,7 @@ class MetadataModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateMetadataTemplate2.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateMetadataTemplate2.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -275,7 +275,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to update metadata template and produce file model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/metadata_templates/enterprise_490685/customer/schema") && isMethodPUT()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateMetadataTemplate.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateMetadataTemplate.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -364,7 +364,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get enterprise metadata templates and produce file model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/metadata_templates/enterprise") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetEnterpriseTemplates.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetEnterpriseTemplates.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -396,7 +396,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get all metadata objects for particular file when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5010739061/metadata") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetAllMetadataOnFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetAllMetadataOnFile.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -442,7 +442,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata objects for particular file when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5010739061/metadata/enterprise/marketingCollateral") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataOnFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataOnFile.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -487,7 +487,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to create metadata objects for particular file when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5010739061/metadata/enterprise/marketingCollateral") && isMethodPOST()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateMetadataOnFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateMetadataOnFile.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -546,7 +546,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata objects for particular file when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/files/5010739061/metadata/enterprise/marketingCollateral") && isMethodPUT()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateMetadataOnFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateMetadataOnFile.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -636,7 +636,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get all metadata objects for particular folder when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/998951261/metadata") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetAllMetadataOnFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetAllMetadataOnFolder.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -676,7 +676,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata objects for particular folder when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/998951261/metadata/enterprise/documentFlow") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetMetadataOnFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetMetadataOnFolder.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -718,7 +718,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to create metadata objects for particular folder when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/998951261/metadata/enterprise/documentFlow") && isMethodPOST()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateMetadataOnFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateMetadataOnFolder.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -771,7 +771,7 @@ class MetadataModuleSpecs: QuickSpec {
                 it("should make API call to get metadata objects for particular folder when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/folders/998951261/metadata/enterprise/documentFlow") && isMethodPUT()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateMetadataOnFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateMetadataOnFolder.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/RecentItemsModuleSpecs.swift
+++ b/Tests/Modules/RecentItemsModuleSpecs.swift
@@ -34,7 +34,7 @@ class RecentItemsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRecentItems.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRecentItems.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/RetentionPolicyModuleSpecs.swift
+++ b/Tests/Modules/RetentionPolicyModuleSpecs.swift
@@ -34,7 +34,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRetentionPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRetentionPolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -88,7 +88,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateRetentionPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateRetentionPolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -140,7 +140,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateRetentionPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateRetentionPolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -180,7 +180,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateRetentionPolicy.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateRetentionPolicy.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -210,7 +210,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRetentionPolicies.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRetentionPolicies.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -246,7 +246,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRetentionPolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRetentionPolicyAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -292,7 +292,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateRetentionPolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateRetentionPolicyAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -341,7 +341,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateRetentionPolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateRetentionPolicyAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -404,7 +404,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
 
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetRetentionPolicyAssignments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetRetentionPolicyAssignments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -440,7 +440,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileVersionRetention.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileVersionRetention.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -482,7 +482,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileVersionRetentions.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileVersionRetentions.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -519,7 +519,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFilesUnderRetentionForAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFilesUnderRetentionForAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -556,7 +556,7 @@ class RetentionPolicyModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileVersionsUnderRetentionForAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileVersionsUnderRetentionForAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/SearchModuleSpecs.swift
+++ b/Tests/Modules/SearchModuleSpecs.swift
@@ -33,7 +33,7 @@ class SearchModuleSpecs: QuickSpec {
                             && containsQueryParams(["query": "test"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -70,7 +70,7 @@ class SearchModuleSpecs: QuickSpec {
                             && containsQueryParams(["mdfilters": "[{\"scope\":\"global\",\"templateKey\":\"marketingCollateral\",\"filters\":{\"date\":{\"gt\":\"2019-07-24T12:00:00Z\"}}}]"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -98,7 +98,7 @@ class SearchModuleSpecs: QuickSpec {
                             && containsQueryParams(["mdfilters": "[{\"scope\":\"enterprise\",\"templateKey\":\"marketingCollateral\",\"filters\":{\"date\":{\"lt\":\"2019-07-24T12:00:00Z\"}}}]"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -126,7 +126,7 @@ class SearchModuleSpecs: QuickSpec {
                             && containsQueryParams(["mdfilters": "[{\"scope\":\"enterprise\",\"templateKey\":\"marketingCollateral\",\"filters\":{\"documentType\":\"dataSheet\"}}]"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -154,7 +154,7 @@ class SearchModuleSpecs: QuickSpec {
                             && containsQueryParams(["mdfilters": "[{\"scope\":\"global\",\"templateKey\":\"marketingCollateral\",\"filters\":{\"documentType\":\"dataSheet\"}}]"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -194,7 +194,7 @@ class SearchModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("Search200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "Search200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -244,7 +244,7 @@ class SearchModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("SearchResult200.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "SearchResult200.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/SharedItemsModuleSpecs.swift
+++ b/Tests/Modules/SharedItemsModuleSpecs.swift
@@ -35,7 +35,7 @@ class SharedItemsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -68,7 +68,7 @@ class SharedItemsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetFileInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetFileInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/SignRequestsModuleSpecs.swift
+++ b/Tests/Modules/SignRequestsModuleSpecs.swift
@@ -59,7 +59,7 @@ class SignRequestsModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateSignRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateSignRequest.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -141,7 +141,7 @@ class SignRequestsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetSignRequests.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetSignRequests.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -185,7 +185,7 @@ class SignRequestsModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetSignRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetSignRequest.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -250,7 +250,7 @@ class SignRequestsModuleSpecs: QuickSpec {
                             && isMethodPOST()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CancelSignRequest.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CancelSignRequest.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/StoragePoliciesModuleSpecs.swift
+++ b/Tests/Modules/StoragePoliciesModuleSpecs.swift
@@ -33,7 +33,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetStoragePolicyInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetStoragePolicyInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -64,7 +64,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetStoragePolicies.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetStoragePolicies.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -97,7 +97,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetStoragePolicyAssignmentInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetStoragePolicyAssignmentInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -129,7 +129,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetStoragePolicyAssignments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetStoragePolicyAssignments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -170,7 +170,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateStoragePolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateStoragePolicyAssignment.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -220,7 +220,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetStoragePolicyAssignments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetStoragePolicyAssignments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -237,7 +237,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateStoragePolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateStoragePolicyAssignment.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -275,7 +275,7 @@ class StoragePoliciesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateStoragePolicyAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateStoragePolicyAssignment.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/TasksModuleSpecs.swift
+++ b/Tests/Modules/TasksModuleSpecs.swift
@@ -34,7 +34,7 @@ class TasksModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTask.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTask.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -94,7 +94,7 @@ class TasksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateTask.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateTask.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -153,7 +153,7 @@ class TasksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateTask.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateTask.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -240,7 +240,7 @@ class TasksModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTaskAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTaskAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -315,7 +315,7 @@ class TasksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateTaskAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateTaskAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -390,7 +390,7 @@ class TasksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateTaskAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateTaskAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -460,7 +460,7 @@ class TasksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateTaskAssignment.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateTaskAssignment.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -554,7 +554,7 @@ class TasksModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetAssignments.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetAssignments.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/TermsOfServicesModuleSpecs.swift
+++ b/Tests/Modules/TermsOfServicesModuleSpecs.swift
@@ -40,7 +40,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateTermsOfService.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateTermsOfService.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -76,7 +76,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullTermsOfService.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullTermsOfService.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -108,7 +108,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullTermsOfService.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullTermsOfService.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -140,7 +140,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTermsOfServices.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTermsOfServices.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -174,7 +174,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                         && containsQueryParams(["tos_type": "managed"])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetManagedTermsOfService.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetManagedTermsOfService.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -216,7 +216,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                         ])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullTermsOfServiceUserStatus.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullTermsOfServiceUserStatus.json")!,
                         statusCode: 201, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -249,7 +249,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                         && containsQueryParams(["tos_id": "12345", "user_id": "88888"])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetTermsOfServiceUserStatuses.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetTermsOfServiceUserStatuses.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -279,7 +279,7 @@ class TermsOfServicesModuleSpecs: QuickSpec {
                         ])
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("FullTermsOfServiceUserStatus.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "FullTermsOfServiceUserStatus.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }

--- a/Tests/Modules/TrashModuleSpecs.swift
+++ b/Tests/Modules/TrashModuleSpecs.swift
@@ -34,7 +34,7 @@ class TrashModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTrashedItems.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTrashedItems.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -75,7 +75,7 @@ class TrashModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTrashedFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTrashedFile.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -110,7 +110,7 @@ class TrashModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTrashedFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTrashedFolder.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -145,7 +145,7 @@ class TrashModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetTrashedWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetTrashedWebLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -184,7 +184,7 @@ class TrashModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RestoreFile.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RestoreFile.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -227,7 +227,7 @@ class TrashModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RestoreFolder.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RestoreFolder.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -270,7 +270,7 @@ class TrashModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RestoreWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RestoreWebLink.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/UsersModuleSpecs.swift
+++ b/Tests/Modules/UsersModuleSpecs.swift
@@ -29,7 +29,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should make API call to retrieve user and produce user model when API call succeeds") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/10543463") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -65,7 +65,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should send fields as comma-separated values when field parameter is passed") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/10543463") && isMethodGET() && containsQueryParams(["fields": "type,id,name"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -90,7 +90,7 @@ class UsersModuleSpecs: QuickSpec {
 
             describe("uploadAvatar()") {
                 it("should upload an image and return valid response") {
-                    let image = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!
+                    let image = TestAssets.image(named: "image")!
                     let data = image.pngData()!
 
                     stub(
@@ -99,7 +99,7 @@ class UsersModuleSpecs: QuickSpec {
 
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UploadUserAvatar.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UploadUserAvatar.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -128,7 +128,7 @@ class UsersModuleSpecs: QuickSpec {
 
             describe("streamUploadAvatar()") {
                 it("should upload an image and return valid response") {
-                    let image = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!
+                    let image = TestAssets.image(named: "image")!
                     let stream = InputStream(data: image.pngData()!)
 
                     stub(
@@ -137,7 +137,7 @@ class UsersModuleSpecs: QuickSpec {
 
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UploadUserAvatar.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UploadUserAvatar.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -171,7 +171,7 @@ class UsersModuleSpecs: QuickSpec {
                             isPath("/2.0/users/10543463/avatar") &&
                             isMethodGET()
                     ) { _ in
-                        let image = UIImage(named: "image", in: Bundle(for: type(of: self)), compatibleWith: nil)!
+                        let image = TestAssets.image(named: "image")!
                         let data = image.jpegData(compressionQuality: 1.0)!
                         return OHHTTPStubsResponse(data: data, statusCode: 200, headers: [:])
                     }
@@ -230,7 +230,7 @@ class UsersModuleSpecs: QuickSpec {
                                          "status": UserStatus.active.description])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateUser.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -271,7 +271,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should retreive current user information") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/me") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetCurrentUserInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetCurrentUserInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -308,7 +308,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should create a new app user") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users") && isMethodPOST() && hasJsonBody(["name": "Test User", "is_platform_access_only": true])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateAppUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateAppUser.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -345,7 +345,7 @@ class UsersModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateUser.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -390,7 +390,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should return a list of users of the enterprise") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users") && isMethodGET() && containsQueryParams(["limit": "100"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetEnterpriseUsersOffset-Pagination.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetEnterpriseUsersOffset-Pagination.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -417,7 +417,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should return a list of users of the enterprise using marker pagination") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users") && isMethodGET() && containsQueryParams(["limit": "100", "usemarker": "true"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetEnterpriseUsersMarker-Pagination.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetEnterpriseUsersMarker-Pagination.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -448,7 +448,7 @@ class UsersModuleSpecs: QuickSpec {
                         condition: isHost("api.box.com") && isPath("/2.0/invites") && isMethodPOST() && hasJsonBody(["enterprise": ["id": "42500"], "actionable_by": ["login": "freeuser@email.com"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("InviteUserToEnterprise.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "InviteUserToEnterprise.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -475,7 +475,7 @@ class UsersModuleSpecs: QuickSpec {
                         condition: isHost("api.box.com") && isPath("/2.0/users/1234/folders/0") && isMethodPUT() && hasJsonBody(["owned_by": ["id": "123456"]])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("MoveUserItemsToAnotherUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "MoveUserItemsToAnotherUser.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -498,7 +498,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should change user login and return the user with the new login") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/18180156") && isMethodPUT() && hasJsonBody(["login": "testuser@example.com"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateUserLogin.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateUserLogin.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -523,7 +523,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should retrieves all email aliases for a user and return the iterator with the email aliases of the user ") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/123456/email_aliases") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GellAllUserEmailAliases.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GellAllUserEmailAliases.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -548,7 +548,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should Add new email aliases for a user and return the new email alias for the user") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/123456/email_aliases") && isMethodPOST() && hasJsonBody(["email": "user@email.com"])) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("AddEmailAlias.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "AddEmailAlias.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -593,7 +593,7 @@ class UsersModuleSpecs: QuickSpec {
                 it("should roll out user from enterprise get the updated user") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/users/12345") && isMethodPUT() && self.testRollOutUserFromEnterpriseBody()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateUser.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateUser.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Modules/WebLinksModuleSpecs.swift
+++ b/Tests/Modules/WebLinksModuleSpecs.swift
@@ -43,7 +43,7 @@ class WebLinksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullWebLink.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -72,7 +72,7 @@ class WebLinksModuleSpecs: QuickSpec {
                 it("should make an API call to retrieve a specified web link") {
                     stub(condition: isHost("api.box.com") && isPath("/2.0/web_links/12345") && isMethodGET()) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("FullWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "FullWebLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -131,7 +131,7 @@ class WebLinksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateWebLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -172,7 +172,7 @@ class WebLinksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateWebLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateWebLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -214,7 +214,7 @@ class WebLinksModuleSpecs: QuickSpec {
                             containsQueryParams(["fields": "shared_link"])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetWebLinkSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetWebLinkSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -248,7 +248,7 @@ class WebLinksModuleSpecs: QuickSpec {
                             hasJsonBody(["shared_link": NSNull()])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("RemoveWebLinkSharedLink.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "RemoveWebLinkSharedLink.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -280,7 +280,7 @@ class WebLinksModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "password": "test"]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetWebLinkSharedLink.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetWebLinkSharedLink.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -314,7 +314,7 @@ class WebLinksModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open"]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetWebLinkSharedLink.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetWebLinkSharedLink.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -348,7 +348,7 @@ class WebLinksModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "password": NSNull()]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetWebLinkSharedLink_PasswordNotEnabled.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetWebLinkSharedLink_PasswordNotEnabled.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -382,7 +382,7 @@ class WebLinksModuleSpecs: QuickSpec {
                                 hasJsonBody(["shared_link": ["access": "open", "vanity_name": "testVanityName"]])
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("GetWebLinkSharedLink_VanityNameEnabled.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "GetWebLinkSharedLink_VanityNameEnabled.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }

--- a/Tests/Modules/WebhooksModuleSpecs.swift
+++ b/Tests/Modules/WebhooksModuleSpecs.swift
@@ -42,7 +42,7 @@ class WebhooksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("CreateWebhook.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "CreateWebhook.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -79,7 +79,7 @@ class WebhooksModuleSpecs: QuickSpec {
                             ])
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("UpdateWebhook.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "UpdateWebhook.json")!,
                             statusCode: 201, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -109,7 +109,7 @@ class WebhooksModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetWebhookInfo.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetWebhookInfo.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }
@@ -139,7 +139,7 @@ class WebhooksModuleSpecs: QuickSpec {
                             && isMethodGET()
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("GetWebhooks.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "GetWebhooks.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Network/BoxNetworkAgentSpecs.swift
+++ b/Tests/Network/BoxNetworkAgentSpecs.swift
@@ -85,7 +85,7 @@ class BoxNetworkAgentSpecs: QuickSpec {
                         && hasHeaderNamed("X-Box-UA", value: analyticsHeader)
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -116,7 +116,7 @@ class BoxNetworkAgentSpecs: QuickSpec {
                         && hasHeaderNamed("X-Box-UA", value: analyticsHeader)
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }
@@ -140,7 +140,7 @@ class BoxNetworkAgentSpecs: QuickSpec {
                         && hasHeaderNamed("Content-Type", value: "application/vnd.box+json")
                 ) { _ in
                     OHHTTPStubsResponse(
-                        fileAtPath: OHPathForFile("GetUserInfo.json", type(of: self))!,
+                        fileAtPath: TestAssets.path(forResource: "GetUserInfo.json")!,
                         statusCode: 200, headers: ["Content-Type": "application/json"]
                     )
                 }

--- a/Tests/Network/PagingIteratorSpecs.swift
+++ b/Tests/Network/PagingIteratorSpecs.swift
@@ -34,7 +34,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["usemarker": "true"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("MarkerBasedPagingWithValidNext.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "MarkerBasedPagingWithValidNext.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -43,7 +43,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["usemarker": "true", "marker": "next_marker_value_1"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("MarkerBasedPagingWithEmptyNext.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "MarkerBasedPagingWithEmptyNext.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -84,7 +84,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["usemarker": "true"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("MarkerBasedPagingWithEmptyNext.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "MarkerBasedPagingWithEmptyNext.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -124,7 +124,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["usemarker": "true"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("MarkerBasedPagingWithNullNext.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "MarkerBasedPagingWithNullNext.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -167,7 +167,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["limit": "2"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("OffsetBasedPagingWithMoreItems.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "OffsetBasedPagingWithMoreItems.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -176,7 +176,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["offset": "2", "limit": "2"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("OffsetBasedPagingWithoutMoreItems.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "OffsetBasedPagingWithoutMoreItems.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -221,7 +221,7 @@ class PagingIteratorSpecs: QuickSpec {
                         && isPath("/2.0/list_items")
                         && isMethodGET() && containsQueryParams(["offset": "2", "limit": "2"])) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("OffsetBasedPagingWithoutMoreItems.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "OffsetBasedPagingWithoutMoreItems.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }

--- a/Tests/Requests/BodyData/SignRequestCreateRequestSpecs.swift
+++ b/Tests/Requests/BodyData/SignRequestCreateRequestSpecs.swift
@@ -26,7 +26,7 @@ class SignRequestCreateRequestSpecs: QuickSpec {
                     }
 
                     it("should correctly create an object using init with file object parameter") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                             fail("Could not find fixture file.")
                             return
                         }
@@ -58,7 +58,7 @@ class SignRequestCreateRequestSpecs: QuickSpec {
                     }
 
                     it("should correctly create an object using init with folder object parameter") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                             fail("Could not find fixture file.")
                             return
                         }

--- a/Tests/Responses/BoxModel/BoxModelSpecs.swift
+++ b/Tests/Responses/BoxModel/BoxModelSpecs.swift
@@ -16,7 +16,7 @@ class BoxModelSpecs: QuickSpec {
     override func spec() {
         describe("testing boxmodel on comment") {
             it("should make call to init() to initalize comment response object from JSON dictionary") {
-                guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                     fail("Could not find fixture file.")
                     return
                 }
@@ -50,7 +50,7 @@ class BoxModelSpecs: QuickSpec {
             }
 
             it("should make call to init() to initalize comment response object from JSON Data") {
-                guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                     fail("Could not find fixture file.")
                     return
                 }

--- a/Tests/Responses/CollaborationItemSpecs.swift
+++ b/Tests/Responses/CollaborationItemSpecs.swift
@@ -18,7 +18,7 @@ class CollaborationItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -49,7 +49,7 @@ class CollaborationItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a folder from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -81,7 +81,7 @@ class CollaborationItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -98,7 +98,7 @@ class CollaborationItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -117,7 +117,7 @@ class CollaborationItemSpecs: QuickSpec {
 
             describe("rawData") {
                 it("should be equal to json data used to create the CollaborationItem file type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -136,7 +136,7 @@ class CollaborationItemSpecs: QuickSpec {
                 }
 
                 it("should be equal to json data used to create the CollaborationItem folder type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -157,7 +157,7 @@ class CollaborationItemSpecs: QuickSpec {
 
             describe("debugDescription") {
                 it("should return correct description for a file type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -174,7 +174,7 @@ class CollaborationItemSpecs: QuickSpec {
                 }
 
                 it("should return correct description for folder type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/CollaborationSpecs.swift
+++ b/Tests/Responses/CollaborationSpecs.swift
@@ -18,7 +18,7 @@ class CollaborationSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullCollaboration", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullCollaboration.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -91,7 +91,7 @@ class CollaborationSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize group collaboration from JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "GroupCollaboration", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "GroupCollaboration.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/CommentItemSpecs.swift
+++ b/Tests/Responses/CommentItemSpecs.swift
@@ -18,7 +18,7 @@ class CommentItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -53,7 +53,7 @@ class CommentItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a comment type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -82,7 +82,7 @@ class CommentItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in `type` filed") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -99,7 +99,7 @@ class CommentItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no `type` field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -118,7 +118,7 @@ class CommentItemSpecs: QuickSpec {
 
             describe("rawData") {
                 it("should be equal to json data used to create the CommentItem file type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -137,7 +137,7 @@ class CommentItemSpecs: QuickSpec {
                 }
 
                 it("should be equal to json data used to create the CommentItem comment type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -158,7 +158,7 @@ class CommentItemSpecs: QuickSpec {
 
             describe("debugDescription") {
                 it("should return correct description for a file type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -175,7 +175,7 @@ class CommentItemSpecs: QuickSpec {
                 }
 
                 it("should return correct description for comment type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/CommentSpecs.swift
+++ b/Tests/Responses/CommentSpecs.swift
@@ -17,7 +17,7 @@ class CommentSpecs: QuickSpec {
             describe("init()") {
                 context("success case") {
                     it("should make call to init() to initalize comment response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullComment", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FullComment.json") else {
                             fail("Could not find fixture file.")
                             return
                         }
@@ -56,7 +56,7 @@ class CommentSpecs: QuickSpec {
 
                 context("decoding error case when required field is missing or mismatched") {
                     it("should make call to init() to initalize comment response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FaultyComment_MissingRequiredField", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FaultyComment_MissingRequiredField.json") else {
                             fail("Could not find fixture file.")
                             return
                         }
@@ -75,7 +75,7 @@ class CommentSpecs: QuickSpec {
 
                 context("decoding error case when required field is missing or mismatched") {
                     it("should make call to init() to initalize comment response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FaultyComment_ValueFormatMismatch", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FaultyComment_ValueFormatMismatch.json") else {
                             fail("Could not find fixture file.")
                             return
                         }

--- a/Tests/Responses/DevicePinSpecs.swift
+++ b/Tests/Responses/DevicePinSpecs.swift
@@ -16,7 +16,7 @@ class DevicePinSpecs: QuickSpec {
         describe("DevicePin") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullDevicePin", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullDevicePin.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileRepresentationSpecs.swift
+++ b/Tests/Responses/FileRepresentationSpecs.swift
@@ -18,7 +18,7 @@ class FileRepresentationSpecs: QuickSpec {
             describe("init") {
 
                 it("should correctly decode a file representation type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FileRepresentationState", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FileRepresentationState.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileRequestSpecs.swift
+++ b/Tests/Responses/FileRequestSpecs.swift
@@ -18,7 +18,7 @@ class FileRequestSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "GetFileRequest", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "GetFileRequest.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileSpecs.swift
+++ b/Tests/Responses/FileSpecs.swift
@@ -18,7 +18,7 @@ class FileSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileVersionLegalHoldSpecs.swift
+++ b/Tests/Responses/FileVersionLegalHoldSpecs.swift
@@ -17,7 +17,7 @@ class FileVersionLegalHoldSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize file version legal hold from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFileVersionLegalHold", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFileVersionLegalHold.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileVersionRetentionSpecs.swift
+++ b/Tests/Responses/FileVersionRetentionSpecs.swift
@@ -18,7 +18,7 @@ class FileVersionRetentionSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize file version retention from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFileVersionRetention", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFileVersionRetention.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FileVersionSpecs.swift
+++ b/Tests/Responses/FileVersionSpecs.swift
@@ -17,7 +17,7 @@ class FileVersionSpecs: QuickSpec {
 
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFileVersion", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFileVersion.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FolderItemSpecs.swift
+++ b/Tests/Responses/FolderItemSpecs.swift
@@ -18,7 +18,7 @@ class FolderItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -49,7 +49,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a folder type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -82,7 +82,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a webLink type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebLink", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebLink.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -116,7 +116,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in type filed") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -133,7 +133,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -152,7 +152,7 @@ class FolderItemSpecs: QuickSpec {
 
             describe("rawData") {
                 it("should be equal to json data used to create the FolderItem file type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -171,7 +171,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should be equal to json data used to create the FolderItem folder type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -190,7 +190,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should be equal to json data used to create the FolderItem webLink type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebLink", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebLink.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -211,7 +211,7 @@ class FolderItemSpecs: QuickSpec {
 
             describe("debugDescription") {
                 it("should return correct description for a file type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -228,7 +228,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should return correct description for folder type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -246,7 +246,7 @@ class FolderItemSpecs: QuickSpec {
                 }
 
                 it("should return correct description for webLink type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebLink", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebLink.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/FolderSpecs.swift
+++ b/Tests/Responses/FolderSpecs.swift
@@ -17,7 +17,7 @@ class FolderSpecs: QuickSpec {
 
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/GroupMembershipSpecs.swift
+++ b/Tests/Responses/GroupMembershipSpecs.swift
@@ -16,7 +16,7 @@ class GroupMembershipSpecs: QuickSpec {
         describe("GroupMembership") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullGroupMembership", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullGroupMembership.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/GroupSpecs.swift
+++ b/Tests/Responses/GroupSpecs.swift
@@ -16,7 +16,7 @@ class GroupSpecs: QuickSpec {
         describe("Group") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullGroup", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullGroup.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/LegalHoldPolicyAssignmentSpecs.swift
+++ b/Tests/Responses/LegalHoldPolicyAssignmentSpecs.swift
@@ -17,7 +17,7 @@ class LegalHoldPolicyAssignmentSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize legal hold assignment from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullPolicyAssignment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullPolicyAssignment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/LegalHoldPolicySpecs.swift
+++ b/Tests/Responses/LegalHoldPolicySpecs.swift
@@ -17,7 +17,7 @@ class LegalHoldPolicySpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize legal hold policy from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullLegalHoldPolicy", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullLegalHoldPolicy.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/RecentItemSpecs.swift
+++ b/Tests/Responses/RecentItemSpecs.swift
@@ -18,7 +18,7 @@ class RecentItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullRecentItem", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullRecentItem.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/RetentionPolicyAssignmentSpecs.swift
+++ b/Tests/Responses/RetentionPolicyAssignmentSpecs.swift
@@ -18,7 +18,7 @@ class RetentionPolicyAssignmentSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize retention policy assignment from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullRetentionPolicyAssignment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullRetentionPolicyAssignment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/RetentionPolicySpecs.swift
+++ b/Tests/Responses/RetentionPolicySpecs.swift
@@ -18,7 +18,7 @@ class RetentionPolicySpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize retention policy from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullRetentionPolicy", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullRetentionPolicy.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/SharedItemSpecs.swift
+++ b/Tests/Responses/SharedItemSpecs.swift
@@ -18,7 +18,7 @@ class SharedItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -49,7 +49,7 @@ class SharedItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a folder type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -82,7 +82,7 @@ class SharedItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a webLink type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebLink", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebLink.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -116,7 +116,7 @@ class SharedItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in type filed") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -133,7 +133,7 @@ class SharedItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/SignRequestSpecs.swift
+++ b/Tests/Responses/SignRequestSpecs.swift
@@ -18,7 +18,7 @@ class SignRequestSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullSignRequest", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullSignRequest.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/StoragePolicyAssignmentSpecs.swift
+++ b/Tests/Responses/StoragePolicyAssignmentSpecs.swift
@@ -17,7 +17,7 @@ class StoragePolicyAssignmentSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullStoragePolicyAssignment", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullStoragePolicyAssignment.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/StoragePolicySpecs.swift
+++ b/Tests/Responses/StoragePolicySpecs.swift
@@ -17,7 +17,7 @@ class StoragePolicySpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullStoragePolicy", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullStoragePolicy.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/TaskItemSpecs.swift
+++ b/Tests/Responses/TaskItemSpecs.swift
@@ -18,7 +18,7 @@ class TaskItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -49,7 +49,7 @@ class TaskItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -66,7 +66,7 @@ class TaskItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -85,7 +85,7 @@ class TaskItemSpecs: QuickSpec {
 
             describe("rawData") {
                 it("should be equal to json data used to create the TaskItem file type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -106,7 +106,7 @@ class TaskItemSpecs: QuickSpec {
 
             describe("debugDescription") {
                 it("should return correct description for a file type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/TaskSpecs.swift
+++ b/Tests/Responses/TaskSpecs.swift
@@ -16,7 +16,7 @@ class TaskSpecs: QuickSpec {
         describe("Task") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullTask", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullTask.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/TermsOfServiceSpecs.swift
+++ b/Tests/Responses/TermsOfServiceSpecs.swift
@@ -18,7 +18,7 @@ class TermsOfServiceSpecs: QuickSpec {
         describe("TermsOfService") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullTermsOfService", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullTermsOfService.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/TermsOfServiceUserStatusSpecs.swift
+++ b/Tests/Responses/TermsOfServiceUserStatusSpecs.swift
@@ -17,7 +17,7 @@ class TermsOfServiceUserStatusSpecs: QuickSpec {
         describe("TermsOfServiceUserStatus") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullTermsOfServiceUserStatus", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullTermsOfServiceUserStatus.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/UserAvatarUploadSpecs.swift
+++ b/Tests/Responses/UserAvatarUploadSpecs.swift
@@ -17,7 +17,7 @@ class UserAvatarUploadSpecs: QuickSpec {
 
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "UploadUserAvatar", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "UploadUserAvatar.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/UserSpecs.swift
+++ b/Tests/Responses/UserSpecs.swift
@@ -17,7 +17,7 @@ class UserSpecs: QuickSpec {
 
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullUser", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullUser.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/WatermarkSpecs.swift
+++ b/Tests/Responses/WatermarkSpecs.swift
@@ -17,7 +17,7 @@ class WatermarkSpecs: QuickSpec {
             describe("init()") {
                 context("success case") {
                     it("should make call to init() to initialize watermark response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWatermark", ofType: "json") else {
+                        guard let filepath = TestAssets.path(forResource: "FullWatermark.json") else {
                             fail("Could not find fixture file.")
                             return
                         }
@@ -38,7 +38,7 @@ class WatermarkSpecs: QuickSpec {
 
                 context("decoding error case when required field is missing") {
                     it("should make call to init() to initialize watermark response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "InvalidWatermarkMissing", ofType: "json")
+                        guard let filepath = TestAssets.path(forResource: "InvalidWatermarkMissing.json")
                         else {
                             fail("Could not find fixture file.")
                             return
@@ -58,7 +58,7 @@ class WatermarkSpecs: QuickSpec {
 
                 context("decoding error case when required field is invalid type") {
                     it("should make call to init() to initialize watermark response object") {
-                        guard let filepath = Bundle(for: type(of: self)).path(forResource: "InvalidWatermarkInvalid", ofType: "json")
+                        guard let filepath = TestAssets.path(forResource: "InvalidWatermarkInvalid.json")
                         else {
                             fail("Could not find fixture file.")
                             return

--- a/Tests/Responses/WebLinkSpecs.swift
+++ b/Tests/Responses/WebLinkSpecs.swift
@@ -16,7 +16,7 @@ class WebLinkSpecs: QuickSpec {
         describe("WebLink") {
             describe("init()") {
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebLink", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebLink.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/WebhookItemSpecs.swift
+++ b/Tests/Responses/WebhookItemSpecs.swift
@@ -18,7 +18,7 @@ class WebhookItemSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize a file type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -49,7 +49,7 @@ class WebhookItemSpecs: QuickSpec {
                 }
 
                 it("should correctly deserialize a folder type from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -82,7 +82,7 @@ class WebhookItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.valueMismatch exception when deserialize an object with an unknown value in type filed") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_ValueFormatMismatch", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_ValueFormatMismatch.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -99,7 +99,7 @@ class WebhookItemSpecs: QuickSpec {
                 }
 
                 it("should throw BoxCodingError.typeMismatch exception when deserialize object with no type field") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile_MissingRequiredField", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile_MissingRequiredField.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -118,7 +118,7 @@ class WebhookItemSpecs: QuickSpec {
 
             describe("rawData") {
                 it("should be equal to json data used to create the WebhookItem file type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -137,7 +137,7 @@ class WebhookItemSpecs: QuickSpec {
                 }
 
                 it("should be equal to json data used to create the WebhookItem folder type object") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -158,7 +158,7 @@ class WebhookItemSpecs: QuickSpec {
 
             describe("debugDescription") {
                 it("should return correct description for a file type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFile", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFile.json") else {
                         fail("Could not find fixture file.")
                         return
                     }
@@ -175,7 +175,7 @@ class WebhookItemSpecs: QuickSpec {
                 }
 
                 it("should return correct description for folder type") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullFolder", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullFolder.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Responses/WebhookSpecs.swift
+++ b/Tests/Responses/WebhookSpecs.swift
@@ -18,7 +18,7 @@ class WebhookSpecs: QuickSpec {
             describe("init()") {
 
                 it("should correctly deserialize from full JSON representation") {
-                    guard let filepath = Bundle(for: type(of: self)).path(forResource: "FullWebhook", ofType: "json") else {
+                    guard let filepath = TestAssets.path(forResource: "FullWebhook.json") else {
                         fail("Could not find fixture file.")
                         return
                     }

--- a/Tests/Sessions/CCGAuthSessionSpecs.swift
+++ b/Tests/Sessions/CCGAuthSessionSpecs.swift
@@ -63,7 +63,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -102,7 +102,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -141,7 +141,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -253,7 +253,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -292,7 +292,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -331,7 +331,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                                 )
                         ) { _ in
                             OHHTTPStubsResponse(
-                                fileAtPath: OHPathForFile("AccessToken.json", type(of: self))!,
+                                fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
                                 statusCode: 200, headers: ["Content-Type": "application/json"]
                             )
                         }
@@ -551,7 +551,7 @@ class CCGAuthSessionSpecs: QuickSpec {
                             )
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("DownscopeToken.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "DownscopeToken.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Sessions/DelegatedAuthSessionSpecs.swift
+++ b/Tests/Sessions/DelegatedAuthSessionSpecs.swift
@@ -193,7 +193,7 @@ class DelegatedAuthSessionSpecs: QuickSpec {
                             )
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("DownscopeToken.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "DownscopeToken.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }

--- a/Tests/Sessions/OAuth2SessionSpecs.swift
+++ b/Tests/Sessions/OAuth2SessionSpecs.swift
@@ -214,7 +214,7 @@ class OAuth2SessionSpecs: QuickSpec {
                             )
                     ) { _ in
                         OHHTTPStubsResponse(
-                            fileAtPath: OHPathForFile("DownscopeToken.json", type(of: self))!,
+                            fileAtPath: TestAssets.path(forResource: "DownscopeToken.json")!,
                             statusCode: 200, headers: ["Content-Type": "application/json"]
                         )
                     }


### PR DESCRIPTION
### Goals :soccer:

Avoid accessing test resources directly through the test bundle, including through the use of `OHPathForFile`, which is third party code. Instead, all accesses in unit tests go through methods on a new `TestAssets` class.

This should not change the existing behavior, but sets up to support testing through a Swift Package Manager test target. The existing test target there fails. One reason is that the tests don't include the needed resources, and even if they did, SPM packages the code in a different way, such that the existing code to locate the resources would fail. This change sets up a single place (`TestAssets.resourceBundle`) which can be modified to direct to account for this packaging difference in the future.