### PR TITLE
test: Fix flaky tests

### DIFF
--- a/BoxSDK/BoxSDK.xcodeproj/project.pbxproj
+++ b/BoxSDK/BoxSDK.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		0C506CB422A6ABA4007F18A4 /* GetCollaboration.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C506CB322A6ABA4007F18A4 /* GetCollaboration.json */; };
 		0C506CB822A6AE76007F18A4 /* CreateCollaboration.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C506CB722A6AE76007F18A4 /* CreateCollaboration.json */; };
 		0C506CBD22A6AF97007F18A4 /* OHTTPStubs+JSONComparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C506CBC22A6AF97007F18A4 /* OHTTPStubs+JSONComparer.swift */; };
+		0DFA00112C1B000000000001 /* FakeNetworkAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFA00102C1B000000000001 /* FakeNetworkAgent.swift */; };
 		0C506CC122A6B376007F18A4 /* PendingCollaborations.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C506CC022A6B376007F18A4 /* PendingCollaborations.json */; };
 		0C506CC522A6BF28007F18A4 /* UpdateCollaboration.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C506CC422A6BF28007F18A4 /* UpdateCollaboration.json */; };
 		0C59EA3B2289C63300DAE688 /* CreateUser.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C59EA2C2289BBBA00DAE688 /* CreateUser.json */; };
@@ -765,6 +766,7 @@
 		0C506CB322A6ABA4007F18A4 /* GetCollaboration.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = GetCollaboration.json; sourceTree = "<group>"; };
 		0C506CB722A6AE76007F18A4 /* CreateCollaboration.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CreateCollaboration.json; sourceTree = "<group>"; };
 		0C506CBC22A6AF97007F18A4 /* OHTTPStubs+JSONComparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OHTTPStubs+JSONComparer.swift"; sourceTree = "<group>"; };
+		0DFA00102C1B000000000001 /* FakeNetworkAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeNetworkAgent.swift; sourceTree = "<group>"; };
 		0C506CC022A6B376007F18A4 /* PendingCollaborations.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PendingCollaborations.json; sourceTree = "<group>"; };
 		0C506CC422A6BF28007F18A4 /* UpdateCollaboration.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UpdateCollaboration.json; sourceTree = "<group>"; };
 		0C59EA2C2289BBBA00DAE688 /* CreateUser.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CreateUser.json; sourceTree = "<group>"; };
@@ -1399,6 +1401,7 @@
 			isa = PBXGroup;
 			children = (
 				0C28DCC322AF099F0005AC46 /* JSONComparison */,
+				0DFA00102C1B000000000001 /* FakeNetworkAgent.swift */,
 				0C506CBC22A6AF97007F18A4 /* OHTTPStubs+JSONComparer.swift */,
 				0D9D60FB2A4124B6006CF672 /* TestAssets.swift */,
 			);
@@ -3193,6 +3196,7 @@
 				0546B2FF26F9F5C500922C04 /* CommentItemSpecs.swift in Sources */,
 				05B51E0429D7144C00CDFA9B /* PagingIteratorSpecs.swift in Sources */,
 				0D9D60FC2A4124B7006CF672 /* TestAssets.swift in Sources */,
+				0DFA00112C1B000000000001 /* FakeNetworkAgent.swift in Sources */,
 				0546B2FC26F9EDDA00922C04 /* TokenScopeSpecs.swift in Sources */,
 				97D3FFBC22B1DBB9008C1CE6 /* FolderSpecs.swift in Sources */,
 				05EE814627185554006A2329 /* SignRequestSpecs.swift in Sources */,

