### PR TITLE
feat: Mark `BoxSDK` module as deprecated

### DIFF
--- a/BoxSDK/Sources/BoxSDK+Async.swift
+++ b/BoxSDK/Sources/BoxSDK+Async.swift
@@ -12,6 +12,7 @@
 import Foundation
 
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+@available(*, deprecated, message: "BoxSDK module is deprecated. Please migrate to BoxSdkGen module and use BoxClient instead. Both modules are available within the same BoxSDK library.")
 public extension BoxSDK {
 
     // MARK: - JWT Client

--- a/BoxSDK/Sources/BoxSDK.swift
+++ b/BoxSDK/Sources/BoxSDK.swift
@@ -16,6 +16,7 @@ import Foundation
 public typealias Callback<T> = (Result<T, BoxSDKError>) -> Void
 
 /// Provides methods for creating BoxSDKClient
+@available(*, deprecated, message: "BoxSDK module is deprecated. Please migrate to BoxSdkGen module and use BoxClient instead. Both modules are available within the same BoxSDK library.")
 public class BoxSDK {
 
     /// Box-specific constants

--- a/BoxSDK/Sources/Client/BoxClient.swift
+++ b/BoxSDK/Sources/Client/BoxClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Provides communication with Box APIs. Defines methods for communication with Box APIs
+@available(*, deprecated, message: "BoxSDK module is deprecated. Please migrate to BoxSdkGen module and use BoxClient instead. Both modules are available within the same BoxSDK library.")
 public class BoxClient {
     /// Provides [File](../Structs/File.html) management.
     public private(set) lazy var files = FilesModule(boxClient: self)


### PR DESCRIPTION
Added deprecation notice when someone is using BoxSDK.
<img width="2164" height="121" alt="image" src="https://github.com/user-attachments/assets/032b3b38-df3c-4607-95f4-c1057d77f3cc" />
