### PR TITLE
chore: Bump XCode for tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   integration-tests:
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     strategy:
       matrix:
         destination: ['platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro']

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   ios-build-and-test:
     runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     strategy:
       matrix:
         destination: ['platform=iOS Simulator,OS=18.6,name=iPhone 16 Pro']


### PR DESCRIPTION
Fixes CI only unit test timeouts by pinning the macOS workflow to `Xcode 26.3`

The failing `AuthModuleSpecs` tests depend on `OHHTTPStubs` intercepting `URLSession` requests. 
They pass locally and now pass on CI after using a newer, explicit Xcode toolchain instead of the `macos-15` default.