--- a/BoxSDK/Tests/Client/BoxClientSpecs.swift
+++ b/BoxSDK/Tests/Client/BoxClientSpecs.swift
@@ -60,22 +60,23 @@ class BoxClientSpecs: QuickSpec {
             }
 
             describe("destroy()") {
+                func makeClient(token: String, clientId: String = "ksdjfksadfisdg", clientSecret: String = "liuwerfiberdus", networkAgent: FakeNetworkAgent) -> BoxClient {
+                    let sdk = BoxSDK(clientId: clientId, clientSecret: clientSecret)
+                    let authModule = AuthModule(networkAgent: networkAgent, configuration: sdk.configuration)
+                    let session = SingleTokenSession(token: token, authModule: authModule)
+                    return BoxClient(networkAgent: networkAgent, session: session, configuration: sdk.configuration)
+                }
+
                 it("should make request to revoke the current access token") {
                     let currentToken = "sdufhgseit983e4g"
                     let clientID = "ksdjfksadfisdg"
                     let clientSecret = "liuwerfiberdus"
-                    let sdk = BoxSDK(clientId: clientID, clientSecret: clientSecret)
-                    let client = sdk.getClient(token: currentToken)
+                    let networkAgent = FakeNetworkAgent()
+                    let client = makeClient(token: currentToken, clientId: clientID, clientSecret: clientSecret, networkAgent: networkAgent)
 
-                    stub(
-                        condition: isHost("api.box.com")
-                            && isPath("/oauth2/revoke")
-                            && isMethodPOST()
-                            && self.compareURLEncodedBody(["client_id": clientID, "client_secret": clientSecret, "token": currentToken])
-                    ) { _ in
-                        HTTPStubsResponse(
-                            data: Data(), statusCode: 200, headers: [:]
-                        )
+                    networkAgent.sendHandler = { request in
+                        expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/revoke", urlEncodedBody: ["client_id": clientID, "client_secret": clientSecret, "token": currentToken])
+                        return .success(makeResponse(request: request, data: Data(), statusCode: 200))
                     }
 
                     waitUntil(timeout: .seconds(10)) { done in
@@ -92,16 +93,13 @@ class BoxClientSpecs: QuickSpec {
                 }
 
                 it("should produce error when revocation request fails") {
-                    let client = BoxSDK.getClient(token: "sajkhdbldf")
+                    let token = "sajkhdbldf"
+                    let networkAgent = FakeNetworkAgent()
+                    let client = makeClient(token: token, networkAgent: networkAgent)
 
-                    stub(
-                        condition: isHost("api.box.com")
-                            && isPath("/oauth2/revoke")
-                            && isMethodPOST()
-                    ) { _ in
-                        HTTPStubsResponse(
-                            data: Data(), statusCode: 400, headers: [:]
-                        )
+                    networkAgent.sendHandler = { request in
+                        expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/revoke", urlEncodedBody: ["client_id": "ksdjfksadfisdg", "client_secret": "liuwerfiberdus", "token": token])
+                        return makeFailure(request: request, data: Data(), statusCode: 400)
                     }
 
                     waitUntil(timeout: .seconds(10)) { done in
@@ -118,16 +116,13 @@ class BoxClientSpecs: QuickSpec {
                 }
 
                 it("should render client inoperable when revocation request succeeds") {
-                    let client = BoxSDK.getClient(token: "sajkhdbldf")
+                    let token = "sajkhdbldf"
+                    let networkAgent = FakeNetworkAgent()
+                    let client = makeClient(token: token, networkAgent: networkAgent)
 
-                    stub(
-                        condition: isHost("api.box.com")
-                            && isPath("/oauth2/revoke")
-                            && isMethodPOST()
-                    ) { _ in
-                        HTTPStubsResponse(
-                            data: Data(), statusCode: 200, headers: [:]
-                        )
+                    networkAgent.sendHandler = { request in
+                        expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/revoke", urlEncodedBody: ["client_id": "ksdjfksadfisdg", "client_secret": "liuwerfiberdus", "token": token])
+                        return .success(makeResponse(request: request, data: Data(), statusCode: 200))
                     }
 
                     waitUntil(timeout: .seconds(10)) { done in

--- a/BoxSDK/Tests/Helpers/FakeNetworkAgent.swift
+++ b/BoxSDK/Tests/Helpers/FakeNetworkAgent.swift
@@ -1,0 +1,89 @@
+//
+//  FakeNetworkAgent.swift
+//  BoxSDKTests-iOS
+//
+//  Copyright © 2026 Box. All rights reserved.
+//
+
+@testable import BoxSDK
+import Foundation
+import Nimble
+
+func expectRequest(
+    _ request: BoxRequest,
+    method: HTTPMethod,
+    host: String,
+    path: String,
+    urlEncodedBody expectedBody: [String: String]? = nil,
+    unorderedValueKeys: Set<String> = []
+) {
+    expect(request.httpMethod).to(equal(method))
+    expect(request.url.host).to(equal(host))
+    expect(request.url.path).to(equal(path))
+
+    guard let expectedBody = expectedBody else {
+        return
+    }
+
+    guard case let .urlencodedForm(actualBody) = request.body else {
+        fail("Expected URL-encoded request body")
+        return
+    }
+
+    expect(actualBody.keys.sorted()).to(equal(expectedBody.keys.sorted()))
+    for (key, expectedValue) in expectedBody {
+        guard let actualValue = actualBody[key] else {
+            fail("Expected request body to contain \(key)")
+            continue
+        }
+
+        if unorderedValueKeys.contains(key) {
+            expect(Set(actualValue.split(separator: " "))).to(equal(Set(expectedValue.split(separator: " "))))
+        }
+        else {
+            expect(actualValue).to(equal(expectedValue))
+        }
+    }
+}
+
+func makeResponse(request: BoxRequest, fixture: String, statusCode: Int, headers: [String: String] = [:]) -> BoxResponse {
+    // swiftlint:disable:next force_unwrapping
+    let fixtureURL = URL(fileURLWithPath: TestAssets.path(forResource: fixture)!)
+    // swiftlint:disable:next force_try
+    let data = try! Data(contentsOf: fixtureURL)
+    return makeResponse(request: request, data: data, statusCode: statusCode, headers: headers)
+}
+
+func makeResponse(request: BoxRequest, data: Data, statusCode: Int, headers: [String: String] = [:]) -> BoxResponse {
+    let urlResponse = HTTPURLResponse(
+        url: request.url,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: headers
+    )
+    return BoxResponse(request: request, body: data, urlResponse: urlResponse)
+}
+
+func makeFailure(request: BoxRequest, jsonObject: [String: Any], statusCode: Int) -> Result<BoxResponse, BoxSDKError> {
+    // swiftlint:disable:next force_try
+    let data = try! JSONSerialization.data(withJSONObject: jsonObject)
+    return makeFailure(request: request, data: data, statusCode: statusCode)
+}
+
+func makeFailure(request: BoxRequest, data: Data, statusCode: Int) -> Result<BoxResponse, BoxSDKError> {
+    let response = makeResponse(request: request, data: data, statusCode: statusCode)
+    return .failure(BoxAPIError(request: response.request, response: response))
+}
+
+class FakeNetworkAgent: NetworkAgentProtocol {
+    var sendHandler: ((BoxRequest) -> Result<BoxResponse, BoxSDKError>)?
+
+    func send(request: BoxRequest, completion: @escaping Callback<BoxResponse>) {
+        guard let sendHandler = sendHandler else {
+            completion(.failure(BoxSDKError(message: "No fake response configured")))
+            return
+        }
+
+        completion(sendHandler(request))
+    }
+}

--- a/BoxSDK/Tests/Modules/AuthModuleSpecs.swift
+++ b/BoxSDK/Tests/Modules/AuthModuleSpecs.swift
@@ -8,8 +8,6 @@
 
 @testable import BoxSDK
 import Nimble
-import OHHTTPStubs
-import OHHTTPStubs.NSURLRequest_HTTPBodyTesting
 import Quick
 
 class AuthModuleSpecs: QuickSpec {
@@ -21,31 +19,21 @@ class AuthModuleSpecs: QuickSpec {
     override class func spec() {
         var sdk: BoxSDK!
         var sut: AuthModule!
+        var networkAgent: FakeNetworkAgent!
 
         beforeEach {
             sdk = BoxSDK(clientId: clientId, clientSecret: clientSecret)
             try? sdk.updateConfiguration(maxRetryAttempts: 0)
-            let networkAgent = BoxNetworkAgent(configuration: sdk.configuration)
+            networkAgent = FakeNetworkAgent()
             sut = AuthModule(networkAgent: networkAgent, configuration: sdk.configuration)
-        }
-
-        afterEach {
-            HTTPStubs.removeAllStubs()
         }
 
         describe("AuthModuleSpecs") {
             context("get access Token after a successful OAuth web authentication") {
                 beforeEach {
-                    stub(
-                        condition: isHost("api.box.com")
-                            && isPath("/oauth2/token")
-                            && isMethodPOST()
-                            && compareURLEncodedBody(["client_id": clientId, "client_secret": clientSecret, "code": code, "grant_type": "authorization_code"])
-                    ) { _ in
-                        HTTPStubsResponse(
-                            fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
-                            statusCode: 200, headers: ["Content-Type": "application/json"]
-                        )
+                    networkAgent.sendHandler = { request in
+                        expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/token", urlEncodedBody: ["client_id": clientId, "client_secret": clientSecret, "code": code, "grant_type": "authorization_code"])
+                        return .success(makeResponse(request: request, fixture: "AccessToken.json", statusCode: 200, headers: ["Content-Type": "application/json"]))
                     }
                 }
 
@@ -70,16 +58,9 @@ class AuthModuleSpecs: QuickSpec {
 
             context("get access Token after an unsuccessful OAuth web authentication") {
                 beforeEach {
-                    stub(
-                        condition: isHost("api.box.com")
-                            && isPath("/oauth2/token")
-                            && isMethodPOST()
-                    ) { _ in
-                        HTTPStubsResponse(
-                            jsonObject: ["error": "invalid_grant", "error_description": "Auth code doesn't exist or is invalid for the client"],
-                            statusCode: 400,
-                            headers: [:]
-                        )
+                    networkAgent.sendHandler = { request in
+                        expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/token", urlEncodedBody: ["client_id": clientId, "client_secret": clientSecret, "code": code, "grant_type": "authorization_code"])
+                        return makeFailure(request: request, jsonObject: ["error": "invalid_grant", "error_description": "Auth code doesn't exist or is invalid for the client"], statusCode: 400)
                     }
                 }
 
@@ -106,15 +87,9 @@ class AuthModuleSpecs: QuickSpec {
 
                 let tokenToRevoke = "asjhkdbfoq83w47gtlqiuwberg"
 
-                stub(
-                    condition: isHost("api.box.com")
-                        && isPath("/oauth2/revoke")
-                        && isMethodPOST()
-                        && compareURLEncodedBody(["client_id": clientId, "client_secret": clientSecret, "token": tokenToRevoke])
-                ) { _ in
-                    HTTPStubsResponse(
-                        data: Data(), statusCode: 200, headers: [:]
-                    )
+                networkAgent.sendHandler = { request in
+                    expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/revoke", urlEncodedBody: ["client_id": clientId, "client_secret": clientSecret, "token": tokenToRevoke])
+                    return .success(makeResponse(request: request, data: Data(), statusCode: 200))
                 }
 
                 waitUntil(timeout: .seconds(10)) { done in
@@ -131,14 +106,9 @@ class AuthModuleSpecs: QuickSpec {
             }
 
             it("should produce error when the revocation request fails") {
-                stub(
-                    condition: isHost("api.box.com")
-                        && isPath("/oauth2/revoke")
-                        && isMethodPOST()
-                ) { _ in
-                    HTTPStubsResponse(
-                        data: Data(), statusCode: 400, headers: [:]
-                    )
+                networkAgent.sendHandler = { request in
+                    expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/revoke", urlEncodedBody: ["client_id": clientId, "client_secret": clientSecret, "token": "adjhfgbs"])
+                    return makeFailure(request: request, data: Data(), statusCode: 400)
                 }
 
                 waitUntil(timeout: .seconds(10)) { done in
@@ -161,40 +131,23 @@ class AuthModuleSpecs: QuickSpec {
 
                 let tokenToDownscope = "asjhkdbfoq83w47gtlqiuwberg"
 
-                stub(
-                    condition: isHost("api.box.com")
-                        && isPath("/oauth2/token")
-                        && isMethodPOST()
-                        && compareURLEncodedBody(
-                            [
-                                "subject_token": tokenToDownscope,
-                                "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                                "scope": "item_preview item_upload",
-                                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                                "resource": "https://api.box.com/2.0/files/123",
-                                "box_shared_link": "https://app.box.com/s/xyz"
-                            ],
-                            checkClosure: { (checkTuple: CheckClosureTuple) in
-                                if let lastPathElement = checkTuple.path.last {
-                                    if case let .string(pathKey) = lastPathElement {
-                                        if pathKey == "scope" {
-                                            if let firstString = checkTuple.first as? String, let secondString = checkTuple.second as? String {
-                                                if Set(firstString.split(separator: " ")) == Set(secondString.split(separator: " ")) {
-                                                    return .equal
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                return .default
-                            }
-                        )
-                ) { _ in
-                    HTTPStubsResponse(
-                        fileAtPath: TestAssets.path(forResource: "DownscopeToken.json")!,
-                        statusCode: 200, headers: ["Content-Type": "application/json"]
+                networkAgent.sendHandler = { request in
+                    expectRequest(
+                        request,
+                        method: .post,
+                        host: "api.box.com",
+                        path: "/oauth2/token",
+                        urlEncodedBody: [
+                            "subject_token": tokenToDownscope,
+                            "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                            "scope": "item_preview item_upload",
+                            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                            "resource": "https://api.box.com/2.0/files/123",
+                            "box_shared_link": "https://app.box.com/s/xyz"
+                        ],
+                        unorderedValueKeys: ["scope"]
                     )
+                    return .success(makeResponse(request: request, fixture: "DownscopeToken.json", statusCode: 200, headers: ["Content-Type": "application/json"]))
                 }
 
                 waitUntil(timeout: .seconds(10)) { done in
@@ -222,23 +175,9 @@ class AuthModuleSpecs: QuickSpec {
 
                 let refreshToken = "zaqxswedc"
 
-                stub(
-                    condition: isHost("api.box.com")
-                        && isPath("/oauth2/token")
-                        && isMethodPOST()
-                        && compareURLEncodedBody(
-                            [
-                                "grant_type": "refresh_token",
-                                "client_id": clientId,
-                                "client_secret": clientSecret,
-                                "refresh_token": refreshToken
-                            ]
-                        )
-                ) { _ in
-                    HTTPStubsResponse(
-                        fileAtPath: TestAssets.path(forResource: "AccessToken.json")!,
-                        statusCode: 200, headers: ["Content-Type": "application/json"]
-                    )
+                networkAgent.sendHandler = { request in
+                    expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/token", urlEncodedBody: ["grant_type": "refresh_token", "client_id": clientId, "client_secret": clientSecret, "refresh_token": refreshToken])
+                    return .success(makeResponse(request: request, fixture: "AccessToken.json", statusCode: 200, headers: ["Content-Type": "application/json"]))
                 }
 
                 waitUntil(timeout: .seconds(10)) { done in
@@ -260,16 +199,9 @@ class AuthModuleSpecs: QuickSpec {
 
             it("should get an 400 error after pass invalid refresh token") {
 
-                stub(
-                    condition: isHost("api.box.com")
-                        && isPath("/oauth2/token")
-                        && isMethodPOST()
-                ) { _ in
-                    HTTPStubsResponse(
-                        jsonObject: ["error": "invalid_grant", "error_description": "Invalid refresh token"],
-                        statusCode: 400,
-                        headers: [:]
-                    )
+                networkAgent.sendHandler = { request in
+                    expectRequest(request, method: .post, host: "api.box.com", path: "/oauth2/token", urlEncodedBody: ["grant_type": "refresh_token", "client_id": clientId, "client_secret": clientSecret, "refresh_token": "invalid token"])
+                    return makeFailure(request: request, jsonObject: ["error": "invalid_grant", "error_description": "Invalid refresh token"], statusCode: 400)
                 }
 
                 waitUntil(timeout: .seconds(10)) { done in


### PR DESCRIPTION
The tests now use a fake `NetworkAgentProtocol`, so they still verify the generated `BoxRequest` and response parsing, but no longer depend on async HTTP stubbing behavior that was causing timeout failures on CI