### PR TITLE
chore: Make SDK compiles on Linux

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,14 +7,14 @@ on:
     branches:
       - main
 jobs:
-  build-and-test:
+  ios-build-and-test:
     runs-on: macos-13
     strategy:
       matrix:
         destination: ['platform=iOS Simulator,OS=16.2,name=iPhone 14']
     steps:
       - name: Git - Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: List Xcode available versions
         run: ls -n /Applications/ | grep Xcode*
       - name: Setup - Xcode
@@ -43,3 +43,18 @@ jobs:
           GIT_BRANCH: ${{ steps.get_branch.outputs.branch }}
           CI_PULL_REQUEST: ${{ github.event.number }}
           COVERAGE_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: swift:6.0-jammy
+            name: 'SPM (Swift 6.0, Ubuntu 22.04)'
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build
+        run: swift build

--- a/BoxSDK/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK/BoxSDK.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0508666128A2A62B0073DC77 /* UpdateFileRequest.json in Resources */ = {isa = PBXBuildFile; fileRef = 0508666028A2A62B0073DC77 /* UpdateFileRequest.json */; };
 		0508666328A2B1240073DC77 /* CopyFileRequest.json in Resources */ = {isa = PBXBuildFile; fileRef = 0508666228A2B1240073DC77 /* CopyFileRequest.json */; };
 		050E725128BE54C000213B4D /* SignRequestSignerInputContentTypeSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050E725028BE54C000213B4D /* SignRequestSignerInputContentTypeSpecs.swift */; };
+		0517CB4D2E6EF9E1000EBD1A /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0517CB4C2E6EF9DF000EBD1A /* SHA1.swift */; };
 		052A03F328772E2F0063513C /* UserAvatarUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052A03F228772E2F0063513C /* UserAvatarUpload.swift */; };
 		052A03F5287885860063513C /* MimeTypeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052A03F4287885860063513C /* MimeTypeProvider.swift */; };
 		052A03F828788CAF0063513C /* MimeTypeProviderSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052A03F628788C7C0063513C /* MimeTypeProviderSpecs.swift */; };
@@ -651,6 +652,7 @@
 		0508666028A2A62B0073DC77 /* UpdateFileRequest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = UpdateFileRequest.json; sourceTree = "<group>"; };
 		0508666228A2B1240073DC77 /* CopyFileRequest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CopyFileRequest.json; sourceTree = "<group>"; };
 		050E725028BE54C000213B4D /* SignRequestSignerInputContentTypeSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignRequestSignerInputContentTypeSpecs.swift; sourceTree = "<group>"; };
+		0517CB4C2E6EF9DF000EBD1A /* SHA1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA1.swift; sourceTree = "<group>"; };
 		052A03F228772E2F0063513C /* UserAvatarUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAvatarUpload.swift; sourceTree = "<group>"; };
 		052A03F4287885860063513C /* MimeTypeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypeProvider.swift; sourceTree = "<group>"; };
 		052A03F628788C7C0063513C /* MimeTypeProviderSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeTypeProviderSpecs.swift; sourceTree = "<group>"; };
@@ -1566,6 +1568,7 @@
 		225638FF2253897C00D951B5 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				0517CB4C2E6EF9DF000EBD1A /* SHA1.swift */,
 				222DBFE22289ABB700D03A88 /* Errors */,
 				223A7F2122770A6E00C136E1 /* Extensions */,
 				0C4A9D17226DBCB4002D069D /* BoxSDKConfiguration.swift */,
@@ -3013,6 +3016,7 @@
 				80BC841A232C52FF00010E08 /* TermsOfService.swift in Sources */,
 				2256394E2253897D00D951B5 /* SessionProtocol.swift in Sources */,
 				2278C542231D72960048FF45 /* CollaborationAllowlistModule.swift in Sources */,
+				0517CB4D2E6EF9E1000EBD1A /* SHA1.swift in Sources */,
 				804F3BF722A59250008CF915 /* CommentsModule.swift in Sources */,
 				22640BB82305902A00C19ECA /* UploadSession.swift in Sources */,
 				223C6DAF22C636C100F4023C /* MetadataObject.swift in Sources */,

--- a/BoxSDK/Sources/BoxSDK.swift
+++ b/BoxSDK/Sources/BoxSDK.swift
@@ -584,8 +584,10 @@ extension BoxSDK {
     ///     This parameter is provided for your use in protecting against hijacked sessions and other attacks.
     /// - Returns: Standard URL object to be used for authorization in external browser.
     public func makeAuthorizeURL(state: String? = nil) -> URL {
-        // swiftlint:disable:next line_length
-        var urlString = "\(configuration.oauth2AuthorizeURL)?\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)&\(BoxOAuth2ParamsKey.redirectURL)=\(configuration.callbackURL)"
+        var urlString = "\(configuration.oauth2AuthorizeURL)?" +
+            "\(BoxOAuth2ParamsKey.responseType)=\(BoxOAuth2ParamsKey.responseTypeValue)" +
+            "&\(BoxOAuth2ParamsKey.clientId)=\(configuration.clientId)" +
+            "&\(BoxOAuth2ParamsKey.redirectURL)=\(configuration.callbackURL)"
 
         if let state = state {
             urlString.append("&\(BoxOAuth2ParamsKey.state)=\(state)")

--- a/BoxSDK/Sources/Client/BoxClient.swift
+++ b/BoxSDK/Sources/Client/BoxClient.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 
 /// Provides communication with Box APIs. Defines methods for communication with Box APIs
 public class BoxClient {

--- a/BoxSDK/Sources/Core/BoxSDKConfiguration.swift
+++ b/BoxSDK/Sources/Core/BoxSDKConfiguration.swift
@@ -56,7 +56,7 @@ public struct BoxSDKConfiguration {
     /// Analytics info that is set to request headers.
     public let clientAnalyticsInfo: ClientAnalyticsInfo?
     /// Console log destination.
-    public let consoleLogDestination: ConsoleLogDestination
+    public let consoleLogDestination: ConsoleLogDestination?
     /// File log destination.
     public let fileLogDestination: FileLogDestination?
     /// An optional custom callback URL string. The URL to which Box redirects the browser when authentication completes.
@@ -88,7 +88,7 @@ public struct BoxSDKConfiguration {
         maxRetryAttempts: Int? = defaultMaxRetryAttempts,
         tokenRefreshThreshold: TimeInterval? = defaultTokenRefreshThreshold,
         retryBaseInterval: TimeInterval? = defaultRetryBaseInterval,
-        consoleLogDestination: ConsoleLogDestination? = ConsoleLogDestination(),
+        consoleLogDestination: ConsoleLogDestination? = nil,
         fileLogDestination: FileLogDestination? = nil,
         clientAnalyticsInfo: ClientAnalyticsInfo? = nil,
         callbackURL: String? = nil
@@ -110,7 +110,13 @@ public struct BoxSDKConfiguration {
         self.maxRetryAttempts = maxRetryAttempts ?? defaultMaxRetryAttempts
         self.tokenRefreshThreshold = tokenRefreshThreshold ?? defaultTokenRefreshThreshold
         self.retryBaseInterval = retryBaseInterval ?? defaultRetryBaseInterval
-        self.consoleLogDestination = consoleLogDestination ?? ConsoleLogDestination()
+        let defaultConsole: ConsoleLogDestination?
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+            defaultConsole = consoleLogDestination ?? ConsoleLogDestination()
+        #else
+            defaultConsole = nil
+        #endif
+        self.consoleLogDestination = consoleLogDestination ?? defaultConsole
         self.fileLogDestination = fileLogDestination
         self.clientAnalyticsInfo = clientAnalyticsInfo
     }

--- a/BoxSDK/Sources/Core/Errors/BoxAPIError.swift
+++ b/BoxSDK/Sources/Core/Errors/BoxAPIError.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// Describes API request related errors.
 public class BoxAPIError: BoxSDKError {

--- a/BoxSDK/Sources/Core/Extensions/DataExtension.swift
+++ b/BoxSDK/Sources/Core/Extensions/DataExtension.swift
@@ -6,16 +6,13 @@
 //  Copyright © 2019 box. All rights reserved.
 //
 
-import CommonCrypto
 import Foundation
 
 extension Data {
     private func sha1data() -> Data {
-        var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        withUnsafeBytes {
-            _ = CC_SHA1($0.baseAddress, CC_LONG(self.count), &digest)
-        }
-        return Data(digest)
+        let sha1 = SHA1()
+        sha1.update(data: self)
+        return sha1.finalize()
     }
 
     func sha1() -> String {

--- a/BoxSDK/Sources/Core/Extensions/UIColorExtension.swift
+++ b/BoxSDK/Sources/Core/Extensions/UIColorExtension.swift
@@ -16,31 +16,68 @@
 
     /// The color type used natively on the target platform.
     public typealias PlatformColor = NSColor
+#else
+    /// A representation of a color using red, green, blue, and alpha components.
+    ///
+    /// This class is designed to be platform-independent, providing a simple way to store
+    /// and transfer color information in a normalized (0.0 - 1.0) format.
+    public class PlatformColor {
+
+        /// The red component of the color (0.0 - 1.0).
+        public let red: Double
+
+        /// The green component of the color (0.0 - 1.0).
+        public let green: Double
+
+        /// The blue component of the color (0.0 - 1.0).
+        public let blue: Double
+
+        /// The alpha (opacity) component of the color (0.0 - 1.0).
+        public let alpha: Double
+
+        /// Initializes a new `PlatformColor` with specified RGBA components.
+        ///
+        /// - Parameters:
+        ///   - red: The red component (0.0 - 1.0).
+        ///   - green: The green component (0.0 - 1.0).
+        ///   - blue: The blue component (0.0 - 1.0).
+        ///   - alpha: The alpha (opacity) component (0.0 - 1.0).
+        public init(red: Double, green: Double, blue: Double, alpha: Double) {
+            self.red = red
+            self.green = green
+            self.blue = blue
+            self.alpha = alpha
+        }
+    }
 #endif
 
 extension PlatformColor {
     convenience init?(hex: String) {
-        let red, green, blue, alpha: CGFloat
-        if hex.hasPrefix("#") {
-            let start = hex.index(hex.startIndex, offsetBy: 1)
-            let hexColor = String(hex[start...])
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
 
-            if hexColor.count == 6 {
-                let scanner = Scanner(string: hexColor)
-                var hexNumber: UInt64 = 0
-
-                if scanner.scanHexInt64(&hexNumber) {
-                    red = CGFloat((hexNumber & 0xFF0000) >> 16) / 255
-                    green = CGFloat((hexNumber & 0x00FF00) >> 8) / 255
-                    blue = CGFloat(hexNumber & 0x0000FF) / 255
-                    alpha = CGFloat(1.0)
-
-                    self.init(red: red, green: green, blue: blue, alpha: alpha)
-                    return
-                }
-            }
+        guard hexSanitized.count == 6 || hexSanitized.count == 8 else {
+            return nil
         }
 
-        return nil
+        guard let hexNumber = UInt64(hexSanitized, radix: 16) else {
+            return nil
+        }
+
+        let red, green, blue, alpha: Double
+        if hexSanitized.count == 8 {
+            red = Double((hexNumber & 0xFF00_0000) >> 24) / 255.0
+            green = Double((hexNumber & 0x00FF_0000) >> 16) / 255.0
+            blue = Double((hexNumber & 0x0000_FF00) >> 8) / 255.0
+            alpha = Double(hexNumber & 0x0000_00FF) / 255.0
+        }
+        else {
+            red = Double((hexNumber & 0xFF0000) >> 16) / 255.0
+            green = Double((hexNumber & 0x00FF00) >> 8) / 255.0
+            blue = Double(hexNumber & 0x0000FF) / 255.0
+            alpha = 1.0
+        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/BoxSDK/Sources/Core/Extensions/URLSessionTaskExtension.swift
+++ b/BoxSDK/Sources/Core/Extensions/URLSessionTaskExtension.swift
@@ -7,5 +7,8 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 extension URLSessionTask: Cancellable {}

--- a/BoxSDK/Sources/Core/MimeTypeProvider.swift
+++ b/BoxSDK/Sources/Core/MimeTypeProvider.swift
@@ -18,6 +18,14 @@ import Foundation
 
 /// Provides method for converting given filename to mime type
 enum MimeTypeProvider {
+    private static let commonMimeTypes: [String: String] = [
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "svg": "image/svg+xml",
+        "bmp": "image/bmp"
+    ]
 
     /// Converting given filename to mime type
     ///
@@ -32,16 +40,21 @@ enum MimeTypeProvider {
             return defaultMimeType
         }
 
-        if #available(iOS 14, macOS 11.0, watchOS 7.0, tvOS 14.0, *) {
-            return UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? defaultMimeType
-        }
-        else {
-            if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as NSString, nil)?.takeRetainedValue(),
-               let mimeType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() {
-                return mimeType as String
-            }
-        }
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 
-        return defaultMimeType
+            if #available(iOS 14, macOS 11.0, watchOS 7.0, tvOS 14.0, *) {
+                return UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? defaultMimeType
+            }
+            else {
+                if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as NSString, nil)?.takeRetainedValue(),
+                   let mimeType = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() {
+                    return mimeType as String
+                }
+            }
+
+            return defaultMimeType
+        #else
+            return commonMimeTypes[pathExtension] ?? defaultMimeType
+        #endif
     }
 }

--- a/BoxSDK/Sources/Core/SHA1.swift
+++ b/BoxSDK/Sources/Core/SHA1.swift
@@ -1,0 +1,240 @@
+import Foundation
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    import CommonCrypto
+#endif
+
+// swiftlint:disable identifier_name force_unwrapping conditional_returns_on_newline
+
+/// Protocol defining methods required for SHA-1 calculation.
+private protocol SHA1Calculator {
+    /// Updates the hash calculation with the given data.
+    ///
+    /// - Parameter data: The data to update the hash with.
+    func update(data: Data)
+
+    /// Finalizes the hash calculation and returns the computed hash.
+    ///
+    /// - Returns: The computed hash as `Data`.
+    func finalize() -> Data
+}
+
+/// `SHA1` class provides an interface for calculating SHA-1 hash using different implementations based on platform availability.
+class SHA1: SHA1Calculator {
+    private let sha1Calculator: SHA1Calculator
+
+    /// Initializes `SHA1` instance and selects appropriate SHA-1 calculator based on platform
+    init() {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+            sha1Calculator = SHA1CommonCrypto()
+        #else
+            sha1Calculator = SHA1Raw()
+        #endif
+    }
+
+    /// Updates the SHA-1 calculation with the given data chunk.
+    ///
+    /// - Parameter data: The data chunk to update the hash calculation.
+    func update(data: Data) {
+        sha1Calculator.update(data: data)
+    }
+
+    /// Finalizes the SHA-1 calculation and returns the computed hash.
+    ///
+    /// - Returns: The computed SHA-1 hash as `Data`.
+    func finalize() -> Data {
+        return sha1Calculator.finalize()
+    }
+}
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    /// `SHA1CommonCrypto` class provides SHA-1 calculation using CommonCrypto library.
+    private class SHA1CommonCrypto: SHA1Calculator {
+        private var context = CC_SHA1_CTX()
+
+        init() {
+            CC_SHA1_Init(&context)
+        }
+
+        /// Updates the SHA-1 calculation with the given data chunk using CommonCrypto.
+        ///
+        /// - Parameter data: The data chunk to update the hash calculation.
+        func update(data: Data) {
+            data.withUnsafeBytes { (bufferPointer: UnsafeRawBufferPointer) in
+                guard let unsafeBufferPointerBaseAddress = bufferPointer.baseAddress else { return }
+                let unsafePointer = unsafeBufferPointerBaseAddress.assumingMemoryBound(to: UInt8.self)
+                CC_SHA1_Update(&context, unsafePointer, CC_LONG(data.count))
+            }
+        }
+
+        /// Finalizes the SHA-1 calculation using CommonCrypto and returns the computed hash.
+        ///
+        /// - Returns: The computed SHA-1 hash as `Data`.
+        func finalize() -> Data {
+            var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+            CC_SHA1_Final(&digest, &context)
+            return Data(digest)
+        }
+    }
+#endif
+
+/// `SHA1Raw` class provides SHA-1 calculation using raw implementation.
+private class SHA1Raw: SHA1Calculator {
+    private static let h0: UInt32 = 0x6745_2301
+    private static let h1: UInt32 = 0xEFCD_AB89
+    private static let h2: UInt32 = 0x98BA_DCFE
+    private static let h3: UInt32 = 0x1032_5476
+    private static let h4: UInt32 = 0xC3D2_E1F0
+
+    private static let k1: UInt32 = 0x5A82_7999
+    private static let k2: UInt32 = 0x6ED9_EBA1
+    private static let k3: UInt32 = 0x8F1B_BCDC
+    private static let k4: UInt32 = 0xCA62_C1D6
+
+    private var currentHash: [UInt32] = [SHA1Raw.h0, SHA1Raw.h1, SHA1Raw.h2, SHA1Raw.h3, SHA1Raw.h4]
+    private var messageLength: UInt64 = 0
+    private var buffer: [UInt8] = []
+
+    private var w = [UInt32](repeating: 0, count: 80)
+
+    /// Updates the SHA-1 calculation with the given data chunk using raw implementation.
+    ///
+    /// - Parameter data: The data chunk to update the hash calculation.
+    func update(data: Data) {
+        data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            guard let baseAddress = bytes.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+            let byteCount = bytes.count
+
+            messageLength &+= UInt64(byteCount * 8)
+            var dataPointer = baseAddress
+
+            if !buffer.isEmpty {
+                let remainingSpace = 64 - buffer.count
+                if byteCount >= remainingSpace {
+                    buffer.append(contentsOf: UnsafeBufferPointer(start: dataPointer, count: remainingSpace))
+                    buffer.withUnsafeBytes { bufferPointer in
+                        processBlock(bufferPointer.baseAddress!.assumingMemoryBound(to: UInt8.self))
+                    }
+                    buffer.removeAll(keepingCapacity: true)
+                    dataPointer = dataPointer.advanced(by: remainingSpace)
+                }
+                else {
+                    buffer.append(contentsOf: UnsafeBufferPointer(start: dataPointer, count: byteCount))
+                    return
+                }
+            }
+
+            while dataPointer.distance(to: baseAddress.advanced(by: byteCount)) >= 64 {
+                processBlock(dataPointer)
+                dataPointer = dataPointer.advanced(by: 64)
+            }
+
+            buffer.append(contentsOf: UnsafeBufferPointer(start: dataPointer, count: dataPointer.distance(to: baseAddress.advanced(by: byteCount))))
+        }
+    }
+
+    /// Finalizes the SHA-1 calculation and returns the computed hash.
+    ///
+    /// - Returns: The computed SHA-1 hash as `Data`.
+    func finalize() -> Data {
+        var paddingLength = 64 - ((buffer.count + 8) % 64)
+        if paddingLength == 0 { paddingLength = 64 }
+
+        buffer.append(0x80)
+        buffer.append(contentsOf: [UInt8](repeating: 0, count: paddingLength - 1))
+
+        let lengthBytes = withUnsafeBytes(of: messageLength.bigEndian) { Array($0) }
+        buffer.append(contentsOf: lengthBytes)
+
+        var hashBuffer = [UInt8]()
+        hashBuffer.reserveCapacity(20)
+
+        buffer.withUnsafeBytes { bufferPointer in
+            let bufferBaseAddress = bufferPointer.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            let bufferCount = buffer.count
+            var dataPointer = bufferBaseAddress
+
+            while dataPointer.distance(to: bufferBaseAddress.advanced(by: bufferCount)) >= 64 {
+                processBlock(dataPointer)
+                dataPointer = dataPointer.advanced(by: 64)
+            }
+
+            // Convert UInt32 values in currentHash to big-endian bytes and append to hashBuffer
+            for value in currentHash {
+                let valueBytes = [
+                    UInt8((value >> 24) & 0xFF),
+                    UInt8((value >> 16) & 0xFF),
+                    UInt8((value >> 8) & 0xFF),
+                    UInt8(value & 0xFF)
+                ]
+                hashBuffer.append(contentsOf: valueBytes)
+            }
+        }
+
+        return Data(hashBuffer)
+    }
+
+    /// Processes a block of data during SHA-1 calculation.
+    ///
+    /// - Parameter chunk: The chunk of data to process.
+    private func processBlock(_ chunk: UnsafePointer<UInt8>) {
+        for i in 0 ..< 16 {
+            w[i] = (UInt32(chunk[4 * i]) << 24) | (UInt32(chunk[4 * i + 1]) << 16) |
+                (UInt32(chunk[4 * i + 2]) << 8) | UInt32(chunk[4 * i + 3])
+        }
+
+        for i in 16 ..< 80 {
+            w[i] = SHA1Raw.rotateLeft(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], bits: 1)
+        }
+
+        var a = currentHash[0]
+        var b = currentHash[1]
+        var c = currentHash[2]
+        var d = currentHash[3]
+        var e = currentHash[4]
+
+        for i in 0 ..< 80 {
+            let f: UInt32
+            let k: UInt32
+
+            switch i {
+            case 0 ..< 20:
+                f = (b & c) | (SHA1Raw.bitwiseNot(b) & d)
+                k = SHA1Raw.k1
+            case 20 ..< 40:
+                f = b ^ c ^ d
+                k = SHA1Raw.k2
+            case 40 ..< 60:
+                f = (b & c) | (b & d) | (c & d)
+                k = SHA1Raw.k3
+            case 60 ..< 80:
+                f = b ^ c ^ d
+                k = SHA1Raw.k4
+            default:
+                fatalError("Should not reach here")
+            }
+
+            let temp = SHA1Raw.rotateLeft(a, bits: 5) &+ f &+ e &+ k &+ w[i]
+            e = d
+            d = c
+            c = SHA1Raw.rotateLeft(b, bits: 30)
+            b = a
+            a = temp
+        }
+
+        currentHash[0] &+= a
+        currentHash[1] &+= b
+        currentHash[2] &+= c
+        currentHash[3] &+= d
+        currentHash[4] &+= e
+    }
+
+    @inline(__always)
+    private static func rotateLeft(_ value: UInt32, bits: UInt32) -> UInt32 {
+        return (value << bits) | (value >> (32 - bits))
+    }
+
+    @inline(__always)
+    private static func bitwiseNot<T: FixedWidthInteger>(_ value: T) -> T {
+        return value ^ T.max
+    }
+}

--- a/BoxSDK/Sources/Logger/ConsoleLogDestination.swift
+++ b/BoxSDK/Sources/Logger/ConsoleLogDestination.swift
@@ -6,67 +6,82 @@
 //  Copyright © 2019 Box. All rights reserved.
 //
 
-import Foundation
-import os.log
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    import Foundation
+    import os.log
 
-/// Defines logging into a console
-public class ConsoleLogDestination: LogDestination {
-    private var sdkLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.sdk.description)
-    private var networkAgentLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.networkAgent.description)
-    private var clientLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.client.description)
-    private var modulesLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.modules.description)
+    /// Defines logging into a console
+    open class ConsoleLogDestination: LogDestination {
+        private var sdkLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.sdk.description)
+        private var networkAgentLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.networkAgent.description)
+        private var clientLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.client.description)
+        private var modulesLogger = OSLog(subsystem: LogSubsystem.boxSwiftSDK, category: LogCategory.modules.description)
 
-    // swiftlint:disable cyclomatic_complexity
+        public init() {}
 
-    /// Logs a message into the console
-    ///
-    /// - Parameters:
-    ///   - message: Message to be written into the console log
-    ///   - level: Log level defining type of log
-    ///   - category: Log category defining type of data logged
-    ///   - args: Log arguments
-    public func write(_ message: StaticString, level: LogLevel, category: LogCategory, _ args: [CVarArg]) {
+        // swiftlint:disable cyclomatic_complexity
 
-        let type = level.osLogType
-        var logger: OSLog
-        switch category {
-        case .sdk:
-            logger = sdkLogger
-        case .client:
-            logger = clientLogger
-        case .modules:
-            logger = modulesLogger
-        case .networkAgent:
-            logger = networkAgentLogger
+        /// Logs a message into the console
+        ///
+        /// - Parameters:
+        ///   - message: Message to be written into the console log
+        ///   - level: Log level defining type of log
+        ///   - category: Log category defining type of data logged
+        ///   - args: Log arguments
+        open func write(_ message: StaticString, level: LogLevel, category: LogCategory, _ args: [CVarArg]) {
+            let type = level.osLogType
+            var logger: OSLog
+            switch category {
+            case .sdk:
+                logger = sdkLogger
+            case .client:
+                logger = clientLogger
+            case .modules:
+                logger = modulesLogger
+            case .networkAgent:
+                logger = networkAgentLogger
+            }
+
+            // The Swift overlay of os_log prevents from accepting an unbounded number of args
+            // http://www.openradar.me/33203955
+            // https://stackoverflow.com/questions/50937765/why-does-wrapping-os-log-cause-doubles-to-not-be-logged-correctly
+            assert(args.count <= 9)
+            switch args.count {
+            case 9:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
+            case 8:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+            case 7:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+            case 6:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5])
+            case 5:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4])
+            case 4:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3])
+            case 3:
+                os_log(message, log: logger, type: type, args[0], args[1], args[2])
+            case 2:
+                os_log(message, log: logger, type: type, args[0], args[1])
+            case 1:
+                os_log(message, log: logger, type: type, args[0])
+            default:
+                os_log(message, log: logger, type: type)
+            }
         }
 
-        // The Swift overlay of os_log prevents from accepting an unbounded number of args
-        // http://www.openradar.me/33203955
-        // https://stackoverflow.com/questions/50937765/why-does-wrapping-os-log-cause-doubles-to-not-be-logged-correctly
-        assert(args.count <= 9)
-        switch args.count {
-        case 9:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8])
-        case 8:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
-        case 7:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5], args[6])
-        case 6:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4], args[5])
-        case 5:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3], args[4])
-        case 4:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2], args[3])
-        case 3:
-            os_log(message, log: logger, type: type, args[0], args[1], args[2])
-        case 2:
-            os_log(message, log: logger, type: type, args[0], args[1])
-        case 1:
-            os_log(message, log: logger, type: type, args[0])
-        default:
-            os_log(message, log: logger, type: type)
+        // swiftlint:enable cyclomatic_complexity
+    }
+#else
+    import Foundation
+
+    open class ConsoleLogDestination: LogDestination {
+
+        public init() {}
+
+        open func write(_ message: StaticString, level: LogLevel, category: LogCategory, _ args: [CVarArg]) {
+            let formattedMessage = FileLogDestination.formattedMessage(message: message.description, args: args)
+            print("[\(level)][\(category)]: \(formattedMessage)")
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
-}
+#endif

--- a/BoxSDK/Sources/Logger/LogDestination.swift
+++ b/BoxSDK/Sources/Logger/LogDestination.swift
@@ -7,7 +7,10 @@
 //
 
 import Foundation
-import os.log
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    import os.log
+#endif
 
 /// Defines main log destination behaviour
 public protocol LogDestination {
@@ -27,18 +30,20 @@ public enum LogLevel: String {
     /// Logging fatal error
     case fatal
 
-    var osLogType: OSLogType {
-        switch self {
-        case .debug:
-            return OSLogType.debug
-        case .info:
-            return OSLogType.info
-        case .error:
-            return OSLogType.error
-        case .fatal:
-            return OSLogType.fault
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+        var osLogType: OSLogType {
+            switch self {
+            case .debug:
+                return OSLogType.debug
+            case .info:
+                return OSLogType.info
+            case .error:
+                return OSLogType.error
+            case .fatal:
+                return OSLogType.fault
+            }
         }
-    }
+    #endif
 }
 
 extension LogLevel: CustomStringConvertible {

--- a/BoxSDK/Sources/Logger/Logger.swift
+++ b/BoxSDK/Sources/Logger/Logger.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
-import os.log
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 // https://www.bignerdranch.com/blog/migrating-to-unified-logging-swift-edition/
 enum LogSubsystem {

--- a/BoxSDK/Sources/Network/ArrayInputStream.swift
+++ b/BoxSDK/Sources/Network/ArrayInputStream.swift
@@ -104,13 +104,17 @@ class ArrayInputStream: InputStream {
         }
     }
 
-    override func property(forKey _: Stream.PropertyKey) -> Any? {
-        return nil
-    }
+    #if os(iOS) || os(macOS)
 
-    override func setProperty(_: Any?, forKey _: Stream.PropertyKey) -> Bool {
-        return false
-    }
+        override func property(forKey _: Stream.PropertyKey) -> Any? {
+            return nil
+        }
+
+        override func setProperty(_: Any?, forKey _: Stream.PropertyKey) -> Bool {
+            return false
+        }
+
+    #endif
 
     override var streamStatus: Stream.Status {
         return _streamStatus

--- a/BoxSDK/Sources/Requests/AnalyticsHeaderGenerator.swift
+++ b/BoxSDK/Sources/Requests/AnalyticsHeaderGenerator.swift
@@ -42,6 +42,12 @@ class AnalyticsHeaderGenerator {
             return "macOS"
         #elseif os(visionOS)
             return "visionOS"
+        #elseif os(Linux)
+            return "Linux"
+        #elseif os(Windows)
+            return "Windows"
+        #else
+            return "N/A"
         #endif
     }()
 
@@ -50,7 +56,7 @@ class AnalyticsHeaderGenerator {
             return UIDevice.current.systemVersion
         #elseif os(watchOS)
             return WKInterfaceDevice.current().systemVersion
-        #elseif os(OSX) || os(visionOS)
+        #else
             let version = ProcessInfo.processInfo.operatingSystemVersion
             let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
             return versionString
@@ -60,8 +66,7 @@ class AnalyticsHeaderGenerator {
     lazy var swiftSDKVersion: String = {
         // swiftlint:disable:next force_unwrapping
         let dictionary = Bundle(for: type(of: self)).infoDictionary!
-        // swiftlint:disable:next force_cast
-        let version = dictionary["CFBundleShortVersionString"] as! String
+        let version = dictionary["CFBundleShortVersionString"] as? String ?? ""
         return version
     }()
 

--- a/BoxSDK/Sources/Requests/BoxRequest.swift
+++ b/BoxSDK/Sources/Requests/BoxRequest.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// Represents Box SDK API request.
 public class BoxRequest {

--- a/BoxSDK/Sources/Requests/QueryParameters/FieldsQueryParam.swift
+++ b/BoxSDK/Sources/Requests/QueryParameters/FieldsQueryParam.swift
@@ -21,7 +21,7 @@ struct FieldsQueryParam {
 extension FieldsQueryParam: QueryParameterConvertible {
 
     /// Query parameter value
-    public var queryParamValue: String? {
+    var queryParamValue: String? {
         return fields?.joined(separator: ",")
     }
 }

--- a/BoxSDK/Sources/Requests/QueryParameters/MetadataFilterQueryParam.swift
+++ b/BoxSDK/Sources/Requests/QueryParameters/MetadataFilterQueryParam.swift
@@ -19,7 +19,7 @@ struct MetadataFilterQueryParam {
 
 extension MetadataFilterQueryParam: QueryParameterConvertible {
 
-    public var queryParamValue: String? {
+    var queryParamValue: String? {
         guard let filter = metadataFilter else {
             return nil
         }

--- a/BoxSDK/Sources/Responses/BoxResponse.swift
+++ b/BoxSDK/Sources/Responses/BoxResponse.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// Box API response
 public struct BoxResponse {

--- a/BoxSDK/Sources/Responses/BoxResponseDescription.swift
+++ b/BoxSDK/Sources/Responses/BoxResponseDescription.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
 
 /// The components that make up a description of a BoxResponse
 public struct BoxResponseDescription {

--- a/BoxSDK/Sources/TokenStore/KeychainRelated/KeychainService.swift
+++ b/BoxSDK/Sources/TokenStore/KeychainRelated/KeychainService.swift
@@ -6,113 +6,115 @@
 //  Copyright © 2019 Box. All rights reserved.
 //
 
-import Foundation
-import Security
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    import Foundation
+    import Security
 
-struct KeychainService {
-    let secureStoreQueryable: KeychainStoreQueryable
+    struct KeychainService {
+        let secureStoreQueryable: KeychainStoreQueryable
 
-    func set<T: Encodable>(_ value: T?, key: String) throws {
-        guard let json = value?.dictionary,
-              let data = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions())
-        else {
-            throw BoxSDKError(message: .keychainDataConversionError)
-        }
-
-        var query = secureStoreQueryable.query
-        query[String(kSecAttrAccount)] = key
-
-        var status = SecItemCopyMatching(query as CFDictionary, nil)
-        switch status {
-        case errSecSuccess:
-            var attributesToUpdate: [String: Any] = [:]
-            attributesToUpdate[String(kSecValueData)] = data
-
-            status = SecItemUpdate(
-                query as CFDictionary,
-                attributesToUpdate as CFDictionary
-            )
-            if status != errSecSuccess {
-                throw error(from: status)
-            }
-        case errSecItemNotFound:
-            query[String(kSecValueData)] = data
-
-            status = SecItemAdd(query as CFDictionary, nil)
-            if status != errSecSuccess {
-                throw error(from: status)
-            }
-        default:
-            throw error(from: status)
-        }
-    }
-
-    func getValue<T: Decodable>(_ key: String) throws -> T? {
-        var query = secureStoreQueryable.query
-        query[String(kSecMatchLimit)] = kSecMatchLimitOne
-        query[String(kSecReturnAttributes)] = kCFBooleanTrue
-        query[String(kSecReturnData)] = kCFBooleanTrue
-        query[String(kSecAttrAccount)] = key
-
-        var queryResult: AnyObject?
-        let status = withUnsafeMutablePointer(to: &queryResult) {
-            SecItemCopyMatching(query as CFDictionary, $0)
-        }
-
-        switch status {
-        case errSecSuccess:
-            guard
-                let queriedItem = queryResult as? [String: Any],
-                let valueData = queriedItem[String(kSecValueData)] as? Data,
-                let value = try? JSONDecoder().decode(T.self, from: valueData)
+        func set<T: Encodable>(_ value: T?, key: String) throws {
+            guard let json = value?.dictionary,
+                  let data = try? JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions())
             else {
                 throw BoxSDKError(message: .keychainDataConversionError)
             }
-            return value
-        case errSecItemNotFound:
-            return nil
-        default:
-            throw error(from: status)
+
+            var query = secureStoreQueryable.query
+            query[String(kSecAttrAccount)] = key
+
+            var status = SecItemCopyMatching(query as CFDictionary, nil)
+            switch status {
+            case errSecSuccess:
+                var attributesToUpdate: [String: Any] = [:]
+                attributesToUpdate[String(kSecValueData)] = data
+
+                status = SecItemUpdate(
+                    query as CFDictionary,
+                    attributesToUpdate as CFDictionary
+                )
+                if status != errSecSuccess {
+                    throw error(from: status)
+                }
+            case errSecItemNotFound:
+                query[String(kSecValueData)] = data
+
+                status = SecItemAdd(query as CFDictionary, nil)
+                if status != errSecSuccess {
+                    throw error(from: status)
+                }
+            default:
+                throw error(from: status)
+            }
+        }
+
+        func getValue<T: Decodable>(_ key: String) throws -> T? {
+            var query = secureStoreQueryable.query
+            query[String(kSecMatchLimit)] = kSecMatchLimitOne
+            query[String(kSecReturnAttributes)] = kCFBooleanTrue
+            query[String(kSecReturnData)] = kCFBooleanTrue
+            query[String(kSecAttrAccount)] = key
+
+            var queryResult: AnyObject?
+            let status = withUnsafeMutablePointer(to: &queryResult) {
+                SecItemCopyMatching(query as CFDictionary, $0)
+            }
+
+            switch status {
+            case errSecSuccess:
+                guard
+                    let queriedItem = queryResult as? [String: Any],
+                    let valueData = queriedItem[String(kSecValueData)] as? Data,
+                    let value = try? JSONDecoder().decode(T.self, from: valueData)
+                else {
+                    throw BoxSDKError(message: .keychainDataConversionError)
+                }
+                return value
+            case errSecItemNotFound:
+                return nil
+            default:
+                throw error(from: status)
+            }
+        }
+
+        func removeValue(for key: String) throws {
+            var query = secureStoreQueryable.query
+            query[String(kSecAttrAccount)] = key
+
+            let status = SecItemDelete(query as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw error(from: status)
+            }
+        }
+
+        func removeAllValues() throws {
+            let query = secureStoreQueryable.query
+
+            let status = SecItemDelete(query as CFDictionary)
+            guard status == errSecSuccess || status == errSecItemNotFound else {
+                throw error(from: status)
+            }
+        }
+
+        func error(from status: OSStatus) -> BoxSDKError {
+            if #available(iOS 11.3, *, watchOSApplicationExtension 4.3, *, tvOS 11.3, *) {
+                let message = SecCopyErrorMessageString(status, nil) as String? ?? NSLocalizedString("Unhandled Error", comment: "")
+
+                return BoxSDKError(message: .keychainUnhandledError(message))
+            }
+            else {
+                // Fallback on earlier versions
+                return BoxSDKError(message: .keychainUnhandledError(""))
+            }
         }
     }
 
-    func removeValue(for key: String) throws {
-        var query = secureStoreQueryable.query
-        query[String(kSecAttrAccount)] = key
-
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw error(from: status)
+    private extension Encodable {
+        var dictionary: [String: Any]? {
+            guard let data = try? JSONEncoder().encode(self) else {
+                return nil
+            }
+            return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
         }
     }
-
-    func removeAllValues() throws {
-        let query = secureStoreQueryable.query
-
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw error(from: status)
-        }
-    }
-
-    func error(from status: OSStatus) -> BoxSDKError {
-        if #available(iOS 11.3, *, watchOSApplicationExtension 4.3, *, tvOS 11.3, *) {
-            let message = SecCopyErrorMessageString(status, nil) as String? ?? NSLocalizedString("Unhandled Error", comment: "")
-
-            return BoxSDKError(message: .keychainUnhandledError(message))
-        }
-        else {
-            // Fallback on earlier versions
-            return BoxSDKError(message: .keychainUnhandledError(""))
-        }
-    }
-}
-
-private extension Encodable {
-    var dictionary: [String: Any]? {
-        guard let data = try? JSONEncoder().encode(self) else {
-            return nil
-        }
-        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
-    }
-}
+#endif

--- a/BoxSDK/Sources/TokenStore/KeychainRelated/KeychainStoreQueryable.swift
+++ b/BoxSDK/Sources/TokenStore/KeychainRelated/KeychainStoreQueryable.swift
@@ -6,33 +6,35 @@
 //  Copyright © 2019 Box. All rights reserved.
 //
 
-import Foundation
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+    import Foundation
 
-protocol KeychainStoreQueryable {
-    var query: [String: Any] { get }
-}
-
-struct GenericPasswordQueryable {
-    let service: String
-    let accessGroup: String?
-
-    init(service: String, accessGroup: String? = nil) {
-        self.service = service
-        self.accessGroup = accessGroup
+    protocol KeychainStoreQueryable {
+        var query: [String: Any] { get }
     }
-}
 
-extension GenericPasswordQueryable: KeychainStoreQueryable {
-    var query: [String: Any] {
-        var query: [String: Any] = [:]
-        query[String(kSecClass)] = kSecClassGenericPassword
-        query[String(kSecAttrService)] = service
-        // Access group if target environment is not simulator
-        #if !targetEnvironment(simulator)
-            if let accessGroup = accessGroup {
-                query[String(kSecAttrAccessGroup)] = accessGroup
-            }
-        #endif
-        return query
+    struct GenericPasswordQueryable {
+        let service: String
+        let accessGroup: String?
+
+        init(service: String, accessGroup: String? = nil) {
+            self.service = service
+            self.accessGroup = accessGroup
+        }
     }
-}
+
+    extension GenericPasswordQueryable: KeychainStoreQueryable {
+        var query: [String: Any] {
+            var query: [String: Any] = [:]
+            query[String(kSecClass)] = kSecClassGenericPassword
+            query[String(kSecAttrService)] = service
+            // Access group if target environment is not simulator
+            #if !targetEnvironment(simulator)
+                if let accessGroup = accessGroup {
+                    query[String(kSecAttrAccessGroup)] = accessGroup
+                }
+            #endif
+            return query
+        }
+    }
+#endif

--- a/BoxSDK/Tests/Modules/SearchModuleSpecs.swift
+++ b/BoxSDK/Tests/Modules/SearchModuleSpecs.swift
@@ -71,8 +71,7 @@ class SearchModuleSpecs: QuickSpec {
                         isHost("api.box.com") && isPath("/2.0/search")
                             && compareComplexQueryParam("mdfilters", ["\"filters\":{\"date\":{\"gt\":\"2019-07-24T12:00:00Z\"}}",
                                                                       "\"templateKey\":\"marketingCollateral\"",
-                                                                      "\"scope\":\"global\""
-                                ])
+                                                                      "\"scope\":\"global\""])
                     ) { _ in
                         HTTPStubsResponse(
                             fileAtPath: TestAssets.path(forResource: "Search200.json")!,
@@ -102,8 +101,7 @@ class SearchModuleSpecs: QuickSpec {
                         isHost("api.box.com") && isPath("/2.0/search")
                             && compareComplexQueryParam("mdfilters", ["\"filters\":{\"date\":{\"lt\":\"2019-07-24T12:00:00Z\"}}",
                                                                       "\"templateKey\":\"marketingCollateral\"",
-                                                                      "\"scope\":\"enterprise\""
-                                ])
+                                                                      "\"scope\":\"enterprise\""])
                     ) { _ in
                         HTTPStubsResponse(
                             fileAtPath: TestAssets.path(forResource: "Search200.json")!,
@@ -133,8 +131,7 @@ class SearchModuleSpecs: QuickSpec {
                         isHost("api.box.com") && isPath("/2.0/search")
                             && compareComplexQueryParam("mdfilters", ["\"filters\":{\"documentType\":\"dataSheet\"}",
                                                                       "\"templateKey\":\"marketingCollateral\"",
-                                                                      "\"scope\":\"enterprise\""
-                                ])
+                                                                      "\"scope\":\"enterprise\""])
                     ) { _ in
                         HTTPStubsResponse(
                             fileAtPath: TestAssets.path(forResource: "Search200.json")!,
@@ -164,8 +161,7 @@ class SearchModuleSpecs: QuickSpec {
                         isHost("api.box.com") && isPath("/2.0/search")
                             && compareComplexQueryParam("mdfilters", ["\"filters\":{\"documentType\":\"dataSheet\"}",
                                                                       "\"templateKey\":\"marketingCollateral\"",
-                                                                      "\"scope\":\"global\""
-                                ])
+                                                                      "\"scope\":\"global\""])
                     ) { _ in
                         HTTPStubsResponse(
                             fileAtPath: TestAssets.path(forResource: "Search200.json")!,

--- a/BoxSDK/Tests/Modules/UsersModuleSpecs.swift
+++ b/BoxSDK/Tests/Modules/UsersModuleSpecs.swift
@@ -618,7 +618,7 @@ class UsersModuleSpecs: QuickSpec {
         }
     }
 
-    public static func testRollOutUserFromEnterpriseBody() -> HTTPStubsTestBlock {
+    static func testRollOutUserFromEnterpriseBody() -> HTTPStubsTestBlock {
         return { request in
             let body = request.ohhttpStubs_httpBody!
             if let jsonBody = try! JSONSerialization.jsonObject(with: body) as? [String: Any] {


### PR DESCRIPTION
Adjusted the code so it compiles and runs on Linux. The changes included:
* Adding compiler directives to conditionally exclude or replace platform-specific code.
* Conditionally importing FoundationNetworking in files that use networking APIs.
* Providing a custom implementation of PlatformColor when it’s not available in the library.
* Creating a SHA1Calculator protocol with two implementations:
    * One using the CommonCrypto library (for iOS).
    * One custom implementation for Linux (sourced from the [box-swift-sdk-gen repo](https://github.com/box/box-swift-sdk-gen/blob/main/Sources/Internal/SHA1.swift)). This class is then used in DataExtension.swift to calculate SHA1 hashes.
* Updating ConsoleLogDestination and FileLogDestination to work on platforms where os.log is unavailable.

This PR is going to be merged into feature branch, so GHA didn't run.
But to ensure that the changes here works, I've created another PR to main -> [here](https://github.com/box/box-ios-sdk/pull/1054) <- just to proof that the it